### PR TITLE
Fixed external address for keep vendor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,31 +282,31 @@ workflows:
       - setup_github_package_registry:
           context: github-package-registry
       - migrate_contracts:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - setup_github_package_registry
       - build_initcontainer:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - migrate_contracts
       - publish_images:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - migrate_contracts
             - build_initcontainer
       - publish_contract_data:
-          filters:
-            branches:
-              only: master
+          # filters:
+          #   branches:
+          #     only: master
           context: keep-dev
           requires:
             - migrate_contracts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,31 +282,31 @@ workflows:
       - setup_github_package_registry:
           context: github-package-registry
       - migrate_contracts:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - setup_github_package_registry
       - build_initcontainer:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - migrate_contracts
       - publish_images:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - migrate_contracts
             - build_initcontainer
       - publish_contract_data:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - migrate_contracts

--- a/implementation/migrations/3_initialize.js
+++ b/implementation/migrations/3_initialize.js
@@ -22,7 +22,7 @@ module.exports = async function(deployer, network) {
   if (process.env.NODE_ENV == "test" && !process.env.INTEGRATION_TEST) return
 
   const keepThreshold = 3
-  const groupSize = 3
+  const keepGroupSize = 3
 
   console.debug(
     `Initializing TBTCSystem [${TBTCSystem.address}] with:\n` +
@@ -34,7 +34,7 @@ module.exports = async function(deployer, network) {
       `  feeRebateToken: ${FeeRebateToken.address}\n` +
       `  vendingMachine: ${VendingMachine.address}\n` +
       `  keepThreshold: ${keepThreshold}\n` +
-      `  keepSize: ${groupSize}`,
+      `  keepSize: ${keepGroupSize}`,
   )
 
   // System.
@@ -48,7 +48,7 @@ module.exports = async function(deployer, network) {
     FeeRebateToken.address,
     VendingMachine.address,
     keepThreshold,
-    groupSize,
+    keepGroupSize,
   )
 
   console.log("TBTCSystem initialized!")

--- a/implementation/migrations/3_initialize.js
+++ b/implementation/migrations/3_initialize.js
@@ -21,6 +21,22 @@ module.exports = async function(deployer, network) {
   // Don't enact this setup during unit testing.
   if (process.env.NODE_ENV == "test" && !process.env.INTEGRATION_TEST) return
 
+  const keepThreshold = 3
+  const groupSize = 3
+
+  console.debug(
+    `Initializing TBTCSystem [${TBTCSystem.address}] with:\n` +
+      `  keepVendor: ${BondedECDSAKeepVendorAddress}\n` +
+      `  depositFactory: ${DepositFactory.address}\n` +
+      `  masterDepositAddress: ${Deposit.address}\n` +
+      `  tbtcToken: ${TBTCToken.address}\n` +
+      `  tbtcDepositToken: ${TBTCDepositToken.address}\n` +
+      `  feeRebateToken: ${FeeRebateToken.address}\n` +
+      `  vendingMachine: ${VendingMachine.address}\n` +
+      `  keepThreshold: ${keepThreshold}\n` +
+      `  keepSize: ${groupSize}`,
+  )
+
   // System.
   const tbtcSystem = await TBTCSystem.deployed()
   await tbtcSystem.initialize(
@@ -31,9 +47,11 @@ module.exports = async function(deployer, network) {
     TBTCDepositToken.address,
     FeeRebateToken.address,
     VendingMachine.address,
-    3,
-    3,
+    keepThreshold,
+    groupSize,
   )
+
+  console.log("TBTCSystem initialized!")
 
   // Price feed.
   const btcEthPriceFeed = await BTCETHPriceFeed.deployed()

--- a/implementation/migrations/externals.js
+++ b/implementation/migrations/externals.js
@@ -1,6 +1,6 @@
 // Configuration for addresses of externally deployed smart contracts
 // prettier-ignore
-const BondedECDSAKeepVendorAddress = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+const BondedECDSAKeepVendorAddress = "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
 
 // Medianized price feeds.
 // These are deployed and maintained by Maker.

--- a/implementation/migrations/externals.js
+++ b/implementation/migrations/externals.js
@@ -1,6 +1,6 @@
 // Configuration for addresses of externally deployed smart contracts
-const BondedECDSAKeepVendorAddress =
-  "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+// prettier-ignore
+const BondedECDSAKeepVendorAddress = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 // Medianized price feeds.
 // These are deployed and maintained by Maker.

--- a/implementation/scripts/circleci-provision-external-contracts.sh
+++ b/implementation/scripts/circleci-provision-external-contracts.sh
@@ -12,6 +12,7 @@ function fetch_bonded_keep_vendor_address() {
 }
 
 function set_bonded_keep_vendor_address() {
+  # TODO: Replace file we store external addresses by a `json` file and use `jq` to update it.
   sed -i -e "/BondedECDSAKeepVendorAddress/s/0x[a-zA-Z0-9]\{0,40\}/${BONDED_ECDSA_KEEP_VENDOR_ADDRESS}/" ./implementation/migrations/externals.js
 }
 

--- a/implementation/scripts/circleci-provision-external-contracts.sh
+++ b/implementation/scripts/circleci-provision-external-contracts.sh
@@ -12,7 +12,7 @@ function fetch_bonded_keep_vendor_address() {
 }
 
 function set_bonded_keep_vendor_address() {
-  sed -i -e "/BondedECDSAKeepVendorAddress/s/0x[a-fA-F0-9]\{0,40\}/${BONDED_ECDSA_KEEP_VENDOR_ADDRESS}/" ./implementation/migrations/externals.js
+  sed -i -e "/BondedECDSAKeepVendorAddress/s/0x[a-zA-Z0-9]\{0,40\}/${BONDED_ECDSA_KEEP_VENDOR_ADDRESS}/" ./implementation/migrations/externals.js
 }
 
 fetch_bonded_keep_vendor_address


### PR DESCRIPTION
Due to broken line by code formatted the address was not being set correctly on contracts migrations. `sed` command we use expects one line to update.
In this PR we:
- inline the `BondedECDSAKeepVendorAddress` definition
- ignore the line for the formatter
- add logging to initialization script to catch problems when debugging
- replace sample address to invalid value so it gets rejected if not updated