### PR TITLE
Update courtesy_call / at-term interactions

### DIFF
--- a/implementation/contracts/deposit/Deposit.sol
+++ b/implementation/contracts/deposit/Deposit.sol
@@ -437,12 +437,4 @@ contract Deposit is DepositFactoryAuthority {
         self.notifyCourtesyTimeout();
         return true;
     }
-
-    /// @notice     Notifies the contract that its term limit has been reached
-    /// @dev        This initiates a courtesy call
-    /// @return     True if successful, otherwise revert
-    function notifyDepositExpiryCourtesyCall() public returns (bool) {
-        self.notifyDepositExpiryCourtesyCall();
-        return true;
-    }
 }

--- a/implementation/contracts/deposit/DepositLiquidation.sol
+++ b/implementation/contracts/deposit/DepositLiquidation.sol
@@ -290,7 +290,6 @@ library DepositLiquidation {
     /// @param  _d  deposit storage pointer
     function exitCourtesyCall(DepositUtils.Deposit storage _d) public {
         require(_d.inCourtesyCall(), "Not currently in courtesy call");
-        require(block.timestamp <= _d.fundedAt + TBTCConstants.getDepositTerm(), "Deposit is expiring");
         require(getCollateralizationPercentage(_d) >= _d.undercollateralizedThresholdPercent, "Deposit is still undercollateralized");
         _d.setActive();
         _d.logExitedCourtesyCall();

--- a/implementation/contracts/deposit/DepositLiquidation.sol
+++ b/implementation/contracts/deposit/DepositLiquidation.sol
@@ -313,15 +313,4 @@ library DepositLiquidation {
         require(block.timestamp >= _d.courtesyCallInitiated + TBTCConstants.getCourtesyCallTimeout(), "Courtesy period has not elapsed");
         startSignerAbortLiquidation(_d);
     }
-
-    /// @notice     Notifies the contract that its term limit has been reached
-    /// @dev        This initiates a courtesy call
-    /// @param  _d  deposit storage pointer
-    function notifyDepositExpiryCourtesyCall(DepositUtils.Deposit storage _d) public {
-        require(_d.inActive(), "Deposit is not active");
-        require(block.timestamp >= _d.fundedAt + TBTCConstants.getDepositTerm(), "Deposit term not elapsed");
-        _d.setCourtesyCall();
-        _d.logCourtesyCalled();
-        _d.courtesyCallInitiated = block.timestamp;
-    }
 }


### PR DESCRIPTION
closes: https://github.com/keep-network/tbtc/issues/475

We have evolved from only using liquidation to terminate at-term Deposits. instead, Deposits can now only be closed by redemption (unless undercollateralized or fraud)