### PR TITLE
Maintainers config template add ignore certificate

### DIFF
--- a/infrastructure/kube/templates/tbtc-maintainers/initcontainer/provision-tbtc-maintainers/tbtc-maintainers-template.toml
+++ b/infrastructure/kube/templates/tbtc-maintainers/initcontainer/provision-tbtc-maintainers/tbtc-maintainers-template.toml
@@ -8,8 +8,8 @@
 
 # TLS configuration for a SSL connection to a Electrum Server.
 [electrum.TLSConfig] 
-    # Skip server certificates verification - a temporary solution for development.
-    InsecureSkipVerify = true
+  # Skip server certificates verification - a temporary solution for development.
+  InsecureSkipVerify = true
 
 # Connection details for Block Cypher API.
 [blockcypher]


### PR DESCRIPTION
tbtc-maintainers configuration template need to contain server certificate verification ignore setting for development environment.