### PR TITLE
Use a pull model to withdraw deposit ETH balances

### DIFF
--- a/solidity/.soliumrc.json
+++ b/solidity/.soliumrc.json
@@ -5,6 +5,7 @@
     ],
     "rules": {
         "security/no-block-members": "off",
-        "security/no-inline-assembly": "off"
+        "security/no-inline-assembly": "off",
+        "security/no-call-value": "off"
     }
 }

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -402,4 +402,11 @@ contract Deposit is DepositFactoryAuthority {
         self.notifyCourtesyTimeout();
         return true;
     }
+
+    /// @notice     Pull any funds owed to msg.sender after contract has reached an end-state.
+    /// @return     True if successful, otherwise revert.
+    function withdrawFunds() public returns (bool) {
+        self.withdrawFunds();
+        return true;
+    }
 }

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -82,7 +82,7 @@ library DepositFunding {
     /// @dev        This is only called as part of funding fraud flow.
     function distributeSignerBondsToFunder(DepositUtils.Deposit storage _d) internal {
         uint256 _seized = _d.seizeSignerBonds();
-        _d.depositOwner().transfer(_seized);  // Transfer whole amount
+        _d.depositOwner().call.value(_seized)("");  // Transfer whole amount
     }
 
     /// @notice     Anyone may notify the contract that signing group setup has timed out.
@@ -97,12 +97,12 @@ library DepositFunding {
         // refund the deposit owner the cost to create a new Deposit at the time the Deposit was opened.
         uint256 _seized = _d.seizeSignerBonds();
 
-        /* solium-disable-next-line security/no-send */
-        _d.depositOwner().send(_d.keepSetupFee);
-        _d.pushFundsToKeepGroup(_seized.sub(_d.keepSetupFee));
-
         _d.setFailedSetup();
         _d.logSetupFailed();
+
+        /* solium-disable-next-line security/no-send */
+        _d.depositOwner().call.value(_d.keepSetupFee)("");
+        _d.pushFundsToKeepGroup(_seized.sub(_d.keepSetupFee));
 
         fundingTeardown(_d);
     }

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -99,12 +99,11 @@ library DepositFunding {
 
         _d.setFailedSetup();
         _d.logSetupFailed();
+        fundingTeardown(_d);
 
         /* solium-disable-next-line security/no-send */
         _d.depositOwner().call.value(_d.keepSetupFee)("");
         _d.pushFundsToKeepGroup(_seized.sub(_d.keepSetupFee));
-
-        fundingTeardown(_d);
     }
 
     /// @notice             we poll the Keep contract to retrieve our pubkey.

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -78,13 +78,6 @@ library DepositFunding {
         return true;
     }
 
-    /// @notice     Seizes signer bonds and distributes them to the funder.
-    /// @dev        This is only called as part of funding fraud flow.
-    function distributeSignerBondsToFunder(DepositUtils.Deposit storage _d) internal {
-        uint256 _seized = _d.seizeSignerBonds();
-        _d.depositOwner().call.value(_seized)("");  // Transfer whole amount
-    }
-
     /// @notice     Anyone may notify the contract that signing group setup has timed out.
     /// @param  _d  Deposit storage pointer.
     function notifySignerSetupFailure(DepositUtils.Deposit storage _d) public {
@@ -102,7 +95,7 @@ library DepositFunding {
         fundingTeardown(_d);
 
         /* solium-disable-next-line security/no-send */
-        _d.depositOwner().call.value(_d.keepSetupFee)("");
+        _d.enableWithdrawal(_d.depositOwner, _d.keepSetupFee);
         _d.pushFundsToKeepGroup(_seized.sub(_d.keepSetupFee));
     }
 
@@ -168,7 +161,11 @@ library DepositFunding {
         bool _isFraud = _d.submitSignatureFraud(_v, _r, _s, _signedDigest, _preimage);
         require(_isFraud, "Signature is not fraudulent");
         _d.logFraudDuringSetup();
-        distributeSignerBondsToFunder(_d);
+
+        // allow deposit owner to withdraw sized bonds after contract termination;
+        uint256 _seized = _d.seizeSignerBonds();
+        _d.enableWithdrawal(_d.depositOwner(), _seized);
+
         fundingFraudTeardown(_d);
         _d.setFailedSetup();
         _d.logSetupFailed();

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -74,7 +74,7 @@ library DepositLiquidation {
         if (_d.auctionTBTCAmount() == 0) {
             // we came from the redemption flow
             _d.setLiquidated();
-            _d.redeemerAddress.transfer(_seized);
+            _d.redeemerAddress.call.value(_seized)("");
             _d.logLiquidated();
             return;
         }
@@ -180,7 +180,7 @@ library DepositLiquidation {
 
         // Distribute funds to auction buyer
         uint256 _valueToDistribute = _d.auctionValue();
-        msg.sender.transfer(_valueToDistribute);
+        msg.sender.call.value(_valueToDistribute)("");
 
         // Send any TBTC left to the Fee Rebate Token holder
         _d.distributeFeeRebate();
@@ -198,13 +198,13 @@ library DepositLiquidation {
         if (contractEthBalance > 1) {
             if (_wasFraud) {
                 /* solium-disable-next-line security/no-send */
-                initiator.send(contractEthBalance);
+                initiator.call.value(contractEthBalance)("");
             } else {
                 // There will always be a liquidation initiator.
                 uint256 split = contractEthBalance.div(2);
                 _d.pushFundsToKeepGroup(split);
                 /* solium-disable-next-line security/no-send */
-                initiator.send(address(this).balance);
+                initiator.call.value(address(this).balance)("");
             }
         }
     }

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -66,6 +66,9 @@ library DepositUtils {
         uint256 fundedAt; // timestamp when funding proof was received
         bytes utxoOutpoint;  // the 36-byte outpoint of the custodied UTXO
 
+        /// @notice Map of ETH balances an address can withdraw after contract reaches ends-state.
+        mapping(address => uint256) withdrawalAllowances;
+
         /// @notice Map of timestamps for transaction digests approved for signing
         /// @dev Holds a timestamp from the moment when the transaction digest
         /// was approved for signing
@@ -394,6 +397,26 @@ library DepositUtils {
         uint256 _postCallBalance = address(this).balance;
         require(_postCallBalance > _preCallBalance, "No funds received, unexpected");
         return _postCallBalance.sub(_preCallBalance);
+    }
+
+
+    /// @notice     Adds a given amount to an addresses withdrawal allowance
+    /// @dev        Withdrawals can only happen post contract-end-state.
+    function enableWithdrawal(DepositUtils.Deposit storage _d, address _withdrawer, uint256 _amount) internal {
+        withdrawalAllowances[_withdrawer].add(_amount);
+    }
+
+    /// @notice     Withdraw caller's allowance.
+    /// @dev        Withdrawals can only happen post contract-end-state.
+    function withdrawFunds(DepositUtils.Deposit storage _d) internal {
+        require(_d.inEndState(), "Contact not yet terminated");
+        require(withdrawalAllowances[msg.sender] > 0, "Nothing to withdraw"");
+
+        // zero-out to prevent reentrancy
+        uint256 available = withdrawalAllowances[msg.sender];
+        withdrawalAllowances[msg.sender] = 0;
+    
+        msg.sender.call.value(available)("");
     }
 
     /// @notice     Distributes the fee rebate to the Fee Rebate Token owner.

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -4363,12 +4363,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "command-exists": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.8.tgz",
-      "integrity": "sha512-PM54PkseWbiiD/mMsbvW351/u+dafwTJ0ye2qB60G1aGQP9j3xK2gmMDc+R34L3nDtx4qMCitXT75mkbkGJDLw==",
-      "dev": true
-    },
     "commander": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
@@ -26576,42 +26570,6 @@
       "resolved": "https://registry.npmjs.org/sol-explore/-/sol-explore-1.6.1.tgz",
       "integrity": "sha1-tZ8HPGn+MyVg1aEMMrqMp/KYbPs=",
       "dev": true
-    },
-    "solc": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.17.tgz",
-      "integrity": "sha512-uI+7XtBu/0CXRc8IMjzxbh0haLwaBF32VxAkkks06zEk+mVcsQbHdjvojXX6zQYtZVuXdVYPVccoIjEhvvqKnQ==",
-      "dev": true,
-      "requires": {
-        "command-exists": "^1.2.8",
-        "commander": "3.0.2",
-        "fs-extra": "^0.30.0",
-        "js-sha3": "0.8.0",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^2.0.0",
-        "semver": "^5.5.0",
-        "tmp": "0.0.33"
-      },
-      "dependencies": {
-        "js-sha3": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-          "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-          "dev": true
-        },
-        "require-from-string": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
     },
     "solidity-bytes-utils": {
       "version": "0.0.7",


### PR DESCRIPTION
Push models have security and stability concerns, a pull model allows for better security, as well as more flexibility and freedom to third-party contract fallbacks given `.call.value()`'s gas-forwarding.

- Accumulated Eth balance can only be withdrawn after the contract reaches an end-state