### PR TITLE
KeepBridge initialization with KeepRegistry address on truffle deploy 

### DIFF
--- a/implementation/migrations/2_deploy_contracts.js
+++ b/implementation/migrations/2_deploy_contracts.js
@@ -1,20 +1,26 @@
+// bitcoin-spv
 const BytesLib = artifacts.require('BytesLib')
 const BTCUtils = artifacts.require('BTCUtils')
 const ValidateSPV = artifacts.require('ValidateSPV')
-const TBTCConstants = artifacts.require('TBTCConstants')
 const CheckBitcoinSigs = artifacts.require('CheckBitcoinSigs')
 
+// logging
 const OutsourceDepositLogging = artifacts.require('OutsourceDepositLogging')
 const DepositLog = artifacts.require('DepositLog')
+
+// deposit
 const DepositStates = artifacts.require('DepositStates')
 const DepositUtils = artifacts.require('DepositUtils')
 const DepositFunding = artifacts.require('DepositFunding')
 const DepositRedemption = artifacts.require('DepositRedemption')
 const DepositLiquidation = artifacts.require('DepositLiquidation')
-
 const Deposit = artifacts.require('Deposit')
 
+// system
+const TBTCConstants = artifacts.require('TBTCConstants')
 const TBTCSystem = artifacts.require('TBTCSystem')
+
+// keep
 const KeepBridge = artifacts.require('KeepBridge')
 const KeepRegistryAddress = '0xd04ed7D5C75cCC22DEafFD90A70c5BF932eC235e' // KeepRegistry contract address
 
@@ -25,40 +31,49 @@ const all = [BytesLib, BTCUtils, ValidateSPV, TBTCConstants, CheckBitcoinSigs,
 
 module.exports = (deployer) => {
   deployer.then(async () => {
+    // bitcoin-spv
     await deployer.deploy(BytesLib)
-
     await deployer.link(BytesLib, all)
-    await deployer.deploy(BTCUtils)
 
+    await deployer.deploy(BTCUtils)
     await deployer.link(BTCUtils, all)
+
     await deployer.deploy(ValidateSPV)
+    await deployer.link(ValidateSPV, all)
+
     await deployer.deploy(CheckBitcoinSigs)
+    await deployer.link(CheckBitcoinSigs, all)
+
+    // constants
     await deployer.deploy(TBTCConstants)
     await deployer.link(TBTCConstants, all)
 
-    await deployer.link(CheckBitcoinSigs, all)
-    await deployer.link(ValidateSPV, all)
-    await deployer.deploy(DepositStates)
+    // logging
     await deployer.deploy(OutsourceDepositLogging)
-
     await deployer.link(OutsourceDepositLogging, all)
+
+    // deposit
+    await deployer.deploy(DepositStates)
     await deployer.link(DepositStates, all)
+
     await deployer.deploy(DepositUtils)
-
     await deployer.link(DepositUtils, all)
+
     await deployer.deploy(DepositLiquidation)
-
     await deployer.link(DepositLiquidation, all)
-    await deployer.deploy(DepositRedemption)
-    await deployer.deploy(DepositFunding)
 
-    await deployer.link(DepositFunding, all)
+    await deployer.deploy(DepositRedemption)
     await deployer.link(DepositRedemption, all)
+
+    await deployer.deploy(DepositFunding)
+    await deployer.link(DepositFunding, all)
 
     await deployer.deploy(Deposit)
 
+    // system
     await deployer.deploy(TBTCSystem)
 
+    // keep
     await deployer.deploy(KeepBridge).then((instance) => {
       instance.initialize(KeepRegistryAddress)
     })


### PR DESCRIPTION
This PR updates the truffle deploy configuration to initialize `KeepBridge` contract after deployment with `KeepRegistry` address.

It also sorts statements in the file.