### PR TITLE
Ropsten Migration Support

### DIFF
--- a/implementation/truffle-config.js
+++ b/implementation/truffle-config.js
@@ -64,6 +64,7 @@ module.exports = {
     },
     keep_test: {
       provider: function() {
+      // ETH_HOSTNAME is set in a Circle Context.
       // CONTRACT_OWNER_ETH_ACCOUNT_PASSWORD is set in a Circle context. For now this value
       // is shared between the contract owner Ethereum account on both our internal testnet
       // and on Ropsten.


### PR DESCRIPTION
### Intro

We want to start deploying tagged releases to Ropsten, instead of our internal Ethereum network in `keep-test`.

We want the instance of tBTC deployed to keep-test to now point at Ropsten contracts, instead of our internal Ethereum network in keep-test.

Here we add the support to deliver ^ via Circle.

### What's Happening

#### `truffle.js`

Changed the `keep-test` profile to point at Ropsten.  We did this as a replacement instead of a new network profile because the local Ethereum network in keep-test will be retired after `tBTC` is migrated to Ropsten.  `keep-core` deployments already run against Ropsten in this environment.

#### Circle Contexts

We lean pretty heavily on `Circle Contexts` to feed our migration and configuration scripts environment specific context. Examples here include: Google service account keys, Ethereum hostname, contract bucket names, etc.

The following Circle Context variables need to be updated before the first run of this PR.

- [ ] `ETH_HOSTNAME` (Currently points at keep-test internal Ethereum network)
- [ ] `ETH_NETWORK_ID` (Currently set to keep-test internal Ethereum network)