### PR TITLE
Version Tether: Continuous packaging and versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,19 +15,6 @@ executors:
     docker:
       - image: thesisco/docker-buildpack:bionic
 jobs:
-  setup_github_package_registry:
-    executor: docker-node
-    steps:
-      - checkout
-      - run:
-          name: Authenticate GitHub Package Registry
-          working_directory: ~/project/solidity
-          command: echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> .npmrc
-      - persist_to_workspace:
-          root: .
-          paths:
-            - solidity/.npmrc
-
   compile_contracts:
     executor: docker-node
     steps:
@@ -232,31 +219,19 @@ workflows:
   version: 2
   lint:
     jobs:
-      - setup_github_package_registry:
-          context: github-package-registry
-      - compile_contracts:
-          requires:
-            - setup_github_package_registry
+      - compile_contracts
       - lint:
           requires:
             - compile_contracts
   test:
     jobs:
-      - setup_github_package_registry:
-          context: github-package-registry
-      - compile_contracts:
-          requires:
-            - setup_github_package_registry
+      - compile_contracts
       - unit_test_contracts:
           requires:
             - compile_contracts
   docs:
     jobs:
-      - setup_github_package_registry:
-          context: github-package-registry
-      - compile_contracts:
-          requires:
-            - setup_github_package_registry
+      - compile_contracts
       - generate_pngs
       - generate_docs_tex
       - generate_docs_solidity:
@@ -273,11 +248,7 @@ workflows:
             - generate_docs_asciidoctor
   migrate_build_publish_keep_dev:
     jobs:
-      - setup_github_package_registry:
-          context: github-package-registry
-      - compile_contracts:
-          requires:
-            - setup_github_package_registry
+      - compile_contracts
       - migrate_contracts:
           filters:
             branches:
@@ -301,13 +272,9 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - setup_github_package_registry:
-          context: github-package-registry
-          requires:
-            - keep_test_approval
       - compile_contracts:
           requires:
-            - setup_github_package_registry
+            - keep_test_approval
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,6 +198,50 @@ jobs:
           root: /tmp/tbtc
           paths:
             - contracts
