### PR TITLE
Add a bare security.txt

### DIFF
--- a/security.txt
+++ b/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:security@keep.network
+Encryption: https://keybase.io/mhluongo/pgp_keys.asc?fingerprint=4821ddea0ebc82d41ff644944e7050f4bbe79624
+Preferred-Languages: en


### PR DESCRIPTION
Before mainnet, we should revise the vulnerability submission process
and make sure all of the right keys and people are included.

Closes #451.