### PR TITLE
Bump keep-ecdsa to 0.10.0-rc and fix seize bonds problem

### DIFF
--- a/implementation/contracts/deposit/DepositUtils.sol
+++ b/implementation/contracts/deposit/DepositUtils.sol
@@ -372,9 +372,10 @@ library DepositUtils {
     /// @return     The amount seized in wei.
     function seizeSignerBonds(Deposit storage _d) internal returns (uint256) {
         uint256 _preCallBalance = address(this).balance;
+
         IBondedECDSAKeep _keep = IBondedECDSAKeep(_d.keepAddress);
-        _keep.closeKeep();
         _keep.seizeSignerBonds();
+
         uint256 _postCallBalance = address(this).balance;
         require(_postCallBalance > _preCallBalance, "No funds received, unexpected");
         return _postCallBalance.sub(_preCallBalance);

--- a/implementation/contracts/test/keep/ECDSAKeepStub.sol
+++ b/implementation/contracts/test/keep/ECDSAKeepStub.sol
@@ -4,17 +4,11 @@ import {
     IBondedECDSAKeep
 } from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeep.sol";
 
-import "openzeppelin-solidity/contracts/math/SafeMath.sol";
-
 /// @notice Implementation of ECDSAKeep interface used in tests only
 /// @dev This is a stub used in tests, so we don't have to call actual ECDSAKeep
 contract ECDSAKeepStub is IBondedECDSAKeep {
-    using SafeMath for uint256;
-
     bytes publicKey;
     bool success;
-    uint256 memberCount = 3;
-    bool isActive = true;
     uint256 bondAmount = 10000;
 
     // Notification that the keep was requested to sign a digest.
@@ -33,34 +27,26 @@ contract ECDSAKeepStub is IBondedECDSAKeep {
         return bondAmount;
     }
 
-    function sign(bytes32 _digest) external onlyWhenActive {
+    function sign(bytes32 _digest) external {
         emit SignatureRequested(_digest);
     }
 
     function distributeETHReward() external payable {
-        uint256 dividend = msg.value.div(memberCount);
-
-        require(dividend > 0, "Dividend value must be non-zero");
+        // solium-disable-previous-line no-empty-blocks
     }
 
     function distributeERC20Reward(address _asset, uint256 _value) external {
-        uint256 dividend = _value.div(memberCount);
-
-        require(dividend > 0, "Dividend value must be non-zero");
+        // solium-disable-previous-line no-empty-blocks
     }
 
-    function seizeSignerBonds() external onlyWhenActive {
-        isActive = false;
-
+    function seizeSignerBonds() external {
         if (address(this).balance > 0) {
             msg.sender.transfer(address(this).balance);
         }
     }
 
     function returnPartialSignerBonds() external payable {
-        uint256 bondPerMember = msg.value.div(memberCount);
-
-        require(bondPerMember > 0, "Partial signer bond must be non-zero");
+        // solium-disable-previous-line no-empty-blocks
     }
 
     function submitSignatureFraud(
@@ -75,21 +61,11 @@ contract ECDSAKeepStub is IBondedECDSAKeep {
         return success;
     }
 
-    function closeKeep() external onlyWhenActive {
-        isActive = false;
-    }
-
-    modifier onlyWhenActive() {
-        require(isActive, "Keep is not active");
-        _;
+    function closeKeep() external {
+        // solium-disable-previous-line no-empty-blocks
     }
 
     // Functions to set data for tests.
-
-    function reset() public {
-        success = true;
-        isActive = true;
-    }
 
     function setPublicKey(bytes memory _publicKey) public {
         publicKey = _publicKey;
@@ -97,10 +73,6 @@ contract ECDSAKeepStub is IBondedECDSAKeep {
 
     function setSuccess(bool _success) public {
         success = _success;
-    }
-
-    function setMemberCount(uint256 _memberCount) public {
-        memberCount = _memberCount;
     }
 
     function setBondAmount(uint256 _bondAmount) public {

--- a/implementation/contracts/test/keep/ECDSAKeepStub.sol
+++ b/implementation/contracts/test/keep/ECDSAKeepStub.sol
@@ -8,7 +8,7 @@ import {
 /// @dev This is a stub used in tests, so we don't have to call actual ECDSAKeep
 contract ECDSAKeepStub is IBondedECDSAKeep {
     bytes publicKey;
-    bool success;
+    bool success = true;
     uint256 bondAmount = 10000;
 
     // Notification that the keep was requested to sign a digest.
@@ -66,6 +66,10 @@ contract ECDSAKeepStub is IBondedECDSAKeep {
     }
 
     // Functions to set data for tests.
+
+    function reset() public {
+        success = true;
+    }
 
     function setPublicKey(bytes memory _publicKey) public {
         publicKey = _publicKey;

--- a/implementation/contracts/test/keep/ECDSAKeepStub.sol
+++ b/implementation/contracts/test/keep/ECDSAKeepStub.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.5.10;
 
-import {IBondedECDSAKeep} from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeep.sol";
+import {
+    IBondedECDSAKeep
+} from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeep.sol";
 
 /// @notice Implementation of ECDSAKeep interface used in tests only
 /// @dev This is a stub used in tests, so we don't have to call actual ECDSAKeep
@@ -10,51 +12,31 @@ contract ECDSAKeepStub is IBondedECDSAKeep {
     uint256 bondAmount = 10000;
 
     // Notification that the keep was requested to sign a digest.
-    event SignatureRequested(
-        bytes32 digest
-    );
+    event SignatureRequested(bytes32 digest);
 
     // Define fallback function so the contract can accept ether.
     function() external payable {}
 
+    // Functions implemented for IBondedECDSAKeep interface.
+
     function getPublicKey() external view returns (bytes memory) {
         return publicKey;
+    }
+
+    function checkBondAmount() external view returns (uint256) {
+        return bondAmount;
     }
 
     function sign(bytes32 _digest) external {
         emit SignatureRequested(_digest);
     }
 
-    function returnPartialSignerBonds() external payable {
-    // solium-disable-previous-line no-empty-blocks
-    }
-
-    function distributeETHToMembers() external payable {
-    // solium-disable-previous-line no-empty-blocks
+    function distributeETHReward() external payable {
+        // solium-disable-previous-line no-empty-blocks
     }
 
     function distributeERC20Reward(address _asset, uint256 _value) external {
-    // solium-disable-previous-line no-empty-blocks
-    }
-
-    function distributeETHReward() external payable{
-    // solium-disable-previous-line no-empty-blocks
-    }
-
-    // Functions implemented for IBondedECDSAKeep interface.
-
-    function submitSignatureFraud(
-        uint8,
-        bytes32,
-        bytes32,
-        bytes32,
-        bytes calldata
-    ) external returns (bool){
-        return success;
-    }
-
-    function checkBondAmount() external view returns (uint256){
-        return bondAmount;
+        // solium-disable-previous-line no-empty-blocks
     }
 
     function seizeSignerBonds() external {
@@ -63,8 +45,24 @@ contract ECDSAKeepStub is IBondedECDSAKeep {
         }
     }
 
+    function returnPartialSignerBonds() external payable {
+        // solium-disable-previous-line no-empty-blocks
+    }
+
+    function submitSignatureFraud(
+        uint8,
+        bytes32,
+        bytes32,
+        bytes32,
+        bytes calldata
+    ) external returns (bool) {
+        require(success, "Signature is not fraudulent");
+
+        return success;
+    }
+
     function closeKeep() external {
-    // solium-disable-previous-line no-empty-blocks
+        // solium-disable-previous-line no-empty-blocks
     }
 
     // Functions to set data for tests.

--- a/implementation/package-lock.json
+++ b/implementation/package-lock.json
@@ -5290,6 +5290,21 @@
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
         "mocha": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
@@ -5304,6 +5319,7 @@
             "glob": "7.1.2",
             "growl": "1.10.3",
             "he": "1.1.1",
+            "mkdirp": "0.5.1",
             "supports-color": "4.4.0"
           }
         },
@@ -20136,7 +20152,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true
             }
           }
@@ -26625,6 +26642,21 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
         "mocha": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
@@ -26639,6 +26671,7 @@
             "glob": "7.1.2",
             "growl": "1.10.3",
             "he": "1.1.1",
+            "mkdirp": "0.5.1",
             "supports-color": "4.4.0"
           }
         },

--- a/implementation/test/DepositFraudTest.js
+++ b/implementation/test/DepositFraudTest.js
@@ -72,7 +72,7 @@ describe("DepositFraud", async function() {
       const block = await web3.eth.getBlock("latest")
       const blockTimestamp = block.timestamp
       fundingProofTimerStart = blockTimestamp - timer.toNumber() - 1 // has elapsed
-      await ecdsaKeepStub.setSuccess(true)
+
       await testDeposit.setState(states.AWAITING_BTC_FUNDING_PROOF)
 
       await ecdsaKeepStub.send(1000000, {from: owner})
@@ -441,8 +441,7 @@ describe("DepositFraud", async function() {
   describe("provideECDSAFraudProof", async () => {
     before(async () => {
       await testDeposit.setState(states.ACTIVE)
-      await ecdsaKeepStub.send(1000000, {from: owner})
-      await ecdsaKeepStub.setSuccess(true)
+      await ecdsaKeepStub.send(1000000, { from: owner })
     })
 
     beforeEach(async () => {

--- a/implementation/test/DepositFraudTest.js
+++ b/implementation/test/DepositFraudTest.js
@@ -441,7 +441,7 @@ describe("DepositFraud", async function() {
   describe("provideECDSAFraudProof", async () => {
     before(async () => {
       await testDeposit.setState(states.ACTIVE)
-      await ecdsaKeepStub.send(1000000, { from: owner })
+      await ecdsaKeepStub.send(1000000, {from: owner})
     })
 
     beforeEach(async () => {

--- a/implementation/test/DepositFraudTest.js
+++ b/implementation/test/DepositFraudTest.js
@@ -57,6 +57,7 @@ describe("DepositFraud", async function() {
 
   beforeEach(async () => {
     await testDeposit.reset()
+    await ecdsaKeepStub.reset()
     await testDeposit.setKeepAddress(ecdsaKeepStub.address)
   })
 

--- a/implementation/test/DepositFundingTest.js
+++ b/implementation/test/DepositFundingTest.js
@@ -75,6 +75,7 @@ describe("DepositFunding", async function() {
     )
 
     await testDeposit.reset()
+    await ecdsaKeepStub.reset()
     await testDeposit.setKeepAddress(ecdsaKeepStub.address)
   })
 

--- a/implementation/test/DepositLiquidationTest.js
+++ b/implementation/test/DepositLiquidationTest.js
@@ -66,6 +66,7 @@ describe("DepositLiquidation", async function() {
       web3.utils.toBN(testDeposit.address),
     )
     await testDeposit.reset()
+    await ecdsaKeepStub.reset()
     await testDeposit.setKeepAddress(ecdsaKeepStub.address)
   })
 

--- a/implementation/test/DepositRedemptionTest.js
+++ b/implementation/test/DepositRedemptionTest.js
@@ -510,7 +510,6 @@ describe("DepositRedemption", async function() {
       await tbtcToken.resetAllowance(testDeposit.address, requiredBalance, {
         from: owner,
       })
-      await ecdsaKeepStub.setSuccess(true)
     })
 
     afterEach(async () => {
@@ -797,7 +796,6 @@ describe("DepositRedemption", async function() {
         withdrawalRequestTime,
         prevSighash,
       )
-      await ecdsaKeepStub.setSuccess(true)
     })
 
     it("approves a new digest for signing, updates the state, and logs RedemptionRequested", async () => {

--- a/implementation/test/DepositRedemptionTest.js
+++ b/implementation/test/DepositRedemptionTest.js
@@ -69,6 +69,7 @@ describe("DepositRedemption", async function() {
 
   beforeEach(async () => {
     await testDeposit.reset()
+    await ecdsaKeepStub.reset()
     await testDeposit.setKeepAddress(ecdsaKeepStub.address)
   })
 

--- a/implementation/test/DepositUtilsTest.js
+++ b/implementation/test/DepositUtilsTest.js
@@ -84,7 +84,10 @@ describe("DepositUtils", async function() {
       fullBtc,
       {value: funderBondAmount},
     )
+  })
 
+  beforeEach(async () => {
+    await ecdsaKeepStub.reset()
     await testDeposit.setKeepAddress(ecdsaKeepStub.address)
   })
 

--- a/implementation/test/VendingMachineTest.js
+++ b/implementation/test/VendingMachineTest.js
@@ -35,7 +35,6 @@ describe("VendingMachine", async function() {
   let tbtcDepositToken
   let feeRebateToken
   let testDeposit
-  let ecdsaKeepStub
 
   let assertBalance
   let tdtId
@@ -47,18 +46,17 @@ describe("VendingMachine", async function() {
 
   before(async () => {
     let deployed
-    ;({
-      mockRelay,
-      tbtcSystemStub,
-      tbtcToken,
-      tbtcDepositToken,
-      feeRebateToken,
-      testDeposit,
-      ecdsaKeepStub,
-      deployed,
-      redemptionScript,
-      fundingScript,
-    } = await deployAndLinkAll())
+      ; ({
+        mockRelay,
+        tbtcSystemStub,
+        tbtcToken,
+        tbtcDepositToken,
+        feeRebateToken,
+        testDeposit,
+        deployed,
+        redemptionScript,
+        fundingScript,
+      } = await deployAndLinkAll())
     vendingMachine = deployed.VendingMachine
 
     assertBalance = new AssertBalance(tbtcToken)
@@ -337,7 +335,6 @@ describe("VendingMachine", async function() {
       await tbtcToken.resetAllowance(vendingMachine.address, requiredBalance, {
         from: owner,
       })
-      await ecdsaKeepStub.setSuccess(true)
       await testDeposit.setState(states.ACTIVE)
       await testDeposit.setUTXOInfo(valueBytes, block.timestamp, outpoint)
     })

--- a/implementation/test/VendingMachineTest.js
+++ b/implementation/test/VendingMachineTest.js
@@ -46,17 +46,17 @@ describe("VendingMachine", async function() {
 
   before(async () => {
     let deployed
-      ; ({
-        mockRelay,
-        tbtcSystemStub,
-        tbtcToken,
-        tbtcDepositToken,
-        feeRebateToken,
-        testDeposit,
-        deployed,
-        redemptionScript,
-        fundingScript,
-      } = await deployAndLinkAll())
+    ;({
+      mockRelay,
+      tbtcSystemStub,
+      tbtcToken,
+      tbtcDepositToken,
+      feeRebateToken,
+      testDeposit,
+      deployed,
+      redemptionScript,
+      fundingScript,
+    } = await deployAndLinkAll())
     vendingMachine = deployed.VendingMachine
 
     assertBalance = new AssertBalance(tbtcToken)


### PR DESCRIPTION
This PR contains a couple of improvements to integration with keep-ecdsa:
- fixed problem with seizing signer bonds being called after keep has already been closed (https://github.com/keep-network/tbtc/commit/f5075ec11ff1877d9fec61083e61e9539fc356fa),
- updated ECDSAKeepStub to be closer to the actual implementation of IBondedECDSAKeep interface, with this we are more likely to catch integration problems like the one above in unit tests,
- updated unit tests to reset ECDSAKeepStub used in testing,
- bumped up version of `@keep-network/keep-ecdsa` to `0.10.0-rc`.

Closes: https://github.com/keep-network/tbtc/issues/401