+  publish_npm_package:
+    executor: docker-node
+    steps:
+      - attach_workspace:
+          at: /tmp/tbtc
+      - checkout
+      - run:
+          name: Bump and publish npm package
+          working_directory: ~/project/solidity
+          command: |
+            set -x
+            mkdir -p artifacts
+            cp -r /tmp/tbtc/contracts/* artifacts/
+            name=$(jq --raw-output .name package.json)
+            version=$(jq --raw-output .version package.json)
+            preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
+
+            # Find the latest published package version matching this preid.
+            # Note that in jq, we wrap the result in an array and then flatten;
+            # this is because npm show json contains a single string if there
+            # is only one matching version, or an array if there are multiple,
+            # and we want to look at an array always.
+            latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | sort | .[-1]")
+            latest_version=${latest_version:-$version}
+            if [ -z $latest_version ]; then
+              echo "Latest version calculation failed. Resolved info:"
+              echo "$name@$version ; preid $preid"
+              exit 1
+            fi
+
+            # Update package.json with the latest published package version matching this
+            # preid to prepare for bumping.
+            echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
+
+            # Bump without doing any git work. Versioning is a build-time action for us.
+            # Consider including commit id? Would be +<commit id>.
+            npm version prerelease --preid=$preid --no-git-tag-version
+
+            # Fix resolved dependency versions.
+            npm update
+
+            # Publish to npm.
+            echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+            npm publish --access=public
   publish_contract_data:
     executor: gcp-cli/default
     steps:
@@ -256,6 +300,13 @@ workflows:
           context: keep-dev
           requires:
             - compile_contracts
+      - publish_npm_package:
+          filters:
+            branches:
+              only: master
+          context: keep-dev
+          requires:
+            - migrate_contracts
       - publish_contract_data:
           filters:
             branches:
@@ -289,6 +340,15 @@ workflows:
           context: keep-test
           requires:
             - compile_contracts
+      - publish_npm_package:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          context: keep-test
+          requires:
+            - migrate_contracts
       - publish_contract_data:
           filters:
             tags:

--- a/solidity/.npmrc
+++ b/solidity/.npmrc
@@ -1,1 +1,0 @@
-@keep-network:registry=https://npm.pkg.github.com/keep-network

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.10.0-pre",
+  "version": "0.12.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,12 +33,13 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.9.2",
-      "resolved": "https://npm.pkg.github.com/download/@keep-network/keep-core/0.9.2/5359ca4c55a914c370ecc9bcaa8ebc0545e094ff2166f68e071f7064eb6dac5c",
-      "integrity": "sha512-4rB0vIrIXWE77ty1psofaWC+URM4fc9tTP7DVwGmr68TpvQxK0tEWe7E2CSiHEdv/VwQux/FtbTtZqrAnsVqAA==",
+      "version": "0.12.0-pre.4",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.12.0-pre.4.tgz",
+      "integrity": "sha512-UF5RsCB4HunM9B4YJ48PQVwqQHcuiogxXSU7hCOxH+xGhNhi01IJQohCvj+cWTojbTCd4eOcWxSSx5O5ixsMfg==",
       "requires": {
-        "openzeppelin-solidity": "2.4.0",
-        "solidity-bytes-utils": "0.0.7"
+        "@openzeppelin/contracts-ethereum-package": "^2.4.0",
+        "@openzeppelin/upgrades": "^2.7.2",
+        "openzeppelin-solidity": "2.4.0"
       },
       "dependencies": {
         "openzeppelin-solidity": {
@@ -49,11 +50,11 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.10.0-rc",
-      "resolved": "https://npm.pkg.github.com/download/@keep-network/keep-ecdsa/0.10.0-rc/3aa2339927bf2709cf0641e06b67081cb6fb541f7cde45cc6cc3340f8b47d51a",
-      "integrity": "sha512-8i2oBwoIaFrFXDg2s2Rm2Vtxz+7GebJbVLC42mY9U6TAhBnYoLdUF8eNy1W2Ti/EmOM/VFxr0GNSxJf9gc8XyA==",
+      "version": "0.12.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.12.0-pre.1.tgz",
+      "integrity": "sha512-O03Ky7nOf2q7hN/f9qb003bGgLrnvWYo9Yngp8xefL1lyR2WSIirhwSh+hA5QUUwc2n2Z64cbRj0u0hkY9TUsw==",
       "requires": {
-        "@keep-network/keep-core": "0.9.2",
+        "@keep-network/keep-core": ">0.12.0-pre <0.12.0-rc",
         "@keep-network/sortition-pools": "0.1.1",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
@@ -62,8 +63,8 @@
     },
     "@keep-network/sortition-pools": {
       "version": "0.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@keep-network/sortition-pools/0.1.1/e0792a48a6f8b67c38349a71b78c07c1b57ba5587a36d6ee4e51daecb34e49cc",
-      "integrity": "sha512-oDaDyryLZcTVljYNrVgUsFHsMBb+dDqSOIlQi25C4gR++vfSDOtIFxMg3yvgM1zg/EpXcGdTLqY20WNjBPDLAg==",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.1.1.tgz",
+      "integrity": "sha512-0A4N6wbtFfjWez7KwHEd2aMh6iB4kNaxI5fGDUCaCkeo2zP/FHOFcI9POIYLQ/17bL71EK/WxM5CnZJz4n/9vg==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0",
         "solidity-bytes-utils": "0.0.7"
@@ -155,6 +156,11 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.0.tgz",
       "integrity": "sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg=="
+    },
+    "@openzeppelin/contracts-ethereum-package": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
+      "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
     },
     "@openzeppelin/test-environment": {
       "version": "0.1.3",
@@ -979,9 +985,9 @@
       }
     },
     "@openzeppelin/upgrades": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades/-/upgrades-2.7.2.tgz",
-      "integrity": "sha512-RU63TpSLNRjoeC6M4IeaEA3lI8UP6DdWF5L+gru9uExU+A/OvrhfepHfNd5lFQtkCB77oQ2I1wauE75K5a/ysg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/upgrades/-/upgrades-2.8.0.tgz",
+      "integrity": "sha512-LzjTQPeljPsgHDPdZyH9cMCbIHZILgd2cpNcYEkdsC2IylBYRHShlbEDXJV9snnqg9JWfzPiKIqyj3XVliwtqQ==",
       "requires": {
         "@types/cbor": "^2.0.0",
         "axios": "^0.18.0",
@@ -990,27 +996,7 @@
         "chalk": "^2.4.1",
         "ethers": "^4.0.20",
         "glob": "^7.1.3",
-        "lodash.concat": "^4.5.0",
-        "lodash.difference": "^4.5.0",
-        "lodash.every": "^4.6.0",
-        "lodash.findlast": "^4.6.0",
-        "lodash.flatten": "^4.4.0",
-        "lodash.includes": "^4.3.0",
-        "lodash.invertby": "^4.7.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.isequal": "^4.5.0",
-        "lodash.isstring": "^4.0.1",
-        "lodash.keys": "^4.2.0",
-        "lodash.map": "^4.6.0",
-        "lodash.omit": "^4.5.0",
-        "lodash.pick": "^4.4.0",
-        "lodash.pickby": "^4.6.0",
-        "lodash.random": "^3.2.0",
-        "lodash.reverse": "^4.0.1",
-        "lodash.some": "^4.6.0",
-        "lodash.uniq": "^4.5.0",
-        "lodash.values": "^4.3.0",
-        "lodash.without": "^4.4.0",
+        "lodash": "^4.17.15",
         "semver": "^5.5.1",
         "spinnies": "^0.4.2",
         "truffle-flattener": "^1.4.0",
@@ -1021,9 +1007,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.30",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-          "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
+          "version": "12.12.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
+          "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g=="
         },
         "bignumber.js": {
           "version": "7.2.1",
@@ -6668,12 +6654,11 @@
       }
     },
     "find-up": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "requires": {
-        "path-exists": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat": {
@@ -23644,116 +23629,17 @@
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
-    "lodash.concat": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.concat/-/lodash.concat-4.5.0.tgz",
-      "integrity": "sha1-sFOuAuSoAIWC5yVrnQK9ptA4A5U="
-    },
-    "lodash.difference": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
-    },
-    "lodash.every": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
-      "integrity": "sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc="
-    },
-    "lodash.findlast": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.findlast/-/lodash.findlast-4.6.0.tgz",
-      "integrity": "sha1-6ou3jPLn54BPyK630ZU+B/4x+8g="
-    },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.invertby": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.invertby/-/lodash.invertby-4.7.0.tgz",
-      "integrity": "sha1-zeu2zUlCqmuN8sdL4cXZSGgnGLA="
-    },
-    "lodash.isempty": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "lodash.keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz",
-      "integrity": "sha1-oIYCrBLk+4P5H8H7ejYKTZujUgU="
-    },
-    "lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
-    },
-    "lodash.omit": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
-      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
-    },
-    "lodash.pick": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
-    },
-    "lodash.pickby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
-    },
-    "lodash.random": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.random/-/lodash.random-3.2.0.tgz",
-      "integrity": "sha1-luJOdjMzGZEw0sni/Vf5FwPMJi0="
-    },
-    "lodash.reverse": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.reverse/-/lodash.reverse-4.0.1.tgz",
-      "integrity": "sha1-Hyr+2s4uFuZg86p8WdMwCm8l0Tw="
-    },
-    "lodash.some": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
-      "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0="
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
-    },
-    "lodash.values": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
-    },
-    "lodash.without": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
     "log-symbols": {
       "version": "3.0.0",
@@ -25415,6 +25301,17 @@
       "requires": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "requires": {
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        }
       }
     },
     "readable-stream": {
@@ -27404,6 +27301,21 @@
           "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
           "dev": true
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
         "mocha": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
@@ -27419,6 +27331,7 @@
             "growl": "1.10.5",
             "he": "1.1.1",
             "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
             "supports-color": "5.4.0"
           }
         },
@@ -27445,25 +27358,12 @@
         "tsort": "0.0.1"
       },
       "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+          "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         }
       }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.10.0-pre",
+  "version": "0.12.0-pre",
   "description": "deposit contract for TBTC",
   "main": "index.js",
+  "files": [
+    "contracts/**/*.sol",
+    "artifacts/"
+  ],
   "scripts": {
     "clean": "rm -rf build/",
     "compile": "truffle compile",
@@ -23,7 +27,7 @@
   "author": "Satoshi Nakamoto 🤪",
   "license": "MIT",
   "dependencies": {
-    "@keep-network/keep-ecdsa": "0.10.0-rc",
+    "@keep-network/keep-ecdsa": ">0.12.0-pre <0.12.0-rc",
     "@summa-tx/bitcoin-spv-sol": "^2.2.0",
     "@summa-tx/relay-sol": "^1.1.0",
     "@truffle/hdwallet-provider": "^1.0.26",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@keep-network/tbtc",
   "version": "0.12.0-pre",
-  "description": "deposit contract for TBTC",
-  "main": "index.js",
+  "description": "The tBTC smart contracts implementing the TBTC trustlessly Bitcoin-backed ERC-20 token.",
+  "repository": {
+    "type": "git",
+    "url": "ssh://git@github.com/keep-network/tbtc.git"
+  },
   "files": [
     "contracts/**/*.sol",
     "artifacts/"
@@ -26,6 +29,10 @@
   "precommit": "npm run lint",
   "author": "Satoshi Nakamoto 🤪",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/keep-network/tbtc/issues"
+  },
+  "homepage": "https://tbtc.network/",
   "dependencies": {
     "@keep-network/keep-ecdsa": ">0.12.0-pre <0.12.0-rc",
     "@summa-tx/bitcoin-spv-sol": "^2.2.0",

--- a/solidity/scripts/circleci-migrate-contracts.sh
+++ b/solidity/scripts/circleci-migrate-contracts.sh
@@ -57,8 +57,13 @@ ssh utilitybox << EOF
   ./node_modules/.bin/truffle migrate --reset --network $TRUFFLE_NETWORK
   echo ">>>>>>FINISH Contract Migration FINISH>>>>>>"
   echo "<<<<<<START Tenderly Push START<<<<<<"
+  # Temporary fix for some odd push issues; OpenZeppelin contracts are
+  # referenced at two paths due to older dependencies, leading to problems
+  # resolving contracts during tenderly push.
+  ln -s node_modules/@openzeppelin @openzeppelin
   tenderly login --authentication-method token --token $TENDERLY_TOKEN
-  tenderly push --networks $ETH_NETWORK_ID --tag tbtc --tag $GOOGLE_PROJECT_NAME --tag $BUILD_TAG
+  tenderly push --networks $ETH_NETWORK_ID --tag tbtc \
+    --tag $GOOGLE_PROJECT_NAME --tag $BUILD_TAG || echo "tendery push failed :("
   echo "<<<<<<FINISH Tenderly Push FINISH<<<<<<"
 EOF
 


### PR DESCRIPTION
This PR picks up the work in keep-core and keep-ecdsa to publish new,
artifacts-included npm packages on contract migration. It adds the same
functionality to tbtc, and additionally updates the version string referencing
keep-ecdsa to properly integrate with keep-ecdsa's versioning.

The major changes are as in keep-ecdsa:
- `package.json` for Solidity contracts is set to `<version>-pre`, with no
  numeric suffix.
- A new Circle job, `publish_npm_package`, runs on master merge. This
  job updates the package version to `-pre.<number>`, where `<number>`
  represents a new, unpublished version.
- Contract artifacts from the contract migration are copied to an `artifacts/`
  subdirectory and included in the package.
- The package is published to the main npm repository (not the GitHub
  package repository).