### PR TITLE
Inserted missing `await` in Mocha `before` blocks

### DIFF
--- a/implementation/test/DepositFundingTest.js
+++ b/implementation/test/DepositFundingTest.js
@@ -91,9 +91,9 @@ contract('DepositFunding', (accounts) => {
 
     testInstance = deployed.TestDeposit
 
-    testInstance.setExteriorAddresses(tbtcSystemStub.address, tbtcToken.address)
+    await testInstance.setExteriorAddresses(tbtcSystemStub.address, tbtcToken.address)
 
-    tbtcSystemStub.forceMint(accounts[4], web3.utils.toBN(deployed.TestDeposit.address))
+    await tbtcSystemStub.forceMint(accounts[4], web3.utils.toBN(deployed.TestDeposit.address))
 
     beneficiary = accounts[4]
   })

--- a/implementation/test/DepositLiquidationTest.js
+++ b/implementation/test/DepositLiquidationTest.js
@@ -87,9 +87,9 @@ contract('DepositLiquidation', (accounts) => {
 
     testInstance = deployed.TestDeposit
 
-    testInstance.setExteriorAddresses(tbtcSystemStub.address, tbtcToken.address)
+    await testInstance.setExteriorAddresses(tbtcSystemStub.address, tbtcToken.address)
 
-    tbtcSystemStub.forceMint(beneficiary, web3.utils.toBN(deployed.TestDeposit.address))
+    await tbtcSystemStub.forceMint(beneficiary, web3.utils.toBN(deployed.TestDeposit.address))
 
 
     const keepRegistry = await KeepRegistryStub.new()

--- a/implementation/test/DepositRedemptionTest.js
+++ b/implementation/test/DepositRedemptionTest.js
@@ -68,9 +68,9 @@ contract('DepositRedemption', (accounts) => {
 
     testInstance = deployed.TestDeposit
 
-    testInstance.setExteriorAddresses(tbtcSystemStub.address, tbtcToken.address)
+    await testInstance.setExteriorAddresses(tbtcSystemStub.address, tbtcToken.address)
 
-    tbtcSystemStub.forceMint(accounts[4], web3.utils.toBN(deployed.TestDeposit.address))
+    await tbtcSystemStub.forceMint(accounts[4], web3.utils.toBN(deployed.TestDeposit.address))
   })
 
   beforeEach(async () => {

--- a/implementation/test/integration/UniswapTest.js
+++ b/implementation/test/integration/UniswapTest.js
@@ -196,8 +196,8 @@ integration('Uniswap', (accounts) => {
 
         await tbtcSystem.reinitialize(uniswapExchangeAddress)
 
-        deposit.setExteriorAddresses(tbtcSystem.address, tbtcToken.address)
-        tbtcSystem.forceMint(accounts[0], web3.utils.toBN(deposit.address))
+        await deposit.setExteriorAddresses(tbtcSystem.address, tbtcToken.address)
+        await tbtcSystem.forceMint(accounts[0], web3.utils.toBN(deposit.address))
 
         // Helpers
         assertBalance = new AssertBalance(tbtcToken)


### PR DESCRIPTION
In these places we weren't waiting for the promise to resolve before continuing, which could interfere with test cases. Just something I noticed during #374.