### PR TITLE
Deploy the DepositOwnerToken

### DIFF
--- a/implementation/migrations/2_deploy_contracts.js
+++ b/implementation/migrations/2_deploy_contracts.js
@@ -28,6 +28,7 @@ const TBTCSystem = artifacts.require('TBTCSystem')
 
 // keep
 const TBTCToken = artifacts.require('TBTCToken')
+const DepositOwnerToken = artifacts.require('DepositOwnerToken')
 
 // deposit factory
 const DepositFactory = artifacts.require('DepositFactory')
@@ -105,5 +106,6 @@ module.exports = (deployer, network, accounts) => {
 
     // token
     await deployer.deploy(TBTCToken, TBTCSystem.address)
+    await deployer.deploy(DepositOwnerToken)
   })
 }


### PR DESCRIPTION
We missed deploying the DOT in #368. This deploys it so we can use it in the dApp's logic.

I'll note that we incidentally missed this, as we were engaged in prototyping out the DOT work. DOT is still missing ACL - I spoke with Nic and we'll be addressing it in the final pass of #334.