### PR TITLE
Discuss: burning TBTC in liquidation flows

### DIFF
--- a/implementation/contracts/deposit/DepositLiquidation.sol
+++ b/implementation/contracts/deposit/DepositLiquidation.sol
@@ -88,6 +88,7 @@ library DepositLiquidation {
         }
 
         bool _liquidated = attemptToLiquidateOnchain(_d);
+        // TODO burn down the TBTC
 
         if (_liquidated) {
             _d.distributeBeneficiaryReward();
@@ -111,6 +112,7 @@ library DepositLiquidation {
         _d.seizeSignerBonds();
 
         bool _liquidated = attemptToLiquidateOnchain(_d);
+        // TODO burn down the TBTC
 
         if (_liquidated) {
             _d.distributeBeneficiaryReward();
@@ -253,6 +255,10 @@ library DepositLiquidation {
         // Burn the outstanding TBTC
         TBTCToken _tbtcToken = TBTCToken(_d.TBTCToken);
         require(_tbtcToken.balanceOf(msg.sender) >= TBTCConstants.getLotSize(), "Not enough TBTC to cover outstanding debt");
+        // Currently we're planning to setup an ACL on TBTCToken that only permits VendingMachine.
+        // But moving all the burning logic to vending machine is more complex than the current control flow.
+        //
+        // It might make more sense to enable burnFrom for Deposit too.
         _tbtcToken.burnFrom(msg.sender, TBTCConstants.getLotSize());  // burn minimal amount to cover size
 
         // Distribute funds to auction buyer


### PR DESCRIPTION
The vending machine now is responsible for minting and burning TBTC, and exchanging this TBTC to its non-fungible form, the DOT. 

We planned to centralise the logic of minting and burning to the vending machine. These changes are already merged:

 1. Funding: the funding flow no longer mints TBTC; instead it marks a DOT as qualified, which can later be exchanged for TBTC in the vending machine. (#373)
 2. Redemption: the redemption flow now relies only on accepting a DOT in place of burning TBTC. (#374)

The last area is the liquidation flow, which might not need changing. The liquidation flows rely on buying and burning TBTC with signer bonds to maintain the supply peg. It doesn't look like doing this through the vending machine would be simpler than what we have already, just purely because it doesn't make sense to care about the DOT at this point. 

Epic: #334