### PR TITLE
Liquidation can be non-fraud

### DIFF
--- a/implementation/contracts/deposit/DepositLiquidation.sol
+++ b/implementation/contracts/deposit/DepositLiquidation.sol
@@ -95,7 +95,7 @@ library DepositLiquidation {
 
         _d.liquidationInitiated = block.timestamp;  // Store the timestamp for auction
         _d.liquidationInitiator = msg.sender;
-        _d.setFraudLiquidationInProgress();
+        _d.setLiquidationInProgress();
     }
 
     /// @notice                 Anyone can provide a signature that was not requested to prove fraud.

--- a/implementation/test/DepositFraudTest.js
+++ b/implementation/test/DepositFraudTest.js
@@ -356,7 +356,7 @@ describe("DepositFraud", async function() {
       await restoreSnapshot()
     })
 
-    it("executes", async () => {
+    it("executes and moves state to FRAUD_LIQUIDATION_IN_PROGRESS", async () => {
       await testDeposit.provideECDSAFraudProof(
         0,
         bytes32zero,
@@ -364,6 +364,8 @@ describe("DepositFraud", async function() {
         bytes32zero,
         "0x00",
       )
+      const depositState = await testDeposit.getState.call()
+      expect(depositState).to.eq.BN(states.FRAUD_LIQUIDATION_IN_PROGRESS)
     })
 
     it("reverts if in the funding flow", async () => {
@@ -519,7 +521,7 @@ describe("DepositFraud", async function() {
       await ecdsaKeepStub.send(1000000, {from: owner})
     })
 
-    it("executes", async () => {
+    it("executes and moves state to FRAUD_LIQUIDATION_IN_PROGRESS", async () => {
       await testDeposit.provideSPVFraudProof(
         _version,
         _txInputVector,
@@ -530,6 +532,8 @@ describe("DepositFraud", async function() {
         _targetInputIndex,
         _bitcoinHeaders,
       )
+      const depositState = await testDeposit.getState.call()
+      expect(depositState).to.eq.BN(states.FRAUD_LIQUIDATION_IN_PROGRESS)
     })
 
     it("reverts if in the funding flow", async () => {

--- a/implementation/test/DepositLiquidationTest.js
+++ b/implementation/test/DepositLiquidationTest.js
@@ -419,7 +419,7 @@ describe("DepositLiquidation", async function() {
       await ecdsaKeepStub.send(1000000, {from: owner})
     })
 
-    it("executes", async () => {
+    it("executes and moves state to LIQUIDATION_IN_PROGRESS", async () => {
       // Bond value is calculated as:
       // `bondValue = collateralization * (lotSize * oraclePrice) / 100`
       // Here we test collateralization less than severely undercollateralized
@@ -431,6 +431,9 @@ describe("DepositLiquidation", async function() {
       await ecdsaKeepStub.setBondAmount(bondValue)
 
       await testDeposit.notifyUndercollateralizedLiquidation()
+
+      const depositState = await testDeposit.getState.call()
+      expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
       // TODO: Add validations or cover with `reverts if the deposit is not
       // severely undercollateralized` test case.
     })
@@ -490,8 +493,10 @@ describe("DepositLiquidation", async function() {
       await ecdsaKeepStub.send(1000000, {from: owner})
     })
 
-    it("executes", async () => {
+    it("executes and moves state to LIQUIDATION_IN_PROGRESS", async () => {
       await testDeposit.notifyCourtesyTimeout()
+      const depositState = await testDeposit.getState.call()
+      expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
     it("reverts if not in a courtesy call period", async () => {


### PR DESCRIPTION
closes: #497

`LIQUIDATION_IN_PROGRESS` was never used.

set state to `FRAUD_LIQUIDATION IN PROGRESS` when fraud,
and `LIQUIDATION_IN_PROGRESS` when not fraud.