### PR TITLE
0.8.0 release branch

### DIFF
--- a/implementation/package-lock.json
+++ b/implementation/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "tbtc",
-  "version": "0.7.0-pre",
+  "name": "@keep-network/tbtc",
+  "version": "0.7.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "tbtc",
-  "version": "0.7.0-pre",
+  "name": "@keep-network/tbtc",
+  "version": "0.7.0-pre.0",
   "description": "deposit contract for TBTC",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I named this branch wrong. Feel free to fix that and open a new PR, sorry everyone.

Right now releasing the tbtc package requires some manual work. Not all of it is in this PR yet, so handing it off.

Things to do to release 0.8.0:
- [ ] Migrate keep-core, sortition-pools, keep-tecdsa, and tbtc on keep-test.
- [ ] Push *to the npm public registry* the appropriate versions of all three of the non-tbtc packages above. They might be unchanged with respect to the dependencies in this PR, in which case no push needed. `npm publish --access=public` is the trick.
- [ ] If needed, adjust the dependency version of keep-ecdsa in this package.json to the new version pushed above.
- [ ] Pull the artifacts from keep-tecdsa and tbtc from the GCS bucket to an implementation/artifacts/ directory in this rep. Currently all artifacts are in the tbtc package.
- [ ] Push *to the npm public registry* the 0.8.0 version of the implementation directory. That means adjust package.json version as well as removing .npmrc. Make sure the artifacts are in place. Again, `npm publish --access=public`.

Finito, continue with tbtc.js.