### PR TITLE
Disabled publishing of contract artifacts and maintainers container to keep-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,25 +298,25 @@ workflows:
           context: keep-dev
           requires:
             - setup_github_package_registry
-      - build_initcontainer:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - migrate_contracts
-      - publish_images:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - migrate_contracts
-            - build_initcontainer
-      - publish_contract_data:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - migrate_contracts
+#      - build_initcontainer:
+#          filters:
+#            branches:
+#              only: master
+#          context: keep-dev
+#          requires:
+#            - migrate_contracts
+#      - publish_images:
+#          filters:
+#            branches:
+#              only: master
+#          context: keep-dev
+#          requires:
+#            - migrate_contracts
+#            - build_initcontainer
+#      - publish_contract_data:
+#          filters:
+#            branches:
+#              only: master
+#          context: keep-dev
+#          requires:
+#            - migrate_contracts


### PR DESCRIPTION
It's a temporary change for the purpose of having a stable demo environment. We'll bring it back later when we figure out how to version-tag our deployments properly.