### PR TITLE
Parental Involvement: Various tweaks to fix xref/image resolution

### DIFF
--- a/bonding/index.adoc
+++ b/bonding/index.adoc
@@ -1,5 +1,6 @@
 :toc: macro
 
+[#bonding]
 = Bonding
 
 ifndef::tbtc[toc::[]]

--- a/custodial-fees/index.adoc
+++ b/custodial-fees/index.adoc
@@ -1,3 +1,4 @@
+[#custodial-fees]
 = Custodial Fees: Paying for security
 
 * Custodial fee rate

--- a/deposits/index.adoc
+++ b/deposits/index.adoc
@@ -2,7 +2,11 @@
 
 = Deposits
 
-ifndef::tbtc[toc::[]]
+ifndef::tbtc[]
+toc::[]
+
+:root-prefix: ../
+endif::tbtc[]
 
 == Overview
 
@@ -20,7 +24,7 @@ and collateral for the wallet signers.
 Each of these steps is shown in the diagram below and discussed in subsequent
 sections.
 
-image::../img/generated/initiate-deposit.png[]
+image::{root-prefix}img/generated/initiate-deposit.png[]
 
 == Deposit request
 
@@ -47,7 +51,7 @@ network, described in http://keep.network/whitepaper[its whitepaper]. The Keep
 Random Beacon is described in more detail in the
 http://docs.keep.network/random-beacon/[Keep Random Beacon yellowpaper].]
 
-image::../img/generated/signing-group-creation.png[]
+image::{root-prefix}img/generated/signing-group-creation.png[]
 
 When a request comes in to create a signing group, the tBTC system requests a
 random seed from a secure decentralized random beacon.footnote:[A system is only
@@ -69,7 +73,8 @@ signing group once distributed key generation is complete; it is also used to
 penalize a given member if the distributed key generation fails due to an
 attributed misbehavior of that member.
 
-Bonding is described in more detail in the section on <<../bonding/index#,their own section>>.
+Bonding is described in more detail in
+<<{root-prefix}bonding/index#bonding,its own section>>.
 
 ==== Distributed key generation
 
@@ -149,4 +154,5 @@ The depositor mints their allowed TBTC by sending a transaction to the tBTC
 system, which in turn credits their account with the full amount of TBTC they
 are due.
 
-Custodial fees are described in more detail in <<../custodial-fees/index#,their own section>>.
+Custodial fees are described in more detail in
+<<{root-prefix}custodial-fees/index#custodial-fees,their own section>>.

--- a/index.adoc
+++ b/index.adoc
@@ -2,6 +2,9 @@
 :toclevels: 4
 :tbtc:
 
+// Blank root prefix since this is the root doc.
+:root-prefix:
+
 = TBTC: A Decentralized Redeemable BTC-backed ERC-20 Token
 
 ifndef::release[]


### PR DESCRIPTION
Due to a bug in asciidoctor in properly re-resolving relative paths when
compiling an including master document, some manual handling is needed
to deal with the different relative paths for subdirectory vs master
root directory builds. This introduces that infrastructure and applies
it to existing references.

Reported issue in asciidoctor is asciidoctor/asciidoctor#3136.