### PR TITLE
Doc Uploader: Start uploading docs to docs.keep.network

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 version: 2.1
+
+orbs:
+  gcp-cli: circleci/gcp-cli@1.8.2
+
 executors:
   docker-node:
     docker:
@@ -99,9 +103,17 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/docs
-      - store_artifacts:
-          path: /tmp/docs
-          destination: .
+      - gcp-cli/initialize:
+          google-project-id: GOOGLE_PROJECT_ID
+          google-compute-zone: GOOGLE_COMPUTE_ZONE_A
+          # This param doesn't actually set anything, leaving here as a reminder to check when they fix it.
+          gcloud-service-key: GCLOUD_SERVICE_KEY_DOC_UPLOAD
+      - run:
+          name: Upload Document Files to docs.keep.network
+          command: |
+            cd /tmp/docs
+            export DIR=$(test $CIRCLE_BRANCH != master && echo $CIRCLE_BRANCH/)
+            gsutil -m cp -r * gs://docs.keep.network/tbtc/$DIR
 
 workflows:
   version: 2
@@ -120,6 +132,7 @@ workflows:
           requires:
             - generate_pngs
       - upload_docs:
+          context: keep-docs
           requires:
             - generate_docs_tex
             - generate_docs_asciidoctor


### PR DESCRIPTION
Quick version here:
- We use the `gcp-cli` orb to initialize our command line.
- We use a `keep-docs` context in Circle to give us the credentials we need.
- We upload things to `docs.keep.network/tbtc`.

This works exactly like the keep-core upload, which means:
- When you're working with a non-`master` branch, the built files will be available at `docs.keep.network/tbtc/<branch name>/...`.
- When you're working with `master`, the built files are at `docs.keep.network/tbtc/...`.

There's an increased danger of namespace collision here, so it may make sense to start moving the `keep-core` stuff to a `beacon/` subdirectory or similar; that'll be for another time, however.

Example from this branch: http://docs.keep.network/tbtc/doc-uploader/index.html

Closes #194 .
See #141, which we don't complete here because we still aren't linking to the built docs.