### PR TITLE
Don't allow a signer fee > 10% of lot size

### DIFF
--- a/implementation/contracts/system/TBTCSystem.sol
+++ b/implementation/contracts/system/TBTCSystem.sol
@@ -85,7 +85,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     function setSignerFeeDivisor(uint256 _signerFeeDivisor)
         external onlyOwner
     {
-        require(_signerFeeDivisor > 9, "Signer fee must be less than or equal to 10%");
+        require(_signerFeeDivisor > 9, "Signer fee divisor must be greater than 9, for a signer fee that is <= 10%.");
         signerFeeDivisor = _signerFeeDivisor;
         emit SignerFeeDivisorUpdated(_signerFeeDivisor);
     }


### PR DESCRIPTION
On the one hand, the introduction of multiple lot sizes means this fee
structure is clearly imperfect. Base + percent would probably be a
better fit to make sure signers' costs are covered. Using a pure
percent-based structure means the fees on higher lot sizes need to be a
little higher than they otherwise would, as the lower lot size fees have
a market-set floor based on signer gas costs + expected return on capital.

On the other hand, allowing arbitrary fee changes by the contract owner
is a de facto killswitch, and can't go live. A ceiling on the fee rate
limits the potential for abuse.