### PR TITLE
Dynamic base liquidation percentage

### DIFF
--- a/implementation/contracts/deposit/DepositFunding.sol
+++ b/implementation/contracts/deposit/DepositFunding.sol
@@ -70,6 +70,7 @@ library DepositFunding {
         _d.signerFeeDivisor = _system.getSignerFeeDivisor();
         _d.undercollateralizedThresholdPercent = _system.getUndercollateralizedThresholdPercent();
         _d.severelyUndercollateralizedThresholdPercent = _system.getSeverelyUndercollateralizedThresholdPercent();
+        _d.initialCollateralizedPercent = _system.getInitialCollateralizedPercent();
         _d.signingGroupRequestedAt = block.timestamp;
 
         _d.setAwaitingSignerSetup();

--- a/implementation/contracts/deposit/DepositUtils.sol
+++ b/implementation/contracts/deposit/DepositUtils.sol
@@ -33,6 +33,7 @@ library DepositUtils {
         uint256 lotSizeSatoshis;
         uint8 currentState;
         uint256 signerFeeDivisor;
+        uint128 initialCollateralizedPercent;
         uint128 undercollateralizedThresholdPercent;
         uint128 severelyUndercollateralizedThresholdPercent;
 
@@ -373,9 +374,7 @@ library DepositUtils {
     /// @return     The percentage of the InitialCollateralizationPercent that will result
     ///             in a 100% bond value base auction given perfect collateralization.
     function getAuctionBasePercentage(Deposit storage _d) internal view returns (uint256) {
-        ITBTCSystem _sys = ITBTCSystem(_d.TBTCSystem);
-        uint256 initialCollateralizedPercent = _sys.getInitialCollateralizedPercent();
-        return (10000 / initialCollateralizedPercent);
+        return uint256(10000).div(_d.initialCollateralizedPercent);
     }
 
     /// @notice     Seize the signer bond from the keep contract.

--- a/implementation/contracts/deposit/DepositUtils.sol
+++ b/implementation/contracts/deposit/DepositUtils.sol
@@ -230,7 +230,7 @@ library DepositUtils {
         }
 
         // This should make a smooth flow from base% to 100%
-        uint256 _basePercentage = TBTCConstants.getAuctionBasePercentage();
+        uint256 _basePercentage = getAuctionBasePercentage(_d);
         uint256 _elapsedPercentage = uint256(100).sub(_basePercentage).mul(_elapsed).div(TBTCConstants.getAuctionDuration());
         uint256 _percentage = _basePercentage.add(_elapsedPercentage);
 
@@ -365,6 +365,17 @@ library DepositUtils {
         _d.initialRedemptionFee = 0;
         _d.withdrawalRequestTime = 0;
         _d.lastRequestedDigest = bytes32(0);
+    }
+
+
+    /// @notice     Get the starting percentage of the bond at auction.
+    /// @dev        This will return the same value regardless of collateral price.
+    /// @return     The percentage of the InitialCollateralizationPercent that will result
+    ///             in a 100% bond value base auction given perfect collateralization.
+    function getAuctionBasePercentage(Deposit storage _d) internal view returns (uint256) {
+        ITBTCSystem _sys = ITBTCSystem(_d.TBTCSystem);
+        uint256 initialCollateralizedPercent = _sys.getInitialCollateralizedPercent();
+        return (10000 / initialCollateralizedPercent);
     }
 
     /// @notice     Seize the signer bond from the keep contract.

--- a/implementation/contracts/deposit/TBTCConstants.sol
+++ b/implementation/contracts/deposit/TBTCConstants.sol
@@ -26,7 +26,6 @@ library TBTCConstants {
     // Liquidation Flow
     uint256 public constant COURTESY_CALL_DURATION = 6 * 60 * 60; // seconds
     uint256 public constant AUCTION_DURATION = 24 * 60 * 60; // seconds
-    uint256 public constant AUCTION_BASE_PERCENTAGE = 90; // percents
     uint256 public constant PERMITTED_FEE_BUMPS = 5; // number of times the fee can be increased
 
     // Getters for easy access
@@ -47,6 +46,5 @@ library TBTCConstants {
 
     function getCourtesyCallTimeout() public pure returns (uint256) { return COURTESY_CALL_DURATION; }
     function getAuctionDuration() public pure returns (uint256) { return AUCTION_DURATION; }
-    function getAuctionBasePercentage() public pure returns (uint256) { return AUCTION_BASE_PERCENTAGE; }
     function getPermittedFeeBumps() public pure returns (uint256) {return PERMITTED_FEE_BUMPS; }
 }

--- a/implementation/contracts/interfaces/ITBTCSystem.sol
+++ b/implementation/contracts/interfaces/ITBTCSystem.sol
@@ -14,4 +14,6 @@ interface ITBTCSystem {
     // passthrough requests for the oracle
     function fetchRelayCurrentDifficulty() external view returns (uint256);
     function fetchRelayPreviousDifficulty() external view returns (uint256);
+
+    function getInitialCollateralizedPercent() external view returns (uint128);
 }

--- a/implementation/contracts/test/deposit/TestDeposit.sol
+++ b/implementation/contracts/test/deposit/TestDeposit.sol
@@ -238,4 +238,8 @@ contract TestDeposit is Deposit {
     function pushFundsToKeepGroup(uint256 _ethValue) public returns (bool) {
         return self.pushFundsToKeepGroup(_ethValue);
     }
+
+    function getAuctionBasePercentage() public view returns (uint256) {
+        return self.getAuctionBasePercentage();
+    }
 }

--- a/implementation/contracts/test/deposit/TestDeposit.sol
+++ b/implementation/contracts/test/deposit/TestDeposit.sol
@@ -73,6 +73,10 @@ contract TestDeposit is Deposit {
         self.undercollateralizedThresholdPercent = _undercollateralizedThresholdPercent;
     }
 
+    function setInitialCollateralizedPercent(uint128 _initialCollateralizedPercent) public {
+        self.initialCollateralizedPercent = _initialCollateralizedPercent;
+    }
+
     function getUndercollateralizedThresholdPercent() public view returns (uint128) { return self.undercollateralizedThresholdPercent; }
 
     function setSeverelyUndercollateralizedThresholdPercent(uint128 _severelyUndercollateralizedThresholdPercent) public {

--- a/implementation/contracts/test/deposit/TestTBTCConstants.sol
+++ b/implementation/contracts/test/deposit/TestTBTCConstants.sol
@@ -26,7 +26,6 @@ library TestTBTCConstants {
     // Liquidation Flow
     uint256 public constant COURTESY_CALL_DURATION = 6 * 60 * 60; // seconds
     uint256 public constant AUCTION_DURATION = 24 * 60 * 60; // seconds
-    uint256 public constant AUCTION_BASE_PERCENTAGE = 90; // percents
     uint256 public constant PERMITTED_FEE_BUMPS = 5; // number of times the fee can be increased
 
     function getBeneficiaryRewardDivisor() public pure returns (uint256) { return BENEFICIARY_FEE_DIVISOR; }
@@ -46,6 +45,5 @@ library TestTBTCConstants {
 
     function getCourtesyCallTimeout() public pure returns (uint256) { return COURTESY_CALL_DURATION; }
     function getAuctionDuration() public pure returns (uint256) { return AUCTION_DURATION; }
-    function getAuctionBasePercentage() public pure returns (uint256) { return AUCTION_BASE_PERCENTAGE; }
     function getPermittedFeeBumps() public pure returns (uint256) {return PERMITTED_FEE_BUMPS; }
 }

--- a/implementation/test/DepositLiquidationTest.js
+++ b/implementation/test/DepositLiquidationTest.js
@@ -83,6 +83,7 @@ describe("DepositLiquidation", async function() {
 
     before(async () => {
       lotSize = await testDeposit.lotSizeTbtc.call()
+      await testDeposit.setInitialCollateralizedPercent(new BN(150))
       buyer = accounts[1]
     })
 

--- a/implementation/test/DepositLiquidationTest.js
+++ b/implementation/test/DepositLiquidationTest.js
@@ -185,7 +185,7 @@ describe("DepositLiquidation", async function() {
       const block = await web3.eth.getBlock("latest")
       const notifiedTime = block.timestamp
       const value = 1000000000000
-      const basePercentage = await tbtcConstants.getAuctionBasePercentage.call()
+      const basePercentage = await testDeposit.getAuctionBasePercentage.call()
 
       await ecdsaKeepStub.pushFundsFromKeep(testDeposit.address, {value: value})
 
@@ -227,7 +227,7 @@ describe("DepositLiquidation", async function() {
       const notifiedTime = block.timestamp
       const liquidationInitiator = accounts[2]
       const value = 1000000000000
-      const basePercentage = await tbtcConstants.getAuctionBasePercentage.call()
+      const basePercentage = await testDeposit.getAuctionBasePercentage.call()
 
       await ecdsaKeepStub.pushFundsFromKeep(testDeposit.address, {value: value})
 

--- a/implementation/test/DepositUtilsTest.js
+++ b/implementation/test/DepositUtilsTest.js
@@ -383,12 +383,24 @@ describe("DepositUtils", async function() {
     })
   })
 
+  describe("getAuctionBasePercentage()", async () => {
+    it("returns correct base percentage", async () => {
+      const basePercentage = await testDeposit.getAuctionBasePercentage.call()
+
+      const initialCollateralization = await tbtcSystemStub.getInitialCollateralizedPercent()
+
+      // 10000 to avoid losing value to truncating is solidity.
+      const expecged = new BN(10000).div(initialCollateralization)
+      expect(basePercentage).to.eq.BN(expecged) // 66 for 150
+    })
+  })
+
   describe("auctionValue()", async () => {
     let duration
     let basePercentage
     before(async () => {
       duration = await tbtcConstants.getAuctionDuration.call()
-      basePercentage = await tbtcConstants.getAuctionBasePercentage.call()
+      basePercentage = await testDeposit.getAuctionBasePercentage.call()
       auctionValue = new BN(100000000)
     })
     beforeEach(async () => {

--- a/implementation/test/DepositUtilsTest.js
+++ b/implementation/test/DepositUtilsTest.js
@@ -389,9 +389,9 @@ describe("DepositUtils", async function() {
 
       const initialCollateralization = await tbtcSystemStub.getInitialCollateralizedPercent()
 
-      // 10000 to avoid losing value to truncating is solidity.
-      const expecged = new BN(10000).div(initialCollateralization)
-      expect(basePercentage).to.eq.BN(expecged) // 66 for 150
+      // 10000 to avoid losing value to truncating in solidity.
+      const expected = new BN(10000).div(initialCollateralization)
+      expect(basePercentage).to.eq.BN(expected) // 66 for 150
     })
   })
 


### PR DESCRIPTION
Replace `AUCTION_BASE_PERCENTAGE` constant with a function that returns base percentage given the `initialCollateralizationPercent` from `tbtcSystem`

The base collateralization percentage should be the percentage of the `InitialCollateralizationPercent` that will result in a 100% bond value base auction assuming perfect collateralization.

- Note, this breaks down if the recorded collateralization percentage is below 100%