### PR TITLE
Migration Resiliency: Try to fix migration non-timeout timeouts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,22 +31,21 @@ https://discord.gg/4R6RGFf[Discord].
 
 == Installation
 
-tBTC contracts are currently published in the GitHub Package Registry.
+tBTC contracts are currently published in the NPM Registry as the package
+[`@keep-network/tbtc`](https://www.npmjs.com/package/@keep-network/tbtc).
+Packages have versions corresponding to their network:
 
-1.  Add a file `.npmrc` to the same directory as your project's
-`package.json`.
-2.  Paste the following to configure the GitHub Package Registry for
-tBTC:
-+
-....
-@keep-network:registry=https://npm.pkg.github.com/keep-network
-....
-3.  Install the package:
-+
-[source,sh]
-----
+- `-pre` packages contain prerelease packages for the internal Keep testnet.
+- `-rc` packages contain prerelease packages for the Ropsten Ethereum testnet.
+
+Note that only the latest package in a series is expected to reference
+contracts that have a backing set of signers.
+
+To install the package:
+
+```sh
 $ npm install @keep-network/tbtc
-----
+```
 
 == Usage
 

--- a/README.adoc
+++ b/README.adoc
@@ -49,7 +49,7 @@ $ npm install @keep-network/tbtc
 
 == Usage
 
-*NOTE:* tBTC contracts require _solc_ v0.5.10 or higher. You may have to
+*NOTE:* tBTC contracts require _solc_ v0.5.17 or higher. You may have to
 https://www.trufflesuite.com/docs/truffle/reference/configuration#compiler-configuration[configure
 solc in your `truffle-config.js`].
 
@@ -58,7 +58,7 @@ them:
 
 [source,sol]
 ----
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.17;
 
 import "@keep-network/tbtc/contracts/deposit/Deposit.sol";
 

--- a/solidity/scripts/circleci-migrate-contracts.sh
+++ b/solidity/scripts/circleci-migrate-contracts.sh
@@ -65,6 +65,10 @@ ssh utilitybox << EOF
   tenderly push --networks $ETH_NETWORK_ID --tag tbtc \
     --tag $GOOGLE_PROJECT_NAME --tag $BUILD_TAG || echo "tendery push failed :("
   echo "<<<<<<FINISH Tenderly Push FINISH<<<<<<"
+
+  # Explicitly exit, in case something a backgrounded job is trying to keep this
+  # process running.
+  exit 0
 EOF
 
 echo "<<<<<<START Contract Copy START<<<<<<"


### PR DESCRIPTION
Also dropped a couple of doc updates in. The main fix here is an explicit `exit 0`
at the end of the utility script that runs contract migrations. The hope is that this
will let the build finish normally in some edge cases we're seeing where migrations
complete but the actual build job doesn't, leading to a Circle timeout and build
failure.