### PR TITLE
Pass stake lock duration to BondedECDSAKeepFactory

### DIFF
--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -65,7 +65,13 @@ library DepositFunding {
 
         _d.keepSetupFee = _d.tbtcSystem.createNewDepositFeeEstimate();
         /* solium-disable-next-line value-in-payable */
-        _d.keepAddress = _d.tbtcSystem.requestNewKeep.value(msg.value)(_m, _n, _bondRequirementWei);
+        _d.keepAddress = _d.tbtcSystem.requestNewKeep.value(msg.value)(
+            _m,
+            _n,
+            _bondRequirementWei,
+            TBTCConstants.getDepositTerm()
+        );
+
         _d.signerFeeDivisor = _d.tbtcSystem.getSignerFeeDivisor();
         _d.undercollateralizedThresholdPercent = _d.tbtcSystem.getUndercollateralizedThresholdPercent();
         _d.severelyUndercollateralizedThresholdPercent = _d.tbtcSystem.getSeverelyUndercollateralizedThresholdPercent();

--- a/solidity/contracts/interfaces/ITBTCSystem.sol
+++ b/solidity/contracts/interfaces/ITBTCSystem.sol
@@ -17,7 +17,7 @@ interface ITBTCSystem {
     function createNewDepositFeeEstimate() external view returns (uint256);
     function getAllowNewDeposits() external view returns (bool);
     function isAllowedLotSize(uint64 _lotSizeSatoshis) external view returns (bool);
-    function requestNewKeep(uint256 _m, uint256 _n, uint256 _bond) external payable returns (address);
+    function requestNewKeep(uint256 _m, uint256 _n, uint256 _bond, uint256 _stakeLockDuration) external payable returns (address);
     function getSignerFeeDivisor() external view returns (uint16);
     function getInitialCollateralizedPercent() external view returns (uint16);
     function getUndercollateralizedThresholdPercent() external view returns (uint16);

--- a/solidity/contracts/interfaces/ITBTCSystem.sol
+++ b/solidity/contracts/interfaces/ITBTCSystem.sol
@@ -17,7 +17,7 @@ interface ITBTCSystem {
     function createNewDepositFeeEstimate() external view returns (uint256);
     function getAllowNewDeposits() external view returns (bool);
     function isAllowedLotSize(uint64 _lotSizeSatoshis) external view returns (bool);
-    function requestNewKeep(uint256 _m, uint256 _n, uint256 _bond, uint256 _stakeLockDuration) external payable returns (address);
+    function requestNewKeep(uint256 _m, uint256 _n, uint256 _bond, uint256 _maxSecuredLifetime) external payable returns (address);
     function getSignerFeeDivisor() external view returns (uint16);
     function getInitialCollateralizedPercent() external view returns (uint16);
     function getUndercollateralizedThresholdPercent() external view returns (uint16);

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -393,13 +393,13 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @notice Request a new keep opening.
     /// @param _m Minimum number of honest keep members required to sign.
     /// @param _n Number of members in the keep.
-    /// @param _stakeLockDuration Duration of stake lock in seconds.
+    /// @param _maxSecuredLifetime Duration of stake lock in seconds.
     /// @return Address of a new keep.
     function requestNewKeep(
         uint256 _m,
         uint256 _n,
         uint256 _bond,
-        uint256 _stakeLockDuration
+        uint256 _maxSecuredLifetime
     )
         external
         payable
@@ -407,6 +407,6 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     {
         require(tbtcDepositToken.exists(uint256(msg.sender)), "Caller must be a Deposit contract");
         IBondedECDSAKeepFactory _keepFactory = IBondedECDSAKeepFactory(keepVendor.selectFactory());
-        return _keepFactory.openKeep.value(msg.value)(_n, _m, msg.sender, _bond, _stakeLockDuration);
+        return _keepFactory.openKeep.value(msg.value)(_n, _m, msg.sender, _bond, _maxSecuredLifetime);
     }
 }

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -393,14 +393,20 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @notice Request a new keep opening.
     /// @param _m Minimum number of honest keep members required to sign.
     /// @param _n Number of members in the keep.
+    /// @param _stakeLockDuration Duration of stake lock in seconds.
     /// @return Address of a new keep.
-    function requestNewKeep(uint256 _m, uint256 _n, uint256 _bond)
+    function requestNewKeep(
+        uint256 _m,
+        uint256 _n,
+        uint256 _bond,
+        uint256 _stakeLockDuration
+    )
         external
         payable
         returns (address)
     {
         require(tbtcDepositToken.exists(uint256(msg.sender)), "Caller must be a Deposit contract");
         IBondedECDSAKeepFactory _keepFactory = IBondedECDSAKeepFactory(keepVendor.selectFactory());
-        return _keepFactory.openKeep.value(msg.value)(_n, _m, msg.sender, _bond);
+        return _keepFactory.openKeep.value(msg.value)(_n, _m, msg.sender, _bond, _stakeLockDuration);
     }
 }

--- a/solidity/contracts/test/deposit/TBTCSystemStub.sol
+++ b/solidity/contracts/test/deposit/TBTCSystemStub.sol
@@ -23,7 +23,7 @@ contract TBTCSystemStub is TBTCSystem {
         return oraclePrice;
     }
 
-    function requestNewKeep(uint256, uint256, uint256) external payable returns (address _keepAddress) {
+    function requestNewKeep(uint256, uint256, uint256, uint256) external payable returns (address _keepAddress) {
         return keepAddress;
     }
 }

--- a/solidity/contracts/test/keep/ECDSAKeepFactoryStub.sol
+++ b/solidity/contracts/test/keep/ECDSAKeepFactoryStub.sol
@@ -5,16 +5,19 @@ import {IBondedECDSAKeepFactory} from "@keep-network/keep-ecdsa/contracts/api/IB
 contract ECDSAKeepFactoryStub is IBondedECDSAKeepFactory {
     address public keepOwner;
     address public keepAddress = address(888);
+    uint256 public stakeLockDuration;
     uint256 feeEstimate = 123456;
 
     function openKeep(
         uint256,
         uint256,
         address _owner,
-        uint256
+        uint256,
+        uint256 _stakeLockDuration
     ) external payable returns (address) {
         require(msg.value >= feeEstimate, "Insufficient value for new keep creation");
         keepOwner = _owner;
+        stakeLockDuration = _stakeLockDuration;
         return keepAddress;
     }
 
@@ -25,5 +28,4 @@ contract ECDSAKeepFactoryStub is IBondedECDSAKeepFactory {
     function setOpenKeepFeeEstimate(uint256 _fee) external {
         feeEstimate = _fee;
     }
-
 }

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -33,9 +33,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.0.tgz",
-      "integrity": "sha512-VDmCmecn527GSg3wlKx918Mni8nF4t2LfVOa1X3WnFVUROwx1FI3cZcZyrij+oSz0lDDyrY4wFdpxO8oWPl+sA==",
+      "version": "0.13.0-pre.9",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.9.tgz",
+      "integrity": "sha512-I8MsomNf8o5fhc02O6TkThpXnEkbHSjAgHPsL42k4EJbVkOfrxBLHDAc04Rg8LeNsFygpifmncoV6jtbiQwxbA==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -50,9 +50,9 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.13.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.13.0-pre.0.tgz",
-      "integrity": "sha512-f1LQhgF0Jhz5/CxvM0q8O6bwSbAErbn5O++hHg4FLoxwZfzbT2ttnWhpBs5cddv1EaE/Uy2t9MI3cCKNO9WRgQ==",
+      "version": "0.13.0-pre.10",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.13.0-pre.10.tgz",
+      "integrity": "sha512-Jry458+wwUgq47RM9KwKjdYvWp0gTf/f7aq45FnX28d4gqSs1R84C88Q84X4oBl29bnd+RoN8y7CduAA9ClYhg==",
       "requires": {
         "@keep-network/keep-core": ">0.13.0-pre <0.13.0-rc",
         "@keep-network/sortition-pools": "0.1.1",

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -124,6 +124,12 @@ describe("DepositFunding", async function() {
         expectedKeepAddress,
       )
 
+      const stakeLockDuration = await ecdsaKeepFactory.stakeLockDuration.call()
+      expect(
+        stakeLockDuration,
+        "stake lock duration not as expected",
+      ).not.to.eq.BN(await tbtcConstants.getDepositTerm.call())
+
       const signingGroupRequestedAt = await testDeposit.getSigningGroupRequestedAt.call()
       expect(
         signingGroupRequestedAt,

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -33,6 +33,7 @@ describe("TBTCSystem", async function() {
     let openKeepFee
     const tdtOwner = accounts[1]
     const keepOwner = accounts[2]
+    const tokenStakeDuration = 123
 
     before(async () => {
       openKeepFee = await ecdsaKeepFactory.openKeepFeeEstimate.call()
@@ -40,7 +41,7 @@ describe("TBTCSystem", async function() {
     })
 
     it("sends caller as owner to open new keep", async () => {
-      await tbtcSystem.requestNewKeep(5, 10, 0, {
+      await tbtcSystem.requestNewKeep(5, 10, 0, tokenStakeDuration, {
         from: keepOwner,
         value: openKeepFee,
       })
@@ -54,10 +55,16 @@ describe("TBTCSystem", async function() {
     it("returns keep address", async () => {
       const expectedKeepAddress = await ecdsaKeepFactory.keepAddress.call()
 
-      const result = await tbtcSystem.requestNewKeep.call(5, 10, 0, {
-        value: openKeepFee,
-        from: keepOwner,
-      })
+      const result = await tbtcSystem.requestNewKeep.call(
+        5,
+        10,
+        0,
+        tokenStakeDuration,
+        {
+          value: openKeepFee,
+          from: keepOwner,
+        },
+      )
 
       expect(expectedKeepAddress, "incorrect keep address").to.equal(result)
     })
@@ -65,7 +72,7 @@ describe("TBTCSystem", async function() {
     it("forwards value to keep factory", async () => {
       const initialBalance = await web3.eth.getBalance(ecdsaKeepFactory.address)
 
-      await tbtcSystem.requestNewKeep(5, 10, 0, {
+      await tbtcSystem.requestNewKeep(5, 10, 0, tokenStakeDuration, {
         value: openKeepFee,
         from: keepOwner,
       })
@@ -80,7 +87,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller does not match a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(5, 10, 0, {
+        tbtcSystem.requestNewKeep(5, 10, 0, tokenStakeDuration, {
           value: openKeepFee,
           from: accounts[0],
         }),
@@ -90,7 +97,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller is the owner of a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(5, 10, 0, {
+        tbtcSystem.requestNewKeep(5, 10, 0, tokenStakeDuration, {
           value: openKeepFee,
           from: tdtOwner,
         }),

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -33,7 +33,7 @@ describe("TBTCSystem", async function() {
     let openKeepFee
     const tdtOwner = accounts[1]
     const keepOwner = accounts[2]
-    const tokenStakeDuration = 123
+    const maxSecuredLifetime = 123
 
     before(async () => {
       openKeepFee = await ecdsaKeepFactory.openKeepFeeEstimate.call()
@@ -41,7 +41,7 @@ describe("TBTCSystem", async function() {
     })
 
     it("sends caller as owner to open new keep", async () => {
-      await tbtcSystem.requestNewKeep(5, 10, 0, tokenStakeDuration, {
+      await tbtcSystem.requestNewKeep(5, 10, 0, maxSecuredLifetime, {
         from: keepOwner,
         value: openKeepFee,
       })
@@ -59,7 +59,7 @@ describe("TBTCSystem", async function() {
         5,
         10,
         0,
-        tokenStakeDuration,
+        maxSecuredLifetime,
         {
           value: openKeepFee,
           from: keepOwner,
@@ -72,7 +72,7 @@ describe("TBTCSystem", async function() {
     it("forwards value to keep factory", async () => {
       const initialBalance = await web3.eth.getBalance(ecdsaKeepFactory.address)
 
-      await tbtcSystem.requestNewKeep(5, 10, 0, tokenStakeDuration, {
+      await tbtcSystem.requestNewKeep(5, 10, 0, maxSecuredLifetime, {
         value: openKeepFee,
         from: keepOwner,
       })
@@ -87,7 +87,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller does not match a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(5, 10, 0, tokenStakeDuration, {
+        tbtcSystem.requestNewKeep(5, 10, 0, maxSecuredLifetime, {
           value: openKeepFee,
           from: accounts[0],
         }),
@@ -97,7 +97,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller is the owner of a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(5, 10, 0, tokenStakeDuration, {
+        tbtcSystem.requestNewKeep(5, 10, 0, maxSecuredLifetime, {
           value: openKeepFee,
           from: tdtOwner,
         }),


### PR DESCRIPTION
BondedECDSAKeepFactory factory requires a stake lock duration for opening a new keep. The value is used to lock signer KEEP token stakes for the period of the keep activity. It is a protection against staked token being undelegated before the keep is closed.

In this PR we update deposit funding to pass a deposit term as the value for the stake lock duration.

This PR is a draft until https://github.com/keep-network/keep-ecdsa/issues/360 is closed. We will need to update a dependency lock to the new version of keep-ecdsa.

Refs: https://github.com/keep-network/keep-ecdsa/issues/360