### PR TITLE
Update bitcoin-spv dependency in circleci migrations

### DIFF
--- a/implementation/scripts/circleci-migrate-contracts.sh
+++ b/implementation/scripts/circleci-migrate-contracts.sh
@@ -56,7 +56,7 @@ ssh utilitybox << EOF
 
 # TODO: Migrations fail with truffle version specified in package.json file. That's why we install dependencies manually here, bug: https://github.com/keep-network/tbtc/issues/231
 npm install @keep-network/keep-ecdsa@0.1.1
-npm install git+https://github.com/summa-tx/bitcoin-spv.git#v1.1.0-high-err
+npm install @summa-tx/bitcoin-spv-sol@2.1.0
 npm install bn-chai@1.0.1
 npm install bn.js@4.11.8
 npm install chai@4.2.0


### PR DESCRIPTION
Updated depenedncy to bitcoin-spv pacakge in CircleCi migrations script.
The bitcoin-spv project is published to npm package registry, hence we
install it from the new source.

This is a followup after https://github.com/keep-network/tbtc/pull/302 to fix [failing CI](https://circleci.com/gh/keep-network/tbtc/7503?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification).