### PR TITLE
The 't' stands for tBTC 💁

### DIFF
--- a/implementation/contracts/system/TBTCToken.sol
+++ b/implementation/contracts/system/TBTCToken.sol
@@ -13,7 +13,7 @@ contract TBTCToken is ERC20Detailed, ERC20, VendingMachineAuthority {
     /// @dev Constructor, calls ERC20Detailed constructor to set Token info
     ///      ERC20Detailed(TokenName, TokenSymbol, NumberOfDecimals)
     constructor(address _VendingMachine)
-        ERC20Detailed("Trustless bitcoin", "TBTC", 18)
+        ERC20Detailed("tBTC", "TBTC", 18)
         VendingMachineAuthority(_VendingMachine)
     public {
         // solium-disable-previous-line no-empty-blocks


### PR DESCRIPTION
We started a trend of meaningless first-letter token acronyms, let's stay true to it :grinning: 

"Trustless bitcoin" snuck in mid-development, but we don't want to pin a canonical meaning in the smart contract. Still leaving other "tokenized" / "trustless" / "threshold" / "trolling" references for the 't' throughout the repo and docs.