### PR TITLE
Increase mocha test timeout

### DIFF
--- a/implementation/package.json
+++ b/implementation/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "clean": "rm -rf build/",
     "compile": "truffle compile",
-    "test": "truffle compile && mocha --exit --recursive test",
+    "test": "truffle compile && mocha --exit --recursive test --timeout 5000",
     "quick-test": "mocha --exit --recursive test",
     "test:debug": "NODE_ENV=test node --inspect node_modules/.bin/truffle test",
     "js:lint": "eslint ${npm_package_config_eslintPaths}",


### PR DESCRIPTION
The default 2 seconds sometimes hangs on CI.
Increasing it to 5s should be enough for those large beforeAll hooks.