### PR TITLE
Increase fee for redemption

### DIFF
--- a/implementation/demo/6_increase_fee.js
+++ b/implementation/demo/6_increase_fee.js
@@ -56,9 +56,9 @@ async function run() {
   const fee = web3.utils.toBN(latestRedemptionRequest.returnValues._requestedFee)
   const uxtoSize = web3.utils.toBN(latestRedemptionRequest.returnValues._utxoSize)
 
-  const previousOutputValueBytes = uxtoSize.add(fee).toBuffer('le')
+  const previousOutputValueBytes = uxtoSize.sub(fee).toBuffer('le')
   const newFee = fee.mul(new BN(2))
-  const newOutputValueBytes = uxtoSize.add(newFee).toBuffer('le')
+  const newOutputValueBytes = uxtoSize.sub(newFee).toBuffer('le')
 
   console.log(`Current fee is ${fee.toString()} sats`)
   console.log(`Increasing fee to ${newFee.toString()} sats`)


### PR DESCRIPTION
Increases the fee for a redemption transaction, based on a linear doubling every 4hrs.

Depends on: #328, #321 

Refs: #184

## Example output
This was tested with a local Ganache blockchain. A deposit was created, redemption requested, and redemption signature provided using work in #328. 

Redemption bumps are allowed after 4hrs - for this, I ran `evm_increaseTime` as such:

```
$ truffle console
> web3.currentProvider.send({ jsonrpc: "2.0", method: "evm_increaseTime", params: [1 + (4 * 60 * 60)], id: 0 }, function(){})
```

Then you can execute the script, given a deposit.

```
(base) ➜  demo git:(redemption-6-increase-fee) ✗ truffle exec 6_increase_fee.js 0xfA15ca21c0DB590a80D358AC07b8c8F83DCCAb5C
Using network 'development'.

Retrieving most recent redemption fee for deposit...
Current fee is 150 sats
Increasing fee to 300 sats
Digest approved for signing: 0xc03ecc8966416b4119ffd356e6ee0e92c6e35d9ea25f99cd1afb8e48d94020a1
```

## Note about RBF
I tested this with submitting the new redemption transaction, by re-running script `5_submit_redemption_transaction.js`. The transaction failed to submit:

```
failed to broadcast transaction: Error: failed to broadcast transaction: [the transaction was rejected by network rules.

Missing inputs
[0100000000010123426bdb17231cb26a874c9b908b88a6e5132796ff97bfc5c6a6c6407b57e16800000000000000000001bc02000000000000160014333333333333333333333333333333333333333302483045022100f4a279e8da81ea498c77a424b124211012730643aa1753cf09f56cca5be3fe870220723b19ade2b32bf255b33f365353833108e9118ceb7d0bdd6d50a37ad38d9e88012102561bb0c01a97cec44a644b065088d4c8149150575fe2a52dae72ffc48e00a3de00000000]]
```

This is because the previous transaction was mined, as the fee was acceptable. We may need to think of an approach to test the replace-by-fee mechanics, given that we rely on the external Bitcoin testnet.

