### PR TITLE
Update default value transfer method

### DIFF
--- a/solidity/.soliumrc.json
+++ b/solidity/.soliumrc.json
@@ -5,6 +5,7 @@
     ],
     "rules": {
         "security/no-block-members": "off",
-        "security/no-inline-assembly": "off"
+        "security/no-inline-assembly": "off",
+        "security/no-call-value": "off"
     }
 }

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -82,7 +82,7 @@ library DepositFunding {
     /// @dev        This is only called as part of funding fraud flow.
     function distributeSignerBondsToFunder(DepositUtils.Deposit storage _d) internal {
         uint256 _seized = _d.seizeSignerBonds();
-        _d.depositOwner().transfer(_seized);  // Transfer whole amount
+        _d.depositOwner().call.value(_seized)("");  // Transfer whole amount
     }
 
     /// @notice     Anyone may notify the contract that signing group setup has timed out.
@@ -97,12 +97,12 @@ library DepositFunding {
         // refund the deposit owner the cost to create a new Deposit at the time the Deposit was opened.
         uint256 _seized = _d.seizeSignerBonds();
 
-        /* solium-disable-next-line security/no-send */
-        _d.depositOwner().send(_d.keepSetupFee);
-        _d.pushFundsToKeepGroup(_seized.sub(_d.keepSetupFee));
-
         _d.setFailedSetup();
         _d.logSetupFailed();
+
+        /* solium-disable-next-line security/no-send */
+        _d.depositOwner().call.value(_d.keepSetupFee)("");
+        _d.pushFundsToKeepGroup(_seized.sub(_d.keepSetupFee));
 
         fundingTeardown(_d);
     }

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -99,12 +99,11 @@ library DepositFunding {
 
         _d.setFailedSetup();
         _d.logSetupFailed();
+        fundingTeardown(_d);
 
         /* solium-disable-next-line security/no-send */
         _d.depositOwner().call.value(_d.keepSetupFee)("");
         _d.pushFundsToKeepGroup(_seized.sub(_d.keepSetupFee));
-
-        fundingTeardown(_d);
     }
 
     /// @notice             we poll the Keep contract to retrieve our pubkey.

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -74,7 +74,7 @@ library DepositLiquidation {
         if (_d.auctionTBTCAmount() == 0) {
             // we came from the redemption flow
             _d.setLiquidated();
-            _d.redeemerAddress.transfer(_seized);
+            _d.redeemerAddress.call.value(_seized)("");
             _d.logLiquidated();
             return;
         }
@@ -180,7 +180,7 @@ library DepositLiquidation {
 
         // Distribute funds to auction buyer
         uint256 _valueToDistribute = _d.auctionValue();
-        msg.sender.transfer(_valueToDistribute);
+        msg.sender.call.value(_valueToDistribute)("");
 
         // Send any TBTC left to the Fee Rebate Token holder
         _d.distributeFeeRebate();
@@ -198,13 +198,13 @@ library DepositLiquidation {
         if (contractEthBalance > 1) {
             if (_wasFraud) {
                 /* solium-disable-next-line security/no-send */
-                initiator.send(contractEthBalance);
+                initiator.call.value(contractEthBalance)("");
             } else {
                 // There will always be a liquidation initiator.
                 uint256 split = contractEthBalance.div(2);
                 _d.pushFundsToKeepGroup(split);
                 /* solium-disable-next-line security/no-send */
-                initiator.send(address(this).balance);
+                initiator.call.value(address(this).balance)("");
             }
         }
     }


### PR DESCRIPTION
`.call.value()` should not revert in case of failure, but there is also no directly enforced gas limit.
It is important to ensure against reentrance for all value-handling functions.

- `send` also does not revert in case of failure, and there is an enforced gas limit that should limit reentrancy vectors, but it is not entirely reentrancy-secure due to the proven non-constant nature of op-code gas costs. Therefore instead of relying on `send` to restrict reentrancy, we explicitly ensure our contract is non-reentrant and allow a user's fallback to perform calculations beyond `send`'s limit since there is arguable no reason to enforce the gas limit. 