### PR TITLE
tbtc migrations: scp -r too strong

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,8 +183,6 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - checkout
-      - attach_workspace:
-          at: implementation
       - run:
           name: Provision External Contract Addresses
           command: |

--- a/implementation/scripts/circleci-migrate-contracts.sh
+++ b/implementation/scripts/circleci-migrate-contracts.sh
@@ -40,9 +40,9 @@ ssh utilitybox << EOF
   echo ">>>>>>FINISH Download Kube Creds FINISH>>>>>>"
 
   echo "<<<<<<START Port Forward eth-tx-node START<<<<<<"
-  echo "nohup timeout 900 kubectl port-forward svc/eth-tx-node 8545:8545 2>&1 > /dev/null &"
+  echo "nohup kubectl port-forward svc/eth-tx-node 8545:8545 2>&1 > /dev/null &"
   echo "sleep 10s"
-  nohup timeout 900 kubectl port-forward svc/eth-tx-node 8545:8545 2>&1 > /dev/null &
+  nohup kubectl port-forward svc/eth-tx-node 8545:8545 2>&1 > /dev/null &
   sleep 10s
   echo ">>>>>>FINISH Port Forward eth-tx-node FINISH>>>>>>"
 
@@ -53,6 +53,7 @@ ssh utilitybox << EOF
 
   echo "<<<<<<START Contract Migration START<<<<<<"
   cd /tmp/$BUILD_TAG/implementation
+  npm ci
   ./node_modules/.bin/truffle migrate --reset --network $TRUFFLE_NETWORK
   echo ">>>>>>FINISH Contract Migration FINISH>>>>>>"
 EOF


### PR DESCRIPTION
In https://github.com/keep-network/tbtc/pull/485 we do some pre-compiling of contracts and npm packages to try and speed things up downstream.

This is glorious except for the instance in where we need to copy all of this pre-compiled data to the utility-box for a migration run.  In [this](https://app.circleci.com/pipelines/github/keep-network/tbtc/2015/workflows/6ba51f17-1f7f-47e0-ac59-42576ca616f7) job we let migrations run for about 50 minutes then called it since it was still copying.

Here we reverse the use of pre-compiles in `migrate_contracts` and use `npm ci` to try and speed things up a bit.

I did try some partial copies of pre-compiled contract data but due to the location of the `compile_contracts` persisted data I can't really mount the workspace without doing explicit copies of each thing I need, else it will try and suck `npm_modules` down again.  We don't save much time shipping already compiled contracts so I punted on investigating further.

This was tested in [this](https://circleci.com/workflow-run/7ced7bab-0164-4c68-8d4e-a28d757ac4bc) build