### PR TITLE
CI-lons: Fix issue with package-lock and solc 0.5.17, try to ensure it doesn't happen again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
             - v1-client-npm-deps-{{ .Branch }}-{{ checksum "solidity/package-lock.json" }}
             - v1-client-npm-deps-{{ .Branch }}-
             - v1-client-npm-deps-
-      - run: cd solidity && npm install
+      - run: cd solidity && npm ci
       - save_cache:
           key: v1-client-npm-deps-{{ .Branch }}-{{ checksum "solidity/package-lock.json" }}
           paths:

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -26580,7 +26580,7 @@
     "solc": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.17.tgz",
-      "integrity": "sha512-uI+7XtBu/0CXRc8IMjzxbh0haLwaBF32VxAkkks06zEk+mVcsQbHdjvojXX6zQYtZVuXdVYPVccoIjEhvvqKnQ==",
+      "integrity": "sha512-qpX+PGaU0Q3c6lh2vDzMoIbhv6bIrecI4bYsx+xUs01xsGFnY6Nr0L8y/QMyutTnrHN6Lb/Yl672ZVRqxka96w==",
       "dev": true,
       "requires": {
         "command-exists": "^1.2.8",


### PR DESCRIPTION
We were using `npm install`, which failed to catch an issue with the PR
that moved us to solc 0.5.17 (#565) where the lockfile had an incorrect
SHA hash for the new version (likely due to an aggressive find/replace on
my part). This PR both fixes the lockfile hash and moves the build to use
`npm ci`, which will solely reference the lockfile and blow up if things
aren't properly aligned.