### PR TITLE
Add Protocol to maintainer config

### DIFF
--- a/infrastructure/kube/templates/tbtc-maintainers/initcontainer/provision-tbtc-maintainers/tbtc-maintainers-template.toml
+++ b/infrastructure/kube/templates/tbtc-maintainers/initcontainer/provision-tbtc-maintainers/tbtc-maintainers-template.toml
@@ -4,6 +4,7 @@
 [electrum]
   ServerHost  = "electrumx-server.tbtc.svc.cluster.local"
   ServerPort  = "50002"
+  Protocol    = "SSL" # TCP or SSL
 
 # Connection details for Block Cypher API.
 [blockcypher]


### PR DESCRIPTION
Added Protocol to tbtc-maintainer config template. Maintainer now supports both `TLS` and `SSL` options.