### PR TITLE
Bump bitcoin-spv version to 3.0.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1096,9 +1096,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@summa-tx/bitcoin-spv-sol": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-2.2.0.tgz",
-      "integrity": "sha512-HSfxfNldNS4pvZUjLLYqw/wgVrxmIzp67WoRVTxY5SEV7TbOBcn8aYlPCnyLSUX6TeHjMVjAv3inDoIq0zwfCQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-3.0.0.tgz",
+      "integrity": "sha512-zyY0o1i5wGdaM8yK6JYlaUzNmZSdsGipXeEQpM7bNDW5d9/CzVOvbP1pOT97wOok2QYJG6f4oU8vf18OWzxkgQ=="
     },
     "@summa-tx/relay-sol": {
       "version": "1.1.0",
@@ -1107,6 +1107,13 @@
       "requires": {
         "@summa-tx/bitcoin-spv-sol": "^2.1.0",
         "dotenv": "^8.1.0"
+      },
+      "dependencies": {
+        "@summa-tx/bitcoin-spv-sol": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@summa-tx/bitcoin-spv-sol/-/bitcoin-spv-sol-2.2.0.tgz",
+          "integrity": "sha512-HSfxfNldNS4pvZUjLLYqw/wgVrxmIzp67WoRVTxY5SEV7TbOBcn8aYlPCnyLSUX6TeHjMVjAv3inDoIq0zwfCQ=="
+        }
       }
     },
     "@szmarczak/http-timer": {
@@ -27404,6 +27411,21 @@
           "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
           "dev": true
         },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
         "mocha": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
@@ -27419,6 +27441,7 @@
             "growl": "1.10.5",
             "he": "1.1.1",
             "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
             "supports-color": "5.4.0"
           }
         },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@keep-network/keep-ecdsa": "0.10.0-rc",
-    "@summa-tx/bitcoin-spv-sol": "^2.2.0",
+    "@summa-tx/bitcoin-spv-sol": "^3.0.0",
     "@summa-tx/relay-sol": "^1.1.0",
     "@truffle/hdwallet-provider": "^1.0.26",
     "bn-chai": "^1.0.1",


### PR DESCRIPTION
Bitcoin-spv 3.0.0 introduces bugfixes and optimizations.  Use the better version.