### PR TITLE
Support output scripts for redemption transactions

### DIFF
--- a/implementation/contracts/DepositLog.sol
+++ b/implementation/contracts/DepositLog.sol
@@ -24,7 +24,7 @@ contract DepositLog {
         address indexed _requester,
         bytes32 indexed _digest,
         uint256 _utxoSize,
-        bytes20 _requesterPKH,
+        bytes _redeemerOutputScript,
         uint256 _requestedFee,
         bytes _outpoint
     );
@@ -120,7 +120,7 @@ contract DepositLog {
     /// @param  _requester      The ethereum address of the requester
     /// @param  _digest         The calculated sighash digest
     /// @param  _utxoSize       The size of the utxo in sat
-    /// @param  _requesterPKH   The requester's 20-byte bitcoin pkh
+    /// @param  _redeemerOutputScript The redeemer's length-prefixed output script.
     /// @param  _requestedFee   The requester or bump-system specified fee
     /// @param  _outpoint       The 36 byte outpoint
     /// @return                 True if successful, else revert
@@ -128,7 +128,7 @@ contract DepositLog {
         address _requester,
         bytes32 _digest,
         uint256 _utxoSize,
-        bytes20 _requesterPKH,
+        bytes memory _redeemerOutputScript,
         uint256 _requestedFee,
         bytes memory _outpoint
     ) public returns (bool) {
@@ -138,7 +138,7 @@ contract DepositLog {
             _requester,
             _digest,
             _utxoSize,
-            _requesterPKH,
+            _redeemerOutputScript,
             _requestedFee,
             _outpoint);
         return true;

--- a/implementation/contracts/deposit/Deposit.sol
+++ b/implementation/contracts/deposit/Deposit.sol
@@ -97,29 +97,29 @@ contract Deposit is DepositFactoryAuthority {
     /// @notice                     Anyone can request redemption
     /// @dev                        The redeemer specifies details about the Bitcoin redemption tx
     /// @param  _outputValueBytes   The 8-byte LE output size
-    /// @param  _redeemerPKH       The 20-byte Bitcoin pubkeyhash to which to send funds
+    /// @param  _redeemerOutputScript The redeemer's length-prefixed output script.
     /// @return                     True if successful, otherwise revert
     function requestRedemption(
         bytes8 _outputValueBytes,
-        bytes20 _redeemerPKH
+        bytes memory _redeemerOutputScript
     ) public returns (bool) {
-        self.requestRedemption(_outputValueBytes, _redeemerPKH);
+        self.requestRedemption(_outputValueBytes, _redeemerOutputScript);
         return true;
     }
 
     /// @notice                     Anyone can request redemption
     /// @dev                        The redeemer specifies details about the Bitcoin redemption tx and pays for the redemption
     /// @param  _outputValueBytes   The 8-byte LE output size
-    /// @param  _redeemerPKH        The 20-byte Bitcoin pubkeyhash to which to send funds
+    /// @param  _redeemerOutputScript The redeemer's length-prefixed output script.
     /// @param  _finalRecipient     The address to receive the TDT and later be recorded as deposit redeemer.
     function transferAndRequestRedemption(
         bytes8 _outputValueBytes,
-        bytes20 _redeemerPKH,
+        bytes memory _redeemerOutputScript,
         address payable _finalRecipient
     ) public returns (bool) {
         self.transferAndRequestRedemption(
             _outputValueBytes,
-            _redeemerPKH,
+            _redeemerOutputScript,
             _finalRecipient
         );
         return true;

--- a/implementation/contracts/deposit/DepositLiquidation.sol
+++ b/implementation/contracts/deposit/DepositLiquidation.sol
@@ -184,7 +184,7 @@ library DepositLiquidation {
             "No input spending custodied UTXO found at given index"
         );
 
-        if (_d.redeemerPKH != bytes20(0)) {
+        if (_d.redeemerOutputScript.length > 0) {
             require(
                 validateRedeemerNotPaid(_d, _txOutputVector),
                 "Found an output paying the redeemer as requested"
@@ -213,10 +213,8 @@ library DepositLiquidation {
             _output = _txOutputVector.slice(_offset, _txOutputVector.length - _offset);
             _offset += _output.determineOutputLength();
 
-            if (_output.extractValue() >= _requiredOutputValue
-                // extract the output flag and check that it is witness
-                && keccak256(_output.slice(8, 3)) == keccak256(hex"160014")
-                && keccak256(_output.extractHash()) == keccak256(abi.encodePacked(_d.redeemerPKH))) {
+            if (_output.extractValue() >= _requiredOutputValue &&
+                keccak256(_output.slice(8, 3).concat(_output.extractHash())) == keccak256(abi.encodePacked(_d.redeemerOutputScript))) {
                 return false;
             }
         }

--- a/implementation/contracts/deposit/DepositUtils.sol
+++ b/implementation/contracts/deposit/DepositUtils.sol
@@ -53,7 +53,7 @@ library DepositUtils {
 
         // INITIALLY WRITTEN BY REDEMPTION FLOW
         address payable redeemerAddress;  // The redeemer's address, used as fallback for fraud in redemption
-        bytes20 redeemerPKH;  // The 20-byte redeemer PKH
+        bytes redeemerOutputScript;  // The 20-byte redeemer PKH
         uint256 initialRedemptionFee;  // the initial fee as requested
         uint256 withdrawalRequestTime;  // the most recent withdrawal request timestamp
         bytes32 lastRequestedDigest;  // the digest most recently requested for signing
@@ -361,7 +361,7 @@ library DepositUtils {
     /// @dev        We keep around the redeemer address so we can pay them out
     function redemptionTeardown(Deposit storage _d) public {
         // don't 0 redeemerAddress because we use it to calculate auctionTBTCAmount
-        _d.redeemerPKH = bytes20(0);
+        _d.redeemerOutputScript = "";
         _d.initialRedemptionFee = 0;
         _d.withdrawalRequestTime = 0;
         _d.lastRequestedDigest = bytes32(0);

--- a/implementation/contracts/deposit/OutsourceDepositLogging.sol
+++ b/implementation/contracts/deposit/OutsourceDepositLogging.sol
@@ -19,7 +19,7 @@ library OutsourceDepositLogging {
     /// @param  _redeemer       The ethereum address of the redeemer
     /// @param  _digest         The calculated sighash digest
     /// @param  _utxoSize       The size of the utxo in sat
-    /// @param  _redeemerPKH    The redeemer's 20-byte bitcoin pkh
+    /// @param  _redeemerOutputScript The redeemer's length-prefixed output script.
     /// @param  _requestedFee   The redeemer or bump-system specified fee
     /// @param  _outpoint       The 36 byte outpoint
     /// @return                 True if successful, else revert
@@ -28,18 +28,19 @@ library OutsourceDepositLogging {
         address _redeemer,
         bytes32 _digest,
         uint256 _utxoSize,
-        bytes20 _redeemerPKH,
+        bytes memory _redeemerOutputScript,
         uint256 _requestedFee,
-        bytes calldata _outpoint
-    ) external {
+        bytes memory _outpoint
+    ) public { // not external to allow bytes memory output scripts
         DepositLog _logger = DepositLog(_d.TBTCSystem);
         _logger.logRedemptionRequested(
             _redeemer,
             _digest,
             _utxoSize,
-            _redeemerPKH,
+            _redeemerOutputScript,
             _requestedFee,
-            _outpoint);
+            _outpoint
+        );
     }
 
     /// @notice         Fires a GotRedemptionSignature event

--- a/implementation/contracts/system/VendingMachine.sol
+++ b/implementation/contracts/system/VendingMachine.sol
@@ -119,12 +119,12 @@ contract VendingMachine is TBTCSystemAuthority{
     /// @dev Vending Machine transfers TBTC allowance to Deposit.
     /// @param  _depositAddress     The address of the Deposit to redeem.
     /// @param  _outputValueBytes   The 8-byte Bitcoin transaction output size in Little Endian.
-    /// @param  _requesterPKH       The 20-byte Bitcoin pubkeyhash to which to send funds.
+    /// @param  _redeemerOutputScript The redeemer's length-prefixed output script.
     /// @param  _finalRecipient     The deposit redeemer. This address will receive the TDT.
     function tbtcToBtc(
         address payable _depositAddress,
         bytes8 _outputValueBytes,
-        bytes20 _requesterPKH,
+        bytes memory _redeemerOutputScript,
         address payable _finalRecipient
     ) public {
         require(tbtcDepositToken.exists(uint256(_depositAddress)), "tBTC Deposit Token does not exist");
@@ -140,6 +140,6 @@ contract VendingMachine is TBTCSystemAuthority{
             tbtcToken.approve(_depositAddress, tbtcOwed);
         }
 
-        _d.transferAndRequestRedemption(_outputValueBytes, _requesterPKH, _finalRecipient);
+        _d.transferAndRequestRedemption(_outputValueBytes, _redeemerOutputScript, _finalRecipient);
     }
 }

--- a/implementation/package-lock.json
+++ b/implementation/package-lock.json
@@ -66,9 +66,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@summa-tx/bitcoin-spv-sol": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-2.1.0.tgz",
-      "integrity": "sha512-DCt/WO2LaScLDwJ4ItYcqXfrV7YcyDgtw+UdnpGTc4myrW3wB+jMUmz7Azjs7URo3mjgMIhIF0dKN6KMgcfPDQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-2.2.0.tgz",
+      "integrity": "sha512-HSfxfNldNS4pvZUjLLYqw/wgVrxmIzp67WoRVTxY5SEV7TbOBcn8aYlPCnyLSUX6TeHjMVjAv3inDoIq0zwfCQ=="
     },
     "@szmarczak/http-timer": {
       "version": "1.1.2",

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -21,7 +21,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@keep-network/keep-ecdsa": "^0.1.2",
-    "@summa-tx/bitcoin-spv-sol": "^2.1.0",
+    "@summa-tx/bitcoin-spv-sol": "^2.2.0",
     "@truffle/hdwallet-provider": "^1.0.26",
     "bn-chai": "^1.0.1",
     "bn.js": "^4.11.8",

--- a/implementation/test/DepositFraudTest.js
+++ b/implementation/test/DepositFraudTest.js
@@ -350,14 +350,14 @@ contract('DepositFraud', (accounts) => {
 
   describe('validateRedeemerNotPaid', async () => {
     const _txOutputVector = '0x012040351d0000000016001486e7303082a6a21d5837176bc808bf4828371ab6'
-    const requesterPKH = '0x86e7303082a6a21d5837176bc808bf4828371ab6'
+    const redeemerOutputScript = '0x16001486e7303082a6a21d5837176bc808bf4828371ab6'
     const prevoutValueBytes = '0xf078351d00000000'
     const outpoint = '0x913e39197867de39bff2c93c75173e086388ee7e8707c90ce4a02dd23f7d2c0d00000000'
     const _longTxOutputVector = `0x034897070000000000220020a4333e5612ab1a1043b25755c89b16d55184a42f81799e623e6bc39db8539c180000000000000000166a14edb1b5c2f39af0fec151732585b1049b078952112040351d0000000016001486e7303082a6a21d5837176bc808bf4828371ab6`
 
     beforeEach(async () => {
       await testDeposit.setUTXOInfo(prevoutValueBytes, 0, outpoint)
-      await testDeposit.setRequestInfo(utils.address0, requesterPKH, 2424, 0, utils.bytes32zero)
+      await testDeposit.setRequestInfo(utils.address0, redeemerOutputScript, 2424, 0, utils.bytes32zero)
     })
 
     it('returns false if redeemer is paid and value is sufficient', async () => {
@@ -400,7 +400,7 @@ contract('DepositFraud', (accounts) => {
     const _targetInputIndex = 0
     const outpoint = '0x913e39197867de39bff2c93c75173e086388ee7e8707c90ce4a02dd23f7d2c0d00000000'
     const prevoutValueBytes = '0xf078351d00000000' // 490043632
-    const requesterPKH = '0x86e7303082a6a21d5837176bc808bf4828371ab6'
+    const redeemerOutputScript = '0x16001486e7303082a6a21d5837176bc808bf4828371ab6'
 
     beforeEach(async () => {
       await testDeposit.setState(utils.states.ACTIVE)
@@ -476,7 +476,7 @@ contract('DepositFraud', (accounts) => {
       // is `490043632 - (2424 * 6) = 490029088`.
       await testDeposit.setRequestInfo(
         utils.address0,
-        requesterPKH,
+        redeemerOutputScript,
         2424,
         0,
         utils.bytes32zero

--- a/implementation/test/DepositRedemptionTest.js
+++ b/implementation/test/DepositRedemptionTest.js
@@ -390,7 +390,7 @@ contract('DepositRedemption', (accounts) => {
     const valueBytes = '0x1111111111111111'
     const keepPubkeyX = '0x' + '33'.repeat(32)
     const keepPubkeyY = '0x' + '44'.repeat(32)
-    const redeemerPKH = '0x' + '33'.repeat(20)
+    const redeemerOutputScript = '0x160014' + '33'.repeat(20)
     let requiredBalance
 
     before(async () => {
@@ -418,10 +418,10 @@ contract('DepositRedemption', (accounts) => {
       await testDeposit.setSigningGroupPublicKey(keepPubkeyX, keepPubkeyY)
 
       // the fee is ~12,297,829,380 BTC
-      await testDeposit.requestRedemption('0x1111111100000000', redeemerPKH)
+      await testDeposit.requestRedemption('0x1111111100000000', redeemerOutputScript)
 
       const requestInfo = await testDeposit.getRequestInfo()
-      assert.equal(requestInfo[1], redeemerPKH)
+      assert.equal(requestInfo[1], redeemerOutputScript)
       assert(!requestInfo[3].eqn(0)) // withdrawalRequestTime is set
       assert.equal(requestInfo[4], sighash)
 
@@ -437,10 +437,10 @@ contract('DepositRedemption', (accounts) => {
       await testDeposit.setState(utils.states.COURTESY_CALL)
 
       // the fee is ~12,297,829,380 BTC
-      await testDeposit.requestRedemption('0x1111111100000000', redeemerPKH)
+      await testDeposit.requestRedemption('0x1111111100000000', redeemerOutputScript)
 
       const requestInfo = await testDeposit.getRequestInfo()
-      assert.equal(requestInfo[1], redeemerPKH)
+      assert.equal(requestInfo[1], redeemerOutputScript)
       assert(!requestInfo[3].eqn(0)) // withdrawalRequestTime is set
       assert.equal(requestInfo[4], sighash)
 
@@ -456,7 +456,7 @@ contract('DepositRedemption', (accounts) => {
       await testDeposit.setUTXOInfo(valueBytes, block.timestamp, outpoint)
 
       // the fee is ~12,297,829,380 BTC
-      await testDeposit.requestRedemption('0x1111111100000000', redeemerPKH)
+      await testDeposit.requestRedemption('0x1111111100000000', redeemerOutputScript)
 
       const events = await tbtcToken.getPastEvents('Transfer', { fromBlock: block.number, toBlock: 'latest' })
       const event = events[0]
@@ -613,7 +613,7 @@ contract('DepositRedemption', (accounts) => {
     const newOutputBytes = '0x0100feffffffffff'
     const initialFee = 0xffff
     const outpoint = '0x' + '33'.repeat(36)
-    const redeemerPKH = '0x' + '33'.repeat(20)
+    const redeemerOutputScript = '0x160014' + '33'.repeat(20)
     let feeIncreaseTimer
 
     before(async () => {
@@ -628,7 +628,7 @@ contract('DepositRedemption', (accounts) => {
       await testDeposit.setState(utils.states.AWAITING_WITHDRAWAL_PROOF)
       await testDeposit.setSigningGroupPublicKey(keepPubkeyX, keepPubkeyY)
       await testDeposit.setUTXOInfo(prevoutValueBytes, 0, outpoint)
-      await testDeposit.setRequestInfo(utils.address0, redeemerPKH, initialFee, withdrawalRequestTime, prevSighash)
+      await testDeposit.setRequestInfo(utils.address0, redeemerOutputScript, initialFee, withdrawalRequestTime, prevSighash)
       await ecdsaKeepStub.setSuccess(true)
     })
 
@@ -655,7 +655,7 @@ contract('DepositRedemption', (accounts) => {
 
     it('reverts if the increase fee timer has not elapsed', async () => {
       const block = await web3.eth.getBlock('latest')
-      await testDeposit.setRequestInfo(utils.address0, redeemerPKH, initialFee, block.timestamp, prevSighash)
+      await testDeposit.setRequestInfo(utils.address0, redeemerOutputScript, initialFee, block.timestamp, prevSighash)
 
       await expectThrow(
         testDeposit.increaseRedemptionFee(previousOutputBytes, newOutputBytes),
@@ -671,7 +671,7 @@ contract('DepositRedemption', (accounts) => {
     })
 
     it('reverts if the previous sighash was not the latest approved', async () => {
-      await testDeposit.setRequestInfo(utils.address0, redeemerPKH, initialFee, withdrawalRequestTime, keepPubkeyX)
+      await testDeposit.setRequestInfo(utils.address0, redeemerOutputScript, initialFee, withdrawalRequestTime, keepPubkeyX)
 
       // Previous sigHash is not approved for signing.
       await testDeposit.setDigestApprovedAtTime(prevSighash, 0)
@@ -697,13 +697,13 @@ contract('DepositRedemption', (accounts) => {
     const headerChain = '0x00e0ff3fd877ad23af1d0d3e0eb6a700d85b692975dacd36e47b1b00000000000000000095ba61df5961d7fa0a45cd7467e11f20932c7a0b74c59318e86581c6b509554876f6c65c114e2c17e42524d300000020994d3802da5adf80345261bcff2eb87ab7b70db786cb0000000000000000000003169efc259f6e4b5e1bfa469f06792d6f07976a098bff2940c8e7ed3105fdc5eff7c65c114e2c170c4dffc30000c020f898b7ea6a405728055b0627f53f42c57290fe78e0b91900000000000000000075472c91a94fa2aab73369c0686a58796949cf60976e530f6eb295320fa15a1b77f8c65c114e2c17387f1df00000002069137421fc274aa2c907dbf0ec4754285897e8aa36332b0000000000000000004308f2494b702c40e9d61991feb7a15b3be1d73ce988e354e52e7a4e611bd9c2a2f8c65c114e2c1740287df200000020ab63607b09395f856adaa69d553755d9ba5bd8d15da20a000000000000000000090ea7559cda848d97575cb9696c8e33ba7f38d18d5e2f8422837c354aec147839fbc65c114e2c175cf077d6000000200ab3612eac08a31a8fb1d9b5397f897db8d26f6cd83a230000000000000000006f4888720ecbf980ff9c983a8e2e60ad329cc7b130916c2bf2300ea54e412a9ed6fcc65c114e2c17d4fbb88500000020d3e51560f77628a26a8fad01c88f98bd6c9e4bc8703b180000000000000000008e2c6e62a1f4d45dd03be1e6692df89a4e3b1223a4dbdfa94cca94c04c22049992fdc65c114e2c17463edb5e'
     const outpoint = '0x913e39197867de39bff2c93c75173e086388ee7e8707c90ce4a02dd23f7d2c0d00000000'
     const prevoutValueBytes = '0xf078351d00000000'
-    const redeemerPKH = '0x86e7303082a6a21d5837176bc808bf4828371ab6'
+    const redeemerOutputScript = '0x16001486e7303082a6a21d5837176bc808bf4828371ab6'
 
     beforeEach(async () => {
       await tbtcSystemStub.setCurrentDiff(currentDiff)
       await testDeposit.setUTXOInfo(prevoutValueBytes, 0, outpoint)
       await testDeposit.setState(utils.states.AWAITING_WITHDRAWAL_PROOF)
-      await testDeposit.setRequestInfo('0x' + '11'.repeat(20), redeemerPKH, 14544, 0, '0x' + '11' * 32)
+      await testDeposit.setRequestInfo('0x' + '11'.repeat(20), redeemerOutputScript, 14544, 0, '0x' + '11' * 32)
     })
 
     it('updates the state, deconstes struct info, calls TBTC and Keep, and emits a Redeemed event', async () => {
@@ -716,7 +716,7 @@ contract('DepositRedemption', (accounts) => {
 
       const requestInfo = await testDeposit.getRequestInfo.call()
       assert.equal(requestInfo[0], '0x' + '11'.repeat(20)) // address is intentionally not cleared
-      assert.equal(requestInfo[1], utils.address0)
+      assert.equal(requestInfo[1], null)
       assert.equal(requestInfo[4], utils.bytes32zero)
 
       const eventList = await tbtcSystemStub.getPastEvents('Redeemed', { fromBlock: blockNumber, toBlock: 'latest' })
@@ -746,11 +746,11 @@ contract('DepositRedemption', (accounts) => {
     const outputValue = 490029088
     const outpoint = '0x913e39197867de39bff2c93c75173e086388ee7e8707c90ce4a02dd23f7d2c0d00000000'
     const prevoutValueBytes = '0xf078351d00000000'
-    const redeemerPKH = '0x86e7303082a6a21d5837176bc808bf4828371ab6'
+    const redeemerOutputScript = '0x16001486e7303082a6a21d5837176bc808bf4828371ab6'
 
     beforeEach(async () => {
       await testDeposit.setUTXOInfo(prevoutValueBytes, 0, outpoint)
-      await testDeposit.setRequestInfo('0x' + '11'.repeat(20), redeemerPKH, 14544, 0, '0x' + '11' * 32)
+      await testDeposit.setRequestInfo('0x' + '11'.repeat(20), redeemerOutputScript, 14544, 0, '0x' + '11' * 32)
     })
 
     it('returns the output value', async () => {

--- a/implementation/test/DepositUtilsTest.js
+++ b/implementation/test/DepositUtilsTest.js
@@ -10,6 +10,7 @@ import bnChai from 'bn-chai'
 chai.use(bnChai(BN))
 
 const TestDepositUtils = artifacts.require('TestDepositUtils')
+const TestDepositUtilsSPV = artifacts.require('TestDepositUtilsSPV')
 
 // real tx from mainnet bitcoin, interpreted as funding tx
 // tx source: https://www.blockchain.com/btc/tx/7c48181cb5c030655eea651c5e9aa808983f646465cbe9d01c227d99cfbc405f
@@ -215,7 +216,37 @@ contract('DepositUtils', (accounts) => {
   })
 
   describe('validateAndParseFundingSPVProof()', async () => {
+    let tbtcSystemStub
+    let tbtcToken
+    let tbtcDepositToken
+    let feeRebateToken
+    let testDeposit
+
     before(async () => {
+      ({
+        tbtcSystemStub,
+        tbtcToken,
+        tbtcDepositToken,
+        feeRebateToken,
+        testDeposit,
+      } = await deployTestDeposit([], { TestDeposit: TestDepositUtilsSPV }))
+
+      beneficiary = accounts[2]
+
+      feeRebateToken.forceMint(beneficiary, web3.utils.toBN(testDeposit.address))
+
+      await testDeposit.createNewDeposit(
+        tbtcSystemStub.address,
+        tbtcToken.address,
+        tbtcDepositToken.address,
+        feeRebateToken.address,
+        utils.address0,
+        1, // m
+        1, // n
+        fullBtc,
+        { value: funderBondAmount }
+      )
+
       await testDeposit.setPubKey(_signerPubkeyX, _signerPubkeyY)
       await tbtcSystemStub.setCurrentDiff(currentDifficulty)
     })

--- a/implementation/test/VendingMachineTest.js
+++ b/implementation/test/VendingMachineTest.js
@@ -270,7 +270,7 @@ contract('VendingMachine', (accounts) => {
     const valueBytes = '0x1111111111111111'
     const keepPubkeyX = '0x' + '33'.repeat(32)
     const keepPubkeyY = '0x' + '44'.repeat(32)
-    const requesterPKH = '0x' + '33'.repeat(20)
+    const redeemerOutputScript = '0x160014' + '33'.repeat(20)
     let requiredBalance
     let block
 
@@ -301,10 +301,10 @@ contract('VendingMachine', (accounts) => {
 
       // the fee is ~12,297,829,380 BTC
       await feeRebateToken.forceMint(accounts[0], tdtId)
-      await vendingMachine.tbtcToBtc(testDeposit.address, '0x1111111100000000', requesterPKH, accounts[0])
+      await vendingMachine.tbtcToBtc(testDeposit.address, '0x1111111100000000', redeemerOutputScript, accounts[0])
       const requestInfo = await testDeposit.getRequestInfo()
 
-      assert.equal(requestInfo[1], requesterPKH)
+      assert.equal(requestInfo[1], redeemerOutputScript)
       assert(!requestInfo[3].eqn(0)) // withdrawalRequestTime is set
       assert.equal(requestInfo[4], sighash)
 
@@ -321,7 +321,7 @@ contract('VendingMachine', (accounts) => {
       await feeRebateToken.forceMint(accounts[1], tdtId)
 
       await expectThrow(
-        vendingMachine.tbtcToBtc(testDeposit.address, '0x1111111100000000', requesterPKH, accounts[0]),
+        vendingMachine.tbtcToBtc(testDeposit.address, '0x1111111100000000', redeemerOutputScript, accounts[0]),
         'SafeMath: subtraction overflow.'
       )
     })
@@ -353,7 +353,7 @@ contract('VendingMachine', (accounts) => {
 
         const tbtcToBtc = vendingMachine.abi.filter((x) => x.name == 'tbtcToBtc')[0]
         const calldata = web3.eth.abi.encodeFunctionCall(
-          tbtcToBtc, [testDeposit.address, '0x1111111100000000', requesterPKH, accounts[0]]
+          tbtcToBtc, [testDeposit.address, '0x1111111100000000', redeemerOutputScript, accounts[0]]
         )
 
         await tbtcToken.approveAndCall(
@@ -363,7 +363,7 @@ contract('VendingMachine', (accounts) => {
         )
 
         const requestInfo = await testDeposit.getRequestInfo()
-        assert.equal(requestInfo[1], requesterPKH)
+        assert.equal(requestInfo[1], redeemerOutputScript)
         assert(!requestInfo[3].eqn(0)) // withdrawalRequestTime is set
         assert.equal(requestInfo[4], sighash)
 

--- a/implementation/test/contracts/deposit/TestDeposit.sol
+++ b/implementation/test/contracts/deposit/TestDeposit.sol
@@ -44,7 +44,7 @@ contract TestDeposit is Deposit {
     function reset() public {
         setState(0);
         setLiquidationAndCourtesyInitated(0, 0);
-        setRequestInfo(address(0), bytes20(0), 0, 0, bytes32(0));
+        setRequestInfo(address(0), "", 0, 0, bytes32(0));
         setUTXOInfo(bytes8(0), 0, '');
 
         setKeepAddress(address(0));
@@ -133,13 +133,13 @@ contract TestDeposit is Deposit {
 
     function setRequestInfo(
         address payable _redeemerAddress,
-        bytes20 _redeemerPKH,
+        bytes memory _redeemerOutputScript,
         uint256 _initialRedemptionFee,
         uint256 _withdrawalRequestTime,
         bytes32 _lastRequestedDigest
     ) public {
         self.redeemerAddress = _redeemerAddress;
-        self.redeemerPKH = _redeemerPKH;
+        self.redeemerOutputScript = _redeemerOutputScript;
         self.initialRedemptionFee = _initialRedemptionFee;
         self.withdrawalRequestTime = _withdrawalRequestTime;
         self.lastRequestedDigest = _lastRequestedDigest;
@@ -149,13 +149,14 @@ contract TestDeposit is Deposit {
     ) public {
         self.redeemerAddress = _redeemerAddress;
     }
-    function getRequestInfo() public view returns (address, bytes20, uint256, uint256, bytes32) {
+    function getRequestInfo() public view returns (address, bytes memory, uint256, uint256, bytes32) {
         return (
             self.redeemerAddress,
-            self.redeemerPKH,
+            self.redeemerOutputScript,
             self.initialRedemptionFee,
             self.withdrawalRequestTime,
-            self.lastRequestedDigest);
+            self.lastRequestedDigest
+        );
     }
 
     function setUTXOInfo(

--- a/implementation/test/contracts/deposit/TestDepositUtils.sol
+++ b/implementation/test/contracts/deposit/TestDepositUtils.sol
@@ -46,38 +46,8 @@ contract TestDepositUtils is TestDeposit {
         return self.findAndParseFundingOutput(_txOutputVector, _fundingOutputIndex);
     }
 
-    function validateAndParseFundingSPVProof(
-        bytes4 _txVersion,
-        bytes memory _txInputVector,
-        bytes memory _txOutputVector,
-        bytes4 _txLocktime,
-        uint8 _fundingOutputIndex,
-        bytes memory _merkleProof,
-        uint256 _txIndexInBlock,
-        bytes memory _bitcoinHeaders
-    ) public view returns (bytes8 _valueBytes, bytes memory _utxoOutpoint){
-      return self.validateAndParseFundingSPVProof(
-        _txVersion,
-        _txInputVector,
-        _txOutputVector,
-        _txLocktime,
-        _fundingOutputIndex,
-        _merkleProof,
-        _txIndexInBlock,
-        _bitcoinHeaders
-        );
-    }
-
-    function auctionValue() public view returns (uint256) {
-        return self.auctionValue();
-    }
-
     function signerFee() public view returns (uint256) {
         return self.signerFee();
-    }
-
-    function auctionTBTCAmount() public view returns (uint256) {
-        return self.auctionTBTCAmount();
     }
 
     function determineCompressionPrefix(bytes32 _pubkeyY) public pure returns (bytes memory) {
@@ -130,5 +100,44 @@ contract TestDepositUtils is TestDeposit {
 
     function pushFundsToKeepGroup(uint256 _ethValue) public returns (bool) {
         return self.pushFundsToKeepGroup(_ethValue);
+    }
+}
+
+// Separate contract for testing SPV proofs, as putting this in the main
+// TestDepositUtils contract causes it to run out of gas before finishing its
+// deploy.
+contract TestDepositUtilsSPV is TestDeposit {
+    constructor(address _factoryAddress)
+        TestDeposit(_factoryAddress)
+    public{}
+
+    function setPubKey(
+        bytes32 _signingGroupPubkeyX,
+        bytes32 _signingGroupPubkeyY
+    ) public {
+        self.signingGroupPubkeyX = _signingGroupPubkeyX;
+        self.signingGroupPubkeyY = _signingGroupPubkeyY;
+    }
+
+    function validateAndParseFundingSPVProof(
+        bytes4 _txVersion,
+        bytes memory _txInputVector,
+        bytes memory _txOutputVector,
+        bytes4 _txLocktime,
+        uint8 _fundingOutputIndex,
+        bytes memory _merkleProof,
+        uint256 _txIndexInBlock,
+        bytes memory _bitcoinHeaders
+    ) public view returns (bytes8 _valueBytes, bytes memory _utxoOutpoint){
+      return self.validateAndParseFundingSPVProof(
+        _txVersion,
+        _txInputVector,
+        _txOutputVector,
+        _txLocktime,
+        _fundingOutputIndex,
+        _merkleProof,
+        _txIndexInBlock,
+        _bitcoinHeaders
+        );
     }
 }


### PR DESCRIPTION
This requires a few things at the same time:

- Bumping the bitcoin-spv dependency to 2.2.0.
- Moving from CheckBitcoinSigs.oneInputOneOutputSighash to
  wpkhSpendSighash.
- Changing all bytes20 redemerPKHs to bytes redeemerOutputScripts.
- Adjusting any checks or tests to include the proper p2wpkh length
  prefix information, 0x160014, as bitcoin-spv now requires this to
  support different script types.
- Adjusting any empty defaults or comparisons to compare to empty bytes
  instead of 0 bytes20.

The result passes all current tests, though there are no tests for non-
p2wpkh output scripts in the repo yet.

Note that this does require clients that provide redemption proofs to
furnish length-prefixed output scripts, rather than p2wpkh scripts
without the length prefix.