### PR TITLE
Dynamic bidirectional qualification using a 'floodgate'

### DIFF
--- a/implementation/contracts/deposit/DepositFunding.sol
+++ b/implementation/contracts/deposit/DepositFunding.sol
@@ -154,6 +154,8 @@ library DepositFunding {
         _d.setFailedSetup();
         _d.logSetupFailed();
 
+        floodgate.ungate(TBTCConstants.getLotSize());
+
         revokeFunderBond(_d);
         fundingTeardown(_d);
     }
@@ -185,6 +187,8 @@ library DepositFunding {
         _d.seizeSignerBonds();
         _d.logFraudDuringSetup();
 
+        floodgate.ungate(TBTCConstants.getLotSize());
+
         // If the funding timeout has elapsed, punish the funder too!
         if (block.timestamp > _d.fundingProofTimerStart + TBTCConstants.getFundingTimeout()) {
             address(0).transfer(address(this).balance);  // Burn it all down (fire emoji)
@@ -211,6 +215,8 @@ library DepositFunding {
         );
         _d.setFailedSetup();
         _d.logSetupFailed();
+
+        floodgate.ungate(TBTCConstants.getLotSize());
 
         partiallySlashForFraudInFunding(_d);
         fundingFraudTeardown(_d);
@@ -241,6 +247,8 @@ library DepositFunding {
         bytes memory _bitcoinHeaders
     ) public returns (bool) {
         require(_d.inFraudAwaitingBTCFundingProof(), "Not awaiting a funding proof during setup fraud");
+
+        floodgate.ungate(TBTCConstants.getLotSize());
 
         bytes8 _valueBytes;
         bytes memory  _utxoOutpoint;

--- a/implementation/contracts/deposit/DepositRedemption.sol
+++ b/implementation/contracts/deposit/DepositRedemption.sol
@@ -295,6 +295,7 @@ library DepositRedemption {
     function notifySignatureTimeout(DepositUtils.Deposit storage _d) public {
         require(_d.inAwaitingWithdrawalSignature(), "Not currently awaiting a signature");
         require(block.timestamp > _d.withdrawalRequestTime + TBTCConstants.getSignatureTimeout(), "Signature timer has not elapsed");
+        floodgate.ungate(TBTCConstants.getLotSize());
         _d.startSignerAbortLiquidation();  // not fraud, just failure
     }
 
@@ -304,6 +305,7 @@ library DepositRedemption {
     function notifyRedemptionProofTimeout(DepositUtils.Deposit storage _d) public {
         require(_d.inAwaitingWithdrawalProof(), "Not currently awaiting a redemption proof");
         require(block.timestamp > _d.withdrawalRequestTime + TBTCConstants.getRedepmtionProofTimeout(), "Proof timer has not elapsed");
+        floodgate.ungate(TBTCConstants.getLotSize());
         _d.startSignerAbortLiquidation();  // not fraud, just failure
     }
 }

--- a/implementation/contracts/system/BitcoinFloodgate.sol
+++ b/implementation/contracts/system/BitcoinFloodgate.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.5.10;
+
 /**
  * The floodgate mitigates the risk of reorg attacks, by gating the volume of Bitcoin transferred through the system.
  */
@@ -17,13 +19,22 @@ contract BitcoinFloodgate {
     function release(uint _amount, bytes memory _numConfirmations) public {
         uint minConfirmations = BLOCK_REWARD / (gatedVolume + 1);
         require(_numConfirmations >= minConfirmations, "bitcoin not released: not enough confirmations");
+        ungate(_amount);
+    }
+
+    /**
+     * Ungates some previously gated bitcoin
+     * @param _amount The amount of bitcoin
+     */
+    function ungate(uint _amount) public {
+        gatedVolume -= _amount;
     }
     
     /**
-     * Increases the volume of Bitcoin gated for release
+     * Increases the volume of bitcoin gated for release
      * @param _amount Amount of bitcoin gated for release
      */
-    function gate(uint _amount) {
+    function gate(uint _amount) public {
         gatedVolume += _amount;
     }
 }


### PR DESCRIPTION
It makes sense to qualify both the funding and redemption flows, as [both are susceptible](https://github.com/keep-network/tbtc/pull/366#discussion_r350021477) to reorg attacks given large volumes of BTC.

Here's some ideation on designing this using the concept of a "floodgate". The gate creates a barrier to reorg attacks, based on the volume of BTC flowing between Bitcoin <-> Ethereum. 

Epic: #334