### PR TITLE
Use specific contract types

### DIFF
--- a/solidity/contracts/DepositLog.sol
+++ b/solidity/contracts/DepositLog.sol
@@ -118,13 +118,13 @@ contract DepositLog {
     /// @notice               Sets the tbtcDepositToken contract.
     /// @dev                  The contract is used by `approvedToLog` to check if the
     ///                       caller is a Deposit contract. This should only be called once.
-    /// @param  _tbtcDepositTokenAddress  The address of the tbtcDepositToken.
-    function setTbtcDepositToken(address _tbtcDepositTokenAddress) public {
+    /// @param  _tbtcDepositToken  tbtcDepositToken contract.
+    function setTbtcDepositToken(TBTCDepositToken _tbtcDepositToken) public {
         require(
             address(tbtcDepositToken) == address(0),
             "tbtcDepositToken is already set"
         );
-        tbtcDepositToken = TBTCDepositToken(_tbtcDepositTokenAddress);
+        tbtcDepositToken = _tbtcDepositToken;
     }
 
     //

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -97,11 +97,11 @@ contract Deposit is DepositFactoryAuthority {
     // THIS IS THE INIT FUNCTION
     /// @notice        The Deposit Factory can spin up a new deposit.
     /// @dev           Only the Deposit factory can call this.
-    /// @param _TBTCSystem        `TBTCSystem` contract. More info in `VendingMachine`.
-    /// @param _TBTCToken         `TBTCToken` contract. More info in TBTCToken`.
-    /// @param _TBTCDepositToken  `TBTCDepositToken` (TDT) contract. More info in `TBTCDepositToken`.
-    /// @param _FeeRebateToken    `FeeRebateToken` (FRT) contract. More info in `FeeRebateToken`.
-    /// @param _VendingMachineAddress    `VendingMachine` address. More info in `VendingMachine`.
+    /// @param _tbtcSystem        `TBTCSystem` contract. More info in `VendingMachine`.
+    /// @param _tbtcToken         `TBTCToken` contract. More info in TBTCToken`.
+    /// @param _tbtcDepositToken  `TBTCDepositToken` (TDT) contract. More info in `TBTCDepositToken`.
+    /// @param _feeRebateToken    `FeeRebateToken` (FRT) contract. More info in `FeeRebateToken`.
+    /// @param _vendingMachineAddress    `VendingMachine` address. More info in `VendingMachine`.
     /// @param _m           Signing group honesty threshold.
     /// @param _n           Signing group size.
     /// @param _lotSizeSatoshis The minimum amount of satoshi the funder is required to send.
@@ -109,20 +109,20 @@ contract Deposit is DepositFactoryAuthority {
     ///                         (10**7 satoshi == 0.1 BTC == 0.1 TBTC).
     /// @return             True if successful, otherwise revert.
     function createNewDeposit(
-        ITBTCSystem _TBTCSystem,
-        TBTCToken _TBTCToken,
-        IERC721 _TBTCDepositToken,
-        FeeRebateToken _FeeRebateToken,
-        address _VendingMachineAddress,
+        ITBTCSystem _tbtcSystem,
+        TBTCToken _tbtcToken,
+        IERC721 _tbtcDepositToken,
+        FeeRebateToken _feeRebateToken,
+        address _vendingMachineAddress,
         uint256 _m,
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public onlyFactory payable returns (bool) {
-        self.tbtcSystem = _TBTCSystem;
-        self.tbtcToken = _TBTCToken;
-        self.tbtcDepositToken = _TBTCDepositToken;
-        self.feeRebateToken = _FeeRebateToken;
-        self.VendingMachineAddress = _VendingMachineAddress;
+        self.tbtcSystem = _tbtcSystem;
+        self.tbtcToken = _tbtcToken;
+        self.tbtcDepositToken = _tbtcDepositToken;
+        self.feeRebateToken = _feeRebateToken;
+        self.vendingMachineAddress = _vendingMachineAddress;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;
     }

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -5,6 +5,11 @@ import {DepositUtils} from "./DepositUtils.sol";
 import {DepositFunding} from "./DepositFunding.sol";
 import {DepositRedemption} from "./DepositRedemption.sol";
 import {DepositStates} from "./DepositStates.sol";
+import {ITBTCSystem} from "../interfaces/ITBTCSystem.sol";
+import {IERC721} from "openzeppelin-solidity/contracts/token/ERC721/IERC721.sol";
+import {TBTCToken} from "../system/TBTCToken.sol";
+import {FeeRebateToken} from "../system/FeeRebateToken.sol";
+
 import "../system/DepositFactoryAuthority.sol";
 
 /// @title  Deposit.
@@ -113,10 +118,10 @@ contract Deposit is DepositFactoryAuthority {
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public onlyFactory payable returns (bool) {
-        self.TBTCSystem = _TBTCSystem;
-        self.TBTCToken = _TBTCToken;
-        self.TBTCDepositToken = _TBTCDepositToken;
-        self.FeeRebateToken = _FeeRebateToken;
+        self.tbtcSystem = ITBTCSystem(_TBTCSystem);
+        self.tbtcToken = TBTCToken(_TBTCToken);
+        self.tbtcDepositToken = IERC721(_TBTCDepositToken);
+        self.feeRebateToken = FeeRebateToken(_FeeRebateToken);
         self.VendingMachine = _VendingMachine;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -101,7 +101,7 @@ contract Deposit is DepositFactoryAuthority {
     /// @param _TBTCToken         `TBTCToken` contract. More info in TBTCToken`.
     /// @param _TBTCDepositToken  `TBTCDepositToken` (TDT) contract. More info in `TBTCDepositToken`.
     /// @param _FeeRebateToken    `FeeRebateToken` (FRT) contract. More info in `FeeRebateToken`.
-    /// @param _VendingMachine    `VendingMachine` address. More info in `VendingMachine`.
+    /// @param _VendingMachineAddress    `VendingMachine` address. More info in `VendingMachine`.
     /// @param _m           Signing group honesty threshold.
     /// @param _n           Signing group size.
     /// @param _lotSizeSatoshis The minimum amount of satoshi the funder is required to send.
@@ -113,7 +113,7 @@ contract Deposit is DepositFactoryAuthority {
         TBTCToken _TBTCToken,
         IERC721 _TBTCDepositToken,
         FeeRebateToken _FeeRebateToken,
-        address _VendingMachine,
+        address _VendingMachineAddress,
         uint256 _m,
         uint256 _n,
         uint256 _lotSizeSatoshis
@@ -122,7 +122,7 @@ contract Deposit is DepositFactoryAuthority {
         self.tbtcToken = _TBTCToken;
         self.tbtcDepositToken = _TBTCDepositToken;
         self.feeRebateToken = _FeeRebateToken;
-        self.VendingMachine = _VendingMachine;
+        self.VendingMachineAddress = _VendingMachineAddress;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;
     }

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -109,19 +109,19 @@ contract Deposit is DepositFactoryAuthority {
     ///                         (10**7 satoshi == 0.1 BTC == 0.1 TBTC).
     /// @return             True if successful, otherwise revert.
     function createNewDeposit(
-        address _TBTCSystem,
-        address _TBTCToken,
-        address _TBTCDepositToken,
-        address _FeeRebateToken,
+        ITBTCSystem _TBTCSystem,
+        TBTCToken _TBTCToken,
+        IERC721 _TBTCDepositToken,
+        FeeRebateToken _FeeRebateToken,
         address _VendingMachine,
         uint256 _m,
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public onlyFactory payable returns (bool) {
-        self.tbtcSystem = ITBTCSystem(_TBTCSystem);
-        self.tbtcToken = TBTCToken(_TBTCToken);
-        self.tbtcDepositToken = IERC721(_TBTCDepositToken);
-        self.feeRebateToken = FeeRebateToken(_FeeRebateToken);
+        self.tbtcSystem = (_TBTCSystem);
+        self.tbtcToken = (_TBTCToken);
+        self.tbtcDepositToken = (_TBTCDepositToken);
+        self.feeRebateToken = (_FeeRebateToken);
         self.VendingMachine = _VendingMachine;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -97,10 +97,10 @@ contract Deposit is DepositFactoryAuthority {
     // THIS IS THE INIT FUNCTION
     /// @notice        The Deposit Factory can spin up a new deposit.
     /// @dev           Only the Deposit factory can call this.
-    /// @param _TBTCSystem        `TBTCSystem` address. More info in `VendingMachine`.
-    /// @param _TBTCToken         `TBTCToken` address. More info in TBTCToken`.
-    /// @param _TBTCDepositToken  `TBTCDepositToken` (TDT) address. More info in `TBTCDepositToken`.
-    /// @param _FeeRebateToken    `FeeRebateToken` (FRT) address. More info in `FeeRebateToken`.
+    /// @param _TBTCSystem        `TBTCSystem` contract. More info in `VendingMachine`.
+    /// @param _TBTCToken         `TBTCToken` contract. More info in TBTCToken`.
+    /// @param _TBTCDepositToken  `TBTCDepositToken` (TDT) contract. More info in `TBTCDepositToken`.
+    /// @param _FeeRebateToken    `FeeRebateToken` (FRT) contract. More info in `FeeRebateToken`.
     /// @param _VendingMachine    `VendingMachine` address. More info in `VendingMachine`.
     /// @param _m           Signing group honesty threshold.
     /// @param _n           Signing group size.
@@ -118,10 +118,10 @@ contract Deposit is DepositFactoryAuthority {
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public onlyFactory payable returns (bool) {
-        self.tbtcSystem = (_TBTCSystem);
-        self.tbtcToken = (_TBTCToken);
-        self.tbtcDepositToken = (_TBTCDepositToken);
-        self.feeRebateToken = (_FeeRebateToken);
+        self.tbtcSystem = _TBTCSystem;
+        self.tbtcToken = _TBTCToken;
+        self.tbtcDepositToken = _TBTCDepositToken;
+        self.feeRebateToken = _FeeRebateToken;
         self.VendingMachine = _VendingMachine;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -55,7 +55,7 @@ library DepositFunding {
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public returns (bool) {
-        TBTCSystem _system = TBTCSystem(_d.TBTCSystem);
+        TBTCSystem _system = TBTCSystem(address(_d.tbtcSystem));
 
         require(_system.getAllowNewDeposits(), "Opening new deposits is currently disabled.");
         require(_d.inStart(), "Deposit setup already requested");

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -5,7 +5,6 @@ import {BytesLib} from "@summa-tx/bitcoin-spv-sol/contracts/BytesLib.sol";
 import {BTCUtils} from "@summa-tx/bitcoin-spv-sol/contracts/BTCUtils.sol";
 import {IBondedECDSAKeep} from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeep.sol";
 import {TBTCToken} from "../system/TBTCToken.sol";
-import {TBTCSystem} from "../system/TBTCSystem.sol";
 import {DepositUtils} from "./DepositUtils.sol";
 import {DepositLiquidation} from "./DepositLiquidation.sol";
 import {DepositStates} from "./DepositStates.sol";
@@ -55,22 +54,20 @@ library DepositFunding {
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public returns (bool) {
-        TBTCSystem _system = TBTCSystem(address(_d.tbtcSystem));
-
-        require(_system.getAllowNewDeposits(), "Opening new deposits is currently disabled.");
+        require(_d.tbtcSystem.getAllowNewDeposits(), "Opening new deposits is currently disabled.");
         require(_d.inStart(), "Deposit setup already requested");
-        require(_system.isAllowedLotSize(_lotSizeSatoshis), "provided lot size not supported");
+        require(_d.tbtcSystem.isAllowedLotSize(_lotSizeSatoshis), "provided lot size not supported");
 
         _d.lotSizeSatoshis = _lotSizeSatoshis;
-        uint256 _bondRequirementSatoshi = _lotSizeSatoshis.mul(_system.getInitialCollateralizedPercent()).div(100);
+        uint256 _bondRequirementSatoshi = _lotSizeSatoshis.mul(_d.tbtcSystem.getInitialCollateralizedPercent()).div(100);
         uint256 _bondRequirementWei = _d.fetchBitcoinPrice().mul(_bondRequirementSatoshi);
 
         /* solium-disable-next-line value-in-payable */
-        _d.keepAddress = _system.requestNewKeep.value(msg.value)(_m, _n, _bondRequirementWei);
-        _d.signerFeeDivisor = _system.getSignerFeeDivisor();
-        _d.undercollateralizedThresholdPercent = _system.getUndercollateralizedThresholdPercent();
-        _d.severelyUndercollateralizedThresholdPercent = _system.getSeverelyUndercollateralizedThresholdPercent();
-        _d.initialCollateralizedPercent = _system.getInitialCollateralizedPercent();
+        _d.keepAddress = _d.tbtcSystem.requestNewKeep.value(msg.value)(_m, _n, _bondRequirementWei);
+        _d.signerFeeDivisor = _d.tbtcSystem.getSignerFeeDivisor();
+        _d.undercollateralizedThresholdPercent = _d.tbtcSystem.getUndercollateralizedThresholdPercent();
+        _d.severelyUndercollateralizedThresholdPercent = _d.tbtcSystem.getSeverelyUndercollateralizedThresholdPercent();
+        _d.initialCollateralizedPercent = _d.tbtcSystem.getInitialCollateralizedPercent();
         _d.signingGroupRequestedAt = block.timestamp;
 
         _d.setAwaitingSignerSetup();

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -170,7 +170,7 @@ library DepositLiquidation {
         uint256 lotSizeTbtc = _d.lotSizeTbtc();
         require(_d.tbtcToken.balanceOf(msg.sender) >= lotSizeTbtc, "Not enough TBTC to cover outstanding debt");
 
-        if(tdtHolder == _d.VendingMachine){
+        if(tdtHolder == _d.VendingMachineAddress){
             _d.tbtcToken.burnFrom(msg.sender, lotSizeTbtc);  // burn minimal amount to cover size
         }
         else{

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -167,16 +167,14 @@ library DepositLiquidation {
         // send the TBTC to the TDT holder. If the TDT holder is the Vending Machine, burn it to maintain the peg.
         address tdtHolder = _d.depositOwner();
 
-        TBTCToken _tbtcToken = TBTCToken(_d.TBTCToken);
-
         uint256 lotSizeTbtc = _d.lotSizeTbtc();
-        require(_tbtcToken.balanceOf(msg.sender) >= lotSizeTbtc, "Not enough TBTC to cover outstanding debt");
+        require(_d.tbtcToken.balanceOf(msg.sender) >= lotSizeTbtc, "Not enough TBTC to cover outstanding debt");
 
         if(tdtHolder == _d.VendingMachine){
-            _tbtcToken.burnFrom(msg.sender, lotSizeTbtc);  // burn minimal amount to cover size
+            _d.tbtcToken.burnFrom(msg.sender, lotSizeTbtc);  // burn minimal amount to cover size
         }
         else{
-            _tbtcToken.transferFrom(msg.sender, tdtHolder, lotSizeTbtc);
+            _d.tbtcToken.transferFrom(msg.sender, tdtHolder, lotSizeTbtc);
         }
 
         // Distribute funds to auction buyer

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -170,7 +170,7 @@ library DepositLiquidation {
         uint256 lotSizeTbtc = _d.lotSizeTbtc();
         require(_d.tbtcToken.balanceOf(msg.sender) >= lotSizeTbtc, "Not enough TBTC to cover outstanding debt");
 
-        if(tdtHolder == _d.VendingMachineAddress){
+        if(tdtHolder == _d.vendingMachineAddress){
             _d.tbtcToken.burnFrom(msg.sender, lotSizeTbtc);  // burn minimal amount to cover size
         }
         else{

--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -59,7 +59,7 @@ library DepositRedemption {
     /// @dev Burns or transfers depending on term and supply-peg impact.
     function performRedemptionTBTCTransfers(DepositUtils.Deposit storage _d) internal {
         address tdtHolder = _d.depositOwner();
-        address vendingMachineAddress = _d.VendingMachineAddress;
+        address vendingMachineAddress = _d.vendingMachineAddress;
 
         uint256 tbtcLot = _d.lotSizeTbtc();
         uint256 signerFee = _d.signerFee();

--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -59,7 +59,7 @@ library DepositRedemption {
     /// @dev Burns or transfers depending on term and supply-peg impact.
     function performRedemptionTBTCTransfers(DepositUtils.Deposit storage _d) internal {
         address tdtHolder = _d.depositOwner();
-        address vendingMachine = _d.VendingMachine;
+        address vendingMachineAddress = _d.VendingMachineAddress;
 
         uint256 tbtcLot = _d.lotSizeTbtc();
         uint256 signerFee = _d.signerFee();
@@ -81,7 +81,7 @@ library DepositRedemption {
             // As compensation, the TDT owner is reimbursed in TBTC
             // Vending Machine-owned TDTs have been used to mint TBTC,
             // and we should always burn a full TBTC to redeem the deposit.
-            if(tdtHolder == vendingMachine){
+            if(tdtHolder == vendingMachineAddress){
                 _d.tbtcToken.burnFrom(msg.sender, tbtcLot);
             }
             // if signer fee is not escrowed, escrow and it here and send the rest to TDT owner

--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -34,7 +34,7 @@ library DepositRedemption {
         IBondedECDSAKeep _keep = IBondedECDSAKeep(_d.keepAddress);
 
         _d.tbtcToken.approve(_d.keepAddress, _d.signerFee());
-        _keep.distributeERC20Reward(address(_d.tbtcToken), _d.signerFee());
+        _keep.distributeERC20Reward(_d.tbtcToken, _d.signerFee());
     }
 
     /// @notice Closes keep associated with the deposit.

--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -34,7 +34,7 @@ library DepositRedemption {
         IBondedECDSAKeep _keep = IBondedECDSAKeep(_d.keepAddress);
 
         _d.tbtcToken.approve(_d.keepAddress, _d.signerFee());
-        _keep.distributeERC20Reward(_d.tbtcToken, _d.signerFee());
+        _keep.distributeERC20Reward(address(_d.tbtcToken), _d.signerFee());
     }
 
     /// @notice Closes keep associated with the deposit.

--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -31,13 +31,10 @@ library DepositRedemption {
     /// @notice     Pushes signer fee to the Keep group by transferring it to the Keep address.
     /// @dev        Approves the keep contract, then expects it to call transferFrom.
     function distributeSignerFee(DepositUtils.Deposit storage _d) internal {
-        address _tbtcTokenAddress = _d.TBTCToken;
-        TBTCToken _tbtcToken = TBTCToken(_tbtcTokenAddress);
-
         IBondedECDSAKeep _keep = IBondedECDSAKeep(_d.keepAddress);
 
-        _tbtcToken.approve(_d.keepAddress, _d.signerFee());
-        _keep.distributeERC20Reward(_tbtcTokenAddress, _d.signerFee());
+        _d.tbtcToken.approve(_d.keepAddress, _d.signerFee());
+        _keep.distributeERC20Reward(address(_d.tbtcToken), _d.signerFee());
     }
 
     /// @notice Closes keep associated with the deposit.
@@ -61,7 +58,6 @@ library DepositRedemption {
     /// @notice Handles TBTC requirements for redemption.
     /// @dev Burns or transfers depending on term and supply-peg impact.
     function performRedemptionTBTCTransfers(DepositUtils.Deposit storage _d) internal {
-        TBTCToken _tbtc = TBTCToken(_d.TBTCToken);
         address tdtHolder = _d.depositOwner();
         address vendingMachine = _d.VendingMachine;
 
@@ -75,7 +71,7 @@ library DepositRedemption {
         }
         // if we owe > 0 & < signerfee, msg.sender is TDT owner but not FRT holder.
         if(tbtcOwed <= signerFee){
-            _tbtc.transferFrom(msg.sender, address(this), tbtcOwed);
+            _d.tbtcToken.transferFrom(msg.sender, address(this), tbtcOwed);
             return;
         }
         // Redemmer always owes a full TBTC for at-term redemption.
@@ -86,16 +82,16 @@ library DepositRedemption {
             // Vending Machine-owned TDTs have been used to mint TBTC,
             // and we should always burn a full TBTC to redeem the deposit.
             if(tdtHolder == vendingMachine){
-                _tbtc.burnFrom(msg.sender, tbtcLot);
+                _d.tbtcToken.burnFrom(msg.sender, tbtcLot);
             }
             // if signer fee is not escrowed, escrow and it here and send the rest to TDT owner
-            else if(_tbtc.balanceOf(address(this)) < signerFee){
-                _tbtc.transferFrom(msg.sender, address(this), signerFee);
-                _tbtc.transferFrom(msg.sender, tdtHolder, tbtcLot.sub(signerFee));
+            else if(_d.tbtcToken.balanceOf(address(this)) < signerFee){
+                _d.tbtcToken.transferFrom(msg.sender, address(this), signerFee);
+                _d.tbtcToken.transferFrom(msg.sender, tdtHolder, tbtcLot.sub(signerFee));
             }
             // tansfer a full TBTC to TDT owner if signerFee is escrowed
             else{
-                _tbtc.transferFrom(msg.sender, tdtHolder, tbtcLot);
+                _d.tbtcToken.transferFrom(msg.sender, tdtHolder, tbtcLot);
             }
             return;
         }
@@ -162,9 +158,7 @@ library DepositRedemption {
         bytes memory _redeemerOutputScript,
         address payable _finalRecipient
     ) public {
-        IERC721 _tbtcDepositToken = IERC721(_d.TBTCDepositToken);
-
-        _tbtcDepositToken.transferFrom(msg.sender, _finalRecipient, uint256(address(this)));
+        _d.tbtcDepositToken.transferFrom(msg.sender, _finalRecipient, uint256(address(this)));
 
         _requestRedemption(_d, _outputValueBytes, _redeemerOutputScript, _finalRecipient);
     }

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -29,7 +29,7 @@ library DepositUtils {
         TBTCToken tbtcToken;
         IERC721 tbtcDepositToken;
         FeeRebateToken feeRebateToken;
-        address VendingMachine;
+        address VendingMachineAddress;
         uint256 lotSizeSatoshis;
         uint8 currentState;
         uint256 signerFeeDivisor;

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -29,7 +29,7 @@ library DepositUtils {
         TBTCToken tbtcToken;
         IERC721 tbtcDepositToken;
         FeeRebateToken feeRebateToken;
-        address VendingMachineAddress;
+        address vendingMachineAddress;
         uint256 lotSizeSatoshis;
         uint8 currentState;
         uint256 signerFeeDivisor;

--- a/solidity/contracts/deposit/OutsourceDepositLogging.sol
+++ b/solidity/contracts/deposit/OutsourceDepositLogging.sol
@@ -12,7 +12,7 @@ library OutsourceDepositLogging {
     ///                       msg.sender will be the calling Deposit's address.
     /// @param  _keepAddress  The address of the associated keep.
     function logCreated(DepositUtils.Deposit storage _d, address _keepAddress) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logCreated(_keepAddress);
     }
 
@@ -34,7 +34,7 @@ library OutsourceDepositLogging {
         uint256 _requestedFee,
         bytes memory _outpoint
     ) public { // not external to allow bytes memory output scripts
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logRedemptionRequested(
             _redeemer,
             _digest,
@@ -57,7 +57,7 @@ library OutsourceDepositLogging {
         bytes32 _r,
         bytes32 _s
     ) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logGotRedemptionSignature(
             _digest,
             _r,
@@ -72,7 +72,7 @@ library OutsourceDepositLogging {
         bytes32 _signingGroupPubkeyX,
         bytes32 _signingGroupPubkeyY
     ) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logRegisteredPubkey(
             _signingGroupPubkeyX,
             _signingGroupPubkeyY);
@@ -81,28 +81,28 @@ library OutsourceDepositLogging {
     /// @notice     Fires a SetupFailed event.
     /// @dev        The logger is on a system contract, so all logs from all deposits are from the same address.
     function logSetupFailed(DepositUtils.Deposit storage _d) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logSetupFailed();
     }
 
     /// @notice     Fires a FraudDuringSetup event.
     /// @dev        The logger is on a system contract, so all logs from all deposits are from the same address.
     function logFraudDuringSetup(DepositUtils.Deposit storage _d) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logFraudDuringSetup();
     }
 
     /// @notice     Fires a Funded event.
     /// @dev        The logger is on a system contract, so all logs from all deposits are from the same address.
     function logFunded(DepositUtils.Deposit storage _d) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logFunded();
     }
 
     /// @notice     Fires a CourtesyCalled event.
     /// @dev        The logger is on a system contract, so all logs from all deposits are from the same address.
     function logCourtesyCalled(DepositUtils.Deposit storage _d) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logCourtesyCalled();
     }
 
@@ -110,28 +110,28 @@ library OutsourceDepositLogging {
     /// @dev                We append the sender, which is the deposit contract that called.
     /// @param _wasFraud    True if liquidating for fraud.
     function logStartedLiquidation(DepositUtils.Deposit storage _d, bool _wasFraud) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logStartedLiquidation(_wasFraud);
     }
 
     /// @notice     Fires a Redeemed event.
     /// @dev        The logger is on a system contract, so all logs from all deposits are from the same address.
     function logRedeemed(DepositUtils.Deposit storage _d, bytes32 _txid) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logRedeemed(_txid);
     }
 
     /// @notice     Fires a Liquidated event.
     /// @dev        The logger is on a system contract, so all logs from all deposits are from the same address.
     function logLiquidated(DepositUtils.Deposit storage _d) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logLiquidated();
     }
 
     /// @notice     Fires a ExitedCourtesyCall event.
     /// @dev        The logger is on a system contract, so all logs from all deposits are from the same address.
     function logExitedCourtesyCall(DepositUtils.Deposit storage _d) external {
-        DepositLog _logger = DepositLog(_d.TBTCSystem);
+        DepositLog _logger = DepositLog(address(_d.tbtcSystem));
         _logger.logExitedCourtesyCall();
     }
 }

--- a/solidity/contracts/interfaces/ITBTCSystem.sol
+++ b/solidity/contracts/interfaces/ITBTCSystem.sol
@@ -16,4 +16,10 @@ interface ITBTCSystem {
     function fetchRelayPreviousDifficulty() external view returns (uint256);
 
     function getInitialCollateralizedPercent() external view returns (uint128);
+    function getAllowNewDeposits() external view returns (bool);
+    function isAllowedLotSize(uint256 _lotSizeSatoshis) external view returns (bool);
+    function requestNewKeep(uint256 _m, uint256 _n, uint256 _bond) external payable returns (address);
+    function getSignerFeeDivisor() external view returns (uint256);
+    function getUndercollateralizedThresholdPercent() external view returns (uint128);
+    function getSeverelyUndercollateralizedThresholdPercent() external view returns (uint128);
 }

--- a/solidity/contracts/proxy/DepositFactory.sol
+++ b/solidity/contracts/proxy/DepositFactory.sol
@@ -24,7 +24,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     TBTCSystem public tbtcSystem;
     TBTCToken public tbtcToken;
     FeeRebateToken public feeRebateToken;
-    address public vendingMachine;
+    address public vendingMachineAddress;
     uint256 public keepThreshold;
     uint256 public keepSize;
 
@@ -38,7 +38,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     /// @param _tbtcToken             TBTC token contract.
     /// @param _tbtcDepositToken      TBTC Deposit Token contract.
     /// @param _feeRebateToken        AFee Rebate Token contract.
-    /// @param _vendingMachine        Address of the Vending Machine contract.
+    /// @param _vendingMachineAddress Address of the Vending Machine contract.
     /// @param _keepThreshold         Minimum number of honest keep members.
     /// @param _keepSize              Number of all members in a keep.
     function setExternalDependencies(
@@ -47,7 +47,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
         TBTCToken _tbtcToken,
         TBTCDepositToken _tbtcDepositToken,
         FeeRebateToken _feeRebateToken,
-        address _vendingMachine,
+        address _vendingMachineAddress,
         uint256 _keepThreshold,
         uint256 _keepSize
     ) public onlyTbtcSystem {
@@ -56,7 +56,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
         tbtcSystem = _tbtcSystem;
         tbtcToken = _tbtcToken;
         feeRebateToken = _feeRebateToken;
-        vendingMachine = _vendingMachine;
+        vendingMachineAddress = _vendingMachineAddress;
         keepThreshold = _keepThreshold;
         keepSize = _keepSize;
     }
@@ -81,7 +81,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
                 tbtcToken,
                 tbtcDepositToken,
                 feeRebateToken,
-                vendingMachine,
+                vendingMachineAddress,
                 keepThreshold,
                 keepSize,
                 _lotSizeSatoshis

--- a/solidity/contracts/proxy/DepositFactory.sol
+++ b/solidity/contracts/proxy/DepositFactory.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.5.10;
 import "./CloneFactory.sol";
 import "../deposit/Deposit.sol";
 import "../system/TBTCSystem.sol";
+import "../system/TBTCToken.sol";
+import "../system/FeeRebateToken.sol";
 import "../system/TBTCSystemAuthority.sol";
 import {TBTCDepositToken} from "../system/TBTCDepositToken.sol";
 
@@ -19,9 +21,9 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     // which will be used as a master contract for cloning.
     address payable public masterDepositAddress;
     TBTCDepositToken tbtcDepositToken;
-    address public tbtcSystem;
-    address public tbtcToken;
-    address public feeRebateToken;
+    TBTCSystem public tbtcSystem;
+    TBTCToken public tbtcToken;
+    FeeRebateToken public feeRebateToken;
     address public vendingMachine;
     uint256 public keepThreshold;
     uint256 public keepSize;
@@ -51,9 +53,9 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     ) public onlyTbtcSystem {
         masterDepositAddress = _masterDepositAddress;
         tbtcDepositToken = TBTCDepositToken(_tbtcDepositToken);
-        tbtcSystem = _tbtcSystem;
-        tbtcToken = _tbtcToken;
-        feeRebateToken = _feeRebateToken;
+        tbtcSystem = TBTCSystem(_tbtcSystem);
+        tbtcToken = TBTCToken(_tbtcToken);
+        feeRebateToken = FeeRebateToken(_feeRebateToken);
         vendingMachine = _vendingMachine;
         keepThreshold = _keepThreshold;
         keepSize = _keepSize;
@@ -77,7 +79,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
         deposit.createNewDeposit.value(msg.value)(
                 tbtcSystem,
                 tbtcToken,
-                address(tbtcDepositToken),
+                tbtcDepositToken,
                 feeRebateToken,
                 vendingMachine,
                 keepThreshold,

--- a/solidity/contracts/proxy/DepositFactory.sol
+++ b/solidity/contracts/proxy/DepositFactory.sol
@@ -18,9 +18,9 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     // Holds the address of the deposit contract
     // which will be used as a master contract for cloning.
     address payable public masterDepositAddress;
+    TBTCDepositToken tbtcDepositToken;
     address public tbtcSystem;
     address public tbtcToken;
-    address public tbtcDepositToken;
     address public feeRebateToken;
     address public vendingMachine;
     uint256 public keepThreshold;
@@ -34,7 +34,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     /// @param _masterDepositAddress  The address of the master deposit contract.
     /// @param _tbtcSystem            Address of system contract.
     /// @param _tbtcToken             Address of TBTC token contract.
-    /// @param _depositOwnerToken     Address of the Deposit Owner Token contract.
+    /// @param _tbtcDepositToken      Address of the TBTC Deposit Token contract.
     /// @param _feeRebateToken        Address of the Fee Rebate Token contract.
     /// @param _vendingMachine        Address of the Vending Machine contract.
     /// @param _keepThreshold         Minimum number of honest keep members.
@@ -43,16 +43,16 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
         address payable _masterDepositAddress,
         address _tbtcSystem,
         address _tbtcToken,
-        address _depositOwnerToken,
+        address _tbtcDepositToken,
         address _feeRebateToken,
         address _vendingMachine,
         uint256 _keepThreshold,
         uint256 _keepSize
     ) public onlyTbtcSystem {
         masterDepositAddress = _masterDepositAddress;
+        tbtcDepositToken = TBTCDepositToken(_tbtcDepositToken);
         tbtcSystem = _tbtcSystem;
         tbtcToken = _tbtcToken;
-        tbtcDepositToken = _depositOwnerToken;
         feeRebateToken = _feeRebateToken;
         vendingMachine = _vendingMachine;
         keepThreshold = _keepThreshold;
@@ -77,7 +77,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
         deposit.createNewDeposit.value(msg.value)(
                 tbtcSystem,
                 tbtcToken,
-                tbtcDepositToken,
+                address(tbtcDepositToken),
                 feeRebateToken,
                 vendingMachine,
                 keepThreshold,

--- a/solidity/contracts/proxy/DepositFactory.sol
+++ b/solidity/contracts/proxy/DepositFactory.sol
@@ -34,28 +34,28 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
 
     /// @dev                          Set the required external variables.
     /// @param _masterDepositAddress  The address of the master deposit contract.
-    /// @param _tbtcSystem            Address of system contract.
-    /// @param _tbtcToken             Address of TBTC token contract.
-    /// @param _tbtcDepositToken      Address of the TBTC Deposit Token contract.
-    /// @param _feeRebateToken        Address of the Fee Rebate Token contract.
+    /// @param _tbtcSystem            Tbtc system contract.
+    /// @param _tbtcToken             TBTC token contract.
+    /// @param _tbtcDepositToken      TBTC Deposit Token contract.
+    /// @param _feeRebateToken        AFee Rebate Token contract.
     /// @param _vendingMachine        Address of the Vending Machine contract.
     /// @param _keepThreshold         Minimum number of honest keep members.
     /// @param _keepSize              Number of all members in a keep.
     function setExternalDependencies(
         address payable _masterDepositAddress,
-        address _tbtcSystem,
-        address _tbtcToken,
-        address _tbtcDepositToken,
-        address _feeRebateToken,
+        TBTCSystem _tbtcSystem,
+        TBTCToken _tbtcToken,
+        TBTCDepositToken _tbtcDepositToken,
+        FeeRebateToken _feeRebateToken,
         address _vendingMachine,
         uint256 _keepThreshold,
         uint256 _keepSize
     ) public onlyTbtcSystem {
         masterDepositAddress = _masterDepositAddress;
-        tbtcDepositToken = TBTCDepositToken(_tbtcDepositToken);
-        tbtcSystem = TBTCSystem(_tbtcSystem);
-        tbtcToken = TBTCToken(_tbtcToken);
-        feeRebateToken = FeeRebateToken(_feeRebateToken);
+        tbtcDepositToken = _tbtcDepositToken;
+        tbtcSystem = _tbtcSystem;
+        tbtcToken = _tbtcToken;
+        feeRebateToken = _feeRebateToken;
         vendingMachine = _vendingMachine;
         keepThreshold = _keepThreshold;
         keepSize = _keepSize;

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -111,7 +111,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         );
         _depositFactory.setExternalDependencies(
             _masterDepositAddress,
-            TBTCSystem(address(this)),
+            this,
             _tbtcToken,
             _tbtcDepositToken,
             _feeRebateToken,

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -14,6 +14,8 @@ import {IBTCETHPriceFeed} from "../interfaces/IBTCETHPriceFeed.sol";
 import {DepositLog} from "../DepositLog.sol";
 
 import {TBTCDepositToken} from "./TBTCDepositToken.sol";
+import "./TBTCToken.sol";
+import "./FeeRebateToken.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
@@ -79,41 +81,41 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
 
     /// @notice        Initialize contracts
     /// @dev           Only the Deposit factory should call this, and only once.
-    /// @param _keepVendor        ECDSA keep vendor address.
-    /// @param _depositFactory    Deposit Factory address. More info in `DepositFactory`.
+    /// @param _keepVendor        ECDSA keep vendor.
+    /// @param _depositFactory    Deposit Factory. More info in `DepositFactory`.
     /// @param _masterDepositAddress  Master Deposit address. More info in `Deposit`.
-    /// @param _tbtcToken         TBTCToken address. More info in `TBTCToken`.
-    /// @param _tbtcDepositToken  TBTCDepositToken (TDT) address. More info in `TBTCDepositToken`.
-    /// @param _feeRebateToken    FeeRebateToken (FRT) address. More info in `FeeRebateToken`.
-    /// @param _vendingMachine    Vending Machine address. More info in `VendingMachine`.
+    /// @param _tbtcToken         TBTCToken. More info in `TBTCToken`.
+    /// @param _tbtcDepositToken  TBTCDepositToken (TDT). More info in `TBTCDepositToken`.
+    /// @param _feeRebateToken    FeeRebateToken (FRT). More info in `FeeRebateToken`.
+    /// @param _vendingMachine    Vending Machine. More info in `VendingMachine`.
     /// @param _keepThreshold     Signing group honesty threshold.
     /// @param _keepSize          Signing group size.
     function initialize(
-        address _keepVendor,
-        address _depositFactory,
+        IBondedECDSAKeepVendor _keepVendor,
+        DepositFactory _depositFactory,
         address payable _masterDepositAddress,
-        address _tbtcToken,
-        address _tbtcDepositToken,
-        address _feeRebateToken,
-        address _vendingMachine,
+        TBTCToken _tbtcToken,
+        TBTCDepositToken _tbtcDepositToken,
+        FeeRebateToken _feeRebateToken,
+        VendingMachine _vendingMachine,
         uint256 _keepThreshold,
         uint256 _keepSize
     ) external onlyOwner {
         require(!_initialized, "already initialized");
-        tbtcDepositToken = TBTCDepositToken(_tbtcDepositToken);
-        keepVendor = IBondedECDSAKeepVendor(_keepVendor);
-        VendingMachine(_vendingMachine).setExternalAddresses(
+        tbtcDepositToken = _tbtcDepositToken;
+        keepVendor = _keepVendor;
+        _vendingMachine.setExternalAddresses(
             _tbtcToken,
             _tbtcDepositToken,
             _feeRebateToken
         );
-        DepositFactory(_depositFactory).setExternalDependencies(
+        _depositFactory.setExternalDependencies(
             _masterDepositAddress,
-            address(this),
+            TBTCSystem(address(this)),
             _tbtcToken,
             _tbtcDepositToken,
             _feeRebateToken,
-            _vendingMachine,
+            address(_vendingMachine),
             _keepThreshold,
             _keepSize
         );

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -47,10 +47,10 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     uint256 pausedTimestamp;
     uint256 constant pausedDuration = 10 days;
 
-    TBTCDepositToken tbtcDepositToken;
-    IBTCETHPriceFeed priceFeed;
-    IBondedECDSAKeepVendor keepVendor;
-    IRelay relay;
+    TBTCDepositToken public tbtcDepositToken;
+    IBTCETHPriceFeed public  priceFeed;
+    IBondedECDSAKeepVendor public keepVendor;
+    IRelay public relay;
 
     // Parameters governed by the TBTCSystem owner
     bool private allowNewDeposits = false;

--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -27,17 +27,17 @@ contract VendingMachine is TBTCSystemAuthority{
 
     /// @notice Set external contracts needed by the Vending Machine.
     /// @dev    Addresses are used to update the local contract instance.
-    /// @param _tbtcToken        TBTCToken address. More info in `TBTCToken`.
-    /// @param _tbtcDepositToken TBTCDepositToken (TDT) address. More info in `TBTCDepositToken`.
-    /// @param _feeRebateToken   FeeRebateToken (FRT) address. More info in `FeeRebateToken`.
+    /// @param _tbtcToken        TBTCToken contract. More info in `TBTCToken`.
+    /// @param _tbtcDepositToken TBTCDepositToken (TDT) contract. More info in `TBTCDepositToken`.
+    /// @param _feeRebateToken   FeeRebateToken (FRT) contract. More info in `FeeRebateToken`.
     function setExternalAddresses(
-        address _tbtcToken,
-        address _tbtcDepositToken,
-        address _feeRebateToken
+        TBTCToken _tbtcToken,
+        TBTCDepositToken _tbtcDepositToken,
+        FeeRebateToken _feeRebateToken
     ) public onlyTbtcSystem {
-        tbtcToken = TBTCToken(_tbtcToken);
-        tbtcDepositToken = TBTCDepositToken(_tbtcDepositToken);
-        feeRebateToken = FeeRebateToken(_feeRebateToken);
+        tbtcToken = _tbtcToken;
+        tbtcDepositToken = _tbtcDepositToken;
+        feeRebateToken = _feeRebateToken;
     }
 
     /// @notice Determines whether a deposit is qualified for minting TBTC.

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -13,19 +13,19 @@ contract TestDeposit is Deposit {
     }
 
     function createNewDeposit(
-        address _TBTCSystem,
-        address _TBTCToken,
-        address _TBTCDepositToken,
-        address _FeeRebateToken,
+        ITBTCSystem _TBTCSystem,
+        TBTCToken _TBTCToken,
+        IERC721 _TBTCDepositToken,
+        FeeRebateToken _FeeRebateToken,
         address _VendingMachine,
         uint256 _m,
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public payable returns (bool) {
-        self.tbtcSystem = ITBTCSystem(_TBTCSystem);
-        self.tbtcToken = TBTCToken(_TBTCToken);
-        self.tbtcDepositToken = IERC721(_TBTCDepositToken);
-        self.feeRebateToken = FeeRebateToken(_FeeRebateToken);
+        self.tbtcSystem = (_TBTCSystem);
+        self.tbtcToken = (_TBTCToken);
+        self.tbtcDepositToken = (_TBTCDepositToken);
+        self.feeRebateToken = (_FeeRebateToken);
         self.VendingMachine = _VendingMachine;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -13,20 +13,20 @@ contract TestDeposit is Deposit {
     }
 
     function createNewDeposit(
-        ITBTCSystem _TBTCSystem,
-        TBTCToken _TBTCToken,
-        IERC721 _TBTCDepositToken,
-        FeeRebateToken _FeeRebateToken,
+        ITBTCSystem _tbtcSystem,
+        TBTCToken _tbtcToken,
+        IERC721 _tbtcDepositToken,
+        FeeRebateToken _feeRebateToken,
         address _vendingMachineAddress,
         uint256 _m,
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public payable returns (bool) {
-        self.tbtcSystem = (_TBTCSystem);
-        self.tbtcToken = (_TBTCToken);
-        self.tbtcDepositToken = (_TBTCDepositToken);
-        self.feeRebateToken = (_FeeRebateToken);
-        self.VendingMachineAddress = _vendingMachineAddress;
+        self.tbtcSystem = _tbtcSystem;
+        self.tbtcToken = _tbtcToken;
+        self.tbtcDepositToken = _tbtcDepositToken;
+        self.feeRebateToken = _feeRebateToken;
+        self.vendingMachineAddress = _vendingMachineAddress;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;
     }
@@ -42,7 +42,7 @@ contract TestDeposit is Deposit {
         self.tbtcToken = TBTCToken(_token);
         self.tbtcDepositToken = IERC721(_tbtcDepositToken);
         self.feeRebateToken = FeeRebateToken(_feeRebateToken);
-        self.VendingMachineAddress = _vendingMachineAddress;
+        self.vendingMachineAddress = _vendingMachineAddress;
     }
 
     function reset() public {

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -1,6 +1,10 @@
 pragma solidity ^0.5.10;
 
 import {Deposit} from "../../../contracts/deposit/Deposit.sol";
+import {ITBTCSystem} from "../../interfaces/ITBTCSystem.sol";
+import {IERC721} from "openzeppelin-solidity/contracts/token/ERC721/IERC721.sol";
+import {TBTCToken} from "../../system/TBTCToken.sol";
+import {FeeRebateToken} from "../../system/FeeRebateToken.sol";
 
 contract TestDeposit is Deposit {
 
@@ -18,10 +22,10 @@ contract TestDeposit is Deposit {
         uint256 _n,
         uint256 _lotSizeSatoshis
     ) public payable returns (bool) {
-        self.TBTCSystem = _TBTCSystem;
-        self.TBTCToken = _TBTCToken;
-        self.TBTCDepositToken = _TBTCDepositToken;
-        self.FeeRebateToken = _FeeRebateToken;
+        self.tbtcSystem = ITBTCSystem(_TBTCSystem);
+        self.tbtcToken = TBTCToken(_TBTCToken);
+        self.tbtcDepositToken = IERC721(_TBTCDepositToken);
+        self.feeRebateToken = FeeRebateToken(_FeeRebateToken);
         self.VendingMachine = _VendingMachine;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;
@@ -34,10 +38,10 @@ contract TestDeposit is Deposit {
         address _feeRebateToken,
         address _vendingMachine
     ) public {
-        self.TBTCSystem = _sys;
-        self.TBTCToken = _token;
-        self.TBTCDepositToken = _tbtcDepositToken;
-        self.FeeRebateToken = _feeRebateToken;
+        self.tbtcSystem = ITBTCSystem(_sys);
+        self.tbtcToken = TBTCToken(_token);
+        self.tbtcDepositToken = IERC721(_tbtcDepositToken);
+        self.feeRebateToken = FeeRebateToken(_feeRebateToken);
         self.VendingMachine = _vendingMachine;
     }
 

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -17,7 +17,7 @@ contract TestDeposit is Deposit {
         TBTCToken _TBTCToken,
         IERC721 _TBTCDepositToken,
         FeeRebateToken _FeeRebateToken,
-        address _VendingMachine,
+        address _vendingMachineAddress,
         uint256 _m,
         uint256 _n,
         uint256 _lotSizeSatoshis
@@ -26,7 +26,7 @@ contract TestDeposit is Deposit {
         self.tbtcToken = (_TBTCToken);
         self.tbtcDepositToken = (_TBTCDepositToken);
         self.feeRebateToken = (_FeeRebateToken);
-        self.VendingMachine = _VendingMachine;
+        self.VendingMachineAddress = _vendingMachineAddress;
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
         return true;
     }
@@ -36,13 +36,13 @@ contract TestDeposit is Deposit {
         address _token,
         address _tbtcDepositToken,
         address _feeRebateToken,
-        address _vendingMachine
+        address _vendingMachineAddress
     ) public {
         self.tbtcSystem = ITBTCSystem(_sys);
         self.tbtcToken = TBTCToken(_token);
         self.tbtcDepositToken = IERC721(_tbtcDepositToken);
         self.feeRebateToken = FeeRebateToken(_feeRebateToken);
-        self.VendingMachine = _vendingMachine;
+        self.VendingMachineAddress = _vendingMachineAddress;
     }
 
     function reset() public {

--- a/solidity/contracts/test/keep/ECDSAKeepStub.sol
+++ b/solidity/contracts/test/keep/ECDSAKeepStub.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.5.10;
 import {
     IBondedECDSAKeep
 } from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeep.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
 /// @notice Implementation of ECDSAKeep interface used in tests only
 /// @dev This is a stub used in tests, so we don't have to call actual ECDSAKeep
@@ -36,7 +35,7 @@ contract ECDSAKeepStub is IBondedECDSAKeep {
         // solium-disable-previous-line no-empty-blocks
     }
 
-    function distributeERC20Reward(IERC20 _asset, uint256 _value) external {
+    function distributeERC20Reward(address _asset, uint256 _value) external {
         // solium-disable-previous-line no-empty-blocks
     }
 

--- a/solidity/contracts/test/keep/ECDSAKeepStub.sol
+++ b/solidity/contracts/test/keep/ECDSAKeepStub.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.10;
 import {
     IBondedECDSAKeep
 } from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeep.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 
 /// @notice Implementation of ECDSAKeep interface used in tests only
 /// @dev This is a stub used in tests, so we don't have to call actual ECDSAKeep
@@ -35,7 +36,7 @@ contract ECDSAKeepStub is IBondedECDSAKeep {
         // solium-disable-previous-line no-empty-blocks
     }
 
-    function distributeERC20Reward(address _asset, uint256 _value) external {
+    function distributeERC20Reward(IERC20 _asset, uint256 _value) external {
         // solium-disable-previous-line no-empty-blocks
     }
 


### PR DESCRIPTION
closes: #507 

Rather than storing addresses and then casting to the known contract type, it’s better to use the best type available so the compiler can check for type safety.