### PR TITLE
Use a pull model to withdraw deposit ETH balances

### DIFF
--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -411,8 +411,8 @@ contract Deposit is DepositFactoryAuthority {
         return true;
     }
 
-    /// @notice     Get caller's withdrawable allowance.
-    /// @return     The withdrawable allowance in wei.
+    /// @notice     Get caller's withdraw allowance.
+    /// @return     The withdraw allowance in wei.
     function getWithdrawAllowance() public returns (uint256) {
         return self.getWithdrawAllowance();
     }

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -402,4 +402,12 @@ contract Deposit is DepositFactoryAuthority {
         self.notifyCourtesyTimeout();
         return true;
     }
+
+    /// @notice     Withdraw caller's allowance.
+    /// @dev        Withdrawals can only happen when a contract is in an end-state.
+    /// @return     True if successful, otherwise revert.
+    function withdrawFunds() public returns (bool) {
+        self.withdrawFunds();
+        return true;
+    }
 }

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -410,4 +410,10 @@ contract Deposit is DepositFactoryAuthority {
         self.withdrawFunds();
         return true;
     }
+
+    /// @notice     Get caller's withdrawable allowance.
+    /// @return     The withdrawable allowance in wei.
+    function getWithdrawAllowance() public returns (uint256) {
+        return self.getWithdrawAllowance();
+    }
 }

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -163,7 +163,7 @@ library DepositFunding {
         require(_isFraud, "Signature is not fraudulent");
         _d.logFraudDuringSetup();
 
-        // allow deposit owner to withdraw sized bonds after contract termination;
+        // Allow deposit owner to withdraw seized bonds after contract termination.
         uint256 _seized = _d.seizeSignerBonds();
         _d.enableWithdrawal(_d.depositOwner(), _seized);
 

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -179,8 +179,8 @@ library DepositLiquidation {
         }
 
         // Distribute funds to auction buyer
-        uint256 _valueToDistribute = _d.auctionValue();
-        _d.enableWithdrawal(msg.sender, _valueToDistribute);
+        uint256 valueToDistribute = _d.auctionValue();
+        _d.enableWithdrawal(msg.sender, valueToDistribute);
 
         // Send any TBTC left to the Fee Rebate Token holder
         _d.distributeFeeRebate();
@@ -195,8 +195,8 @@ library DepositLiquidation {
         if (initiator == address(0)){
             initiator = address(0xdead);
         }
-        if (contractEthBalance > _valueToDistribute) {
-            uint256 remainingUnallocated = contractEthBalance.sub(_valueToDistribute);
+        if (contractEthBalance > valueToDistribute) {
+            uint256 remainingUnallocated = contractEthBalance.sub(valueToDistribute);
             if (_wasFraud) {
                 _d.enableWithdrawal(initiator, remainingUnallocated);
             } else {

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -195,7 +195,7 @@ library DepositLiquidation {
         if (initiator == address(0)){
             initiator = address(0xdead);
         }
-        if (contractEthBalance > valueToDistribute) {
+        if (contractEthBalance > valueToDistribute + 1) {
             uint256 remainingUnallocated = contractEthBalance.sub(valueToDistribute);
             if (_wasFraud) {
                 _d.enableWithdrawal(initiator, remainingUnallocated);

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -74,7 +74,7 @@ library DepositLiquidation {
         if (_d.auctionTBTCAmount() == 0) {
             // we came from the redemption flow
             _d.setLiquidated();
-            _d.redeemerAddress.transfer(_seized);
+            _d.enableWithdrawal(_d.redeemerAddress, _seized);
             _d.logLiquidated();
             return;
         }
@@ -167,8 +167,8 @@ library DepositLiquidation {
 
         // send the TBTC to the TDT holder. If the TDT holder is the Vending Machine, burn it to maintain the peg.
         address tdtHolder = _d.depositOwner();
-
         uint256 lotSizeTbtc = _d.lotSizeTbtc();
+
         require(_d.tbtcToken.balanceOf(msg.sender) >= lotSizeTbtc, "Not enough TBTC to cover outstanding debt");
 
         if(tdtHolder == _d.vendingMachineAddress){
@@ -180,7 +180,7 @@ library DepositLiquidation {
 
         // Distribute funds to auction buyer
         uint256 _valueToDistribute = _d.auctionValue();
-        msg.sender.transfer(_valueToDistribute);
+        _d.enableWithdrawal(msg.sender, _valueToDistribute);
 
         // Send any TBTC left to the Fee Rebate Token holder
         _d.distributeFeeRebate();
@@ -195,16 +195,15 @@ library DepositLiquidation {
         if (initiator == address(0)){
             initiator = address(0xdead);
         }
-        if (contractEthBalance > 1) {
+        if (contractEthBalance > _valueToDistribute) {
+            uint256 remainingUnallocated = contractEthBalance.sub(_valueToDistribute);
             if (_wasFraud) {
-                /* solium-disable-next-line security/no-send */
-                initiator.send(contractEthBalance);
+                _d.enableWithdrawal(initiator, remainingUnallocated);
             } else {
                 // There will always be a liquidation initiator.
-                uint256 split = contractEthBalance.div(2);
+                uint256 split = remainingUnallocated.div(2);
                 _d.pushFundsToKeepGroup(split);
-                /* solium-disable-next-line security/no-send */
-                initiator.send(address(this).balance);
+                _d.enableWithdrawal(initiator, remainingUnallocated.sub(split));
             }
         }
     }

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -410,7 +410,7 @@ library DepositUtils {
     function withdrawFunds(DepositUtils.Deposit storage _d) internal {
         uint256 available = _d.withdrawalAllowances[msg.sender];
 
-        require(_d.inEndState(), "Contact not yet terminated");
+        require(_d.inEndState(), "Contract not yet terminated");
         require(available > 0, "Nothing to withdraw");
         require(address(this).balance >= available, "Insufficient contract balance");
 

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -66,12 +66,10 @@ library DepositUtils {
         uint256 fundedAt; // timestamp when funding proof was received
         bytes utxoOutpoint;  // the 36-byte outpoint of the custodied UTXO
 
-        /// @notice Map of ETH balances an address can withdraw after contract reaches ends-state.
+        /// @dev Map of ETH balances an address can withdraw after contract reaches ends-state.
         mapping(address => uint256) withdrawalAllowances;
 
-        /// @notice Map of timestamps for transaction digests approved for signing
-        /// @dev Holds a timestamp from the moment when the transaction digest
-        /// was approved for signing
+        /// @dev Map of timestamps representing when transaction digests were approved for signing
         mapping (bytes32 => uint256) approvedDigests;
     }
 

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -399,7 +399,7 @@ library DepositUtils {
         return _postCallBalance.sub(_preCallBalance);
     }
 
-    /// @notice     Adds a given amount to an addresses withdrawal allowance.
+    /// @notice     Adds a given amount to the withdraw allowance for the address.
     /// @dev        Withdrawals can only happen when a contract is in an end-state.
     function enableWithdrawal(DepositUtils.Deposit storage _d, address _withdrawer, uint256 _amount) internal {
         _d.withdrawalAllowances[_withdrawer] = _d.withdrawalAllowances[_withdrawer].add(_amount);
@@ -422,7 +422,7 @@ library DepositUtils {
     }
 
     /// @notice     Get the caller's withdraw allowance.
-    /// @return     The caller's withdrawable allowance in wei.
+    /// @return     The caller's withdraw allowance in wei.
     function getWithdrawAllowance(DepositUtils.Deposit storage _d) internal returns (uint256) {
         return _d.withdrawalAllowances[msg.sender];
     }

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -254,4 +254,9 @@ contract TestDeposit is Deposit {
     function getAuctionBasePercentage() public view returns (uint256) {
         return self.getAuctionBasePercentage();
     }
+
+    function auctionValue() public view returns (uint256) {
+        return self.auctionValue();
+    }
+
 }

--- a/solidity/contracts/test/deposit/TestDepositUtils.sol
+++ b/solidity/contracts/test/deposit/TestDepositUtils.sol
@@ -49,10 +49,6 @@ contract TestDepositUtils is TestDeposit {
         return self.signerPKH();
     }
 
-    function auctionValue() public view returns (uint256) {
-        return self.auctionValue();
-    }
-
     function utxoSize() public view returns (uint256) {
         return self.utxoSize();
     }
@@ -83,6 +79,10 @@ contract TestDepositUtils is TestDeposit {
 
     function pushFundsToKeepGroup(uint256 _ethValue) public returns (bool) {
         return self.pushFundsToKeepGroup(_ethValue);
+    }
+
+    function enableWithdrawal(address _withdrawer, uint256 _amount) public {
+        self.enableWithdrawal(_withdrawer, _amount);
     }
 }
 

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -218,16 +218,15 @@ describe("DepositFunding", async function() {
     })
 
     it("updates state to setup failed, deconstes state, logs SetupFailed, and refunds TDT owner", async () => {
-      const initialFunderBalance = await web3.eth.getBalance(owner)
       const blockNumber = await web3.eth.getBlock("latest").number
-      await testDeposit.notifySignerSetupFailure()
+      await testDeposit.notifySignerSetupFailure({from: owner})
 
       const signingGroupRequestedAt = await testDeposit.getSigningGroupRequestedAt.call()
-      const finalFunderBalance = await web3.eth.getBalance(owner)
 
-      expect(
-        new BN(finalFunderBalance).sub(new BN(initialFunderBalance)),
-      ).to.eq.BN(openKeepFee)
+      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+        from: owner,
+      })
+      expect(withdrawable).to.eq.BN(new BN(openKeepFee))
 
       expect(
         signingGroupRequestedAt,

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -226,7 +226,10 @@ describe("DepositFunding", async function() {
       const withdrawable = await testDeposit.getWithdrawAllowance.call({
         from: owner,
       })
+
+      const depositBalance = await web3.eth.getBalance(testDeposit.address)
       expect(withdrawable).to.eq.BN(new BN(openKeepFee))
+      expect(withdrawable).to.eq.BN(new BN(depositBalance))
 
       expect(
         signingGroupRequestedAt,

--- a/solidity/test/DepositLiquidationTest.js
+++ b/solidity/test/DepositLiquidationTest.js
@@ -163,23 +163,25 @@ describe("DepositLiquidation", async function() {
       ).to.eq.BN(tokenCheck)
     })
 
-    it("distributes value to the buyer", async () => {
-      const value = 10000000000000000
+    it("awards withdrawable value to the buyer", async () => {
+      const value = new BN("10000000000000000")
       const block = await web3.eth.getBlock("latest")
       const notifiedTime = block.timestamp
-      const initialBalance = await web3.eth.getBalance(buyer)
 
       await ecdsaKeepStub.pushFundsFromKeep(testDeposit.address, {value: value})
 
       await testDeposit.setLiquidationAndCourtesyInitated(notifiedTime, 0)
+      const auctionValue = await testDeposit.auctionValue()
+
       await testDeposit.purchaseSignerBondsAtAuction({from: buyer})
 
-      const finalBalance = await web3.eth.getBalance(buyer)
+      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+        from: buyer,
+      })
 
-      expect(
-        new BN(finalBalance),
-        "buyer balance should increase",
-      ).to.be.gte.BN(initialBalance)
+      expect(withdrawable, "buyer should have a withdrawable balance").to.eq.BN(
+        auctionValue,
+      )
     })
 
     it("splits funds between liquidation triggerer and signers if not fraud", async () => {
@@ -191,9 +193,6 @@ describe("DepositLiquidation", async function() {
 
       await ecdsaKeepStub.pushFundsFromKeep(testDeposit.address, {value: value})
 
-      const initialInitiatorBalance = await web3.eth.getBalance(
-        liquidationInitiator,
-      )
       const initialSignerBalance = await web3.eth.getBalance(
         ecdsaKeepStub.address,
       )
@@ -203,16 +202,10 @@ describe("DepositLiquidation", async function() {
       // Buy auction immediately. No scaling taken place. Auction value is base percentage of signer bond.
       await testDeposit.purchaseSignerBondsAtAuction({from: buyer})
 
-      const finalInitiatorBalance = await web3.eth.getBalance(
-        liquidationInitiator,
-      )
       const finalSignerBalance = await web3.eth.getBalance(
         ecdsaKeepStub.address,
       )
 
-      const initiatorBalanceDiff = new BN(finalInitiatorBalance).sub(
-        new BN(initialInitiatorBalance),
-      )
       const signerBalanceDiff = new BN(finalSignerBalance).sub(
         new BN(initialSignerBalance),
       )
@@ -220,7 +213,11 @@ describe("DepositLiquidation", async function() {
       const totalReward = (value * (100 - basePercentage)) / 100
       const split = totalReward / 2
 
-      expect(new BN(split)).to.eq.BN(initiatorBalanceDiff)
+      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+        from: liquidationInitiator,
+      })
+
+      expect(new BN(split)).to.eq.BN(withdrawable)
       expect(new BN(split)).to.eq.BN(signerBalanceDiff)
     })
 
@@ -233,9 +230,6 @@ describe("DepositLiquidation", async function() {
 
       await ecdsaKeepStub.pushFundsFromKeep(testDeposit.address, {value: value})
 
-      const initialInitiatorBalance = await web3.eth.getBalance(
-        liquidationInitiator,
-      )
       const initialSignerBalance = await web3.eth.getBalance(
         ecdsaKeepStub.address,
       )
@@ -246,24 +240,22 @@ describe("DepositLiquidation", async function() {
       // Buy auction immediately. No scaling taken place. Auction value is base percentage of signer bond.
       await testDeposit.purchaseSignerBondsAtAuction({from: buyer})
 
-      const finalInitiatorBalance = await web3.eth.getBalance(
-        liquidationInitiator,
-      )
       const finalSignerBalance = await web3.eth.getBalance(
         ecdsaKeepStub.address,
       )
 
-      const initiatorBalanceDiff = new BN(finalInitiatorBalance).sub(
-        new BN(initialInitiatorBalance),
-      )
       const signerBalanceDiff = new BN(finalSignerBalance).sub(
         new BN(initialSignerBalance),
       )
 
+      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+        from: liquidationInitiator,
+      })
+
       const totalReward = (value * (100 - basePercentage)) / 100
 
       expect(new BN(signerBalanceDiff)).to.eq.BN(0)
-      expect(new BN(initiatorBalanceDiff)).to.eq.BN(totalReward)
+      expect(new BN(withdrawable)).to.eq.BN(totalReward)
     })
   })
 

--- a/solidity/test/DepositLiquidationTest.js
+++ b/solidity/test/DepositLiquidationTest.js
@@ -177,12 +177,12 @@ describe("DepositLiquidation", async function() {
 
       // calculate the split of the un-purchased signer bond
       const split = value.sub(auctionValue).div(new BN(2))
-      
+
       const withdrawable = await testDeposit.getWithdrawAllowance.call({
         from: buyer,
       })
       const depositBalance = await web3.eth.getBalance(testDeposit.address)
-     
+
       expect(depositBalance).to.eq.BN(auctionValue.add(split))
       expect(withdrawable, "buyer should have a withdrawable balance").to.eq.BN(
         auctionValue,
@@ -224,7 +224,7 @@ describe("DepositLiquidation", async function() {
         from: liquidationInitiator,
       })
       const depositBalance = await web3.eth.getBalance(testDeposit.address)
-     
+
       expect(depositBalance).to.eq.BN(auctionValue.add(new BN(split)))
       expect(new BN(split)).to.eq.BN(withdrawable)
       expect(new BN(split)).to.eq.BN(signerBalanceDiff)
@@ -263,7 +263,7 @@ describe("DepositLiquidation", async function() {
 
       const totalReward = (value * (100 - basePercentage)) / 100
       const depositBalance = await web3.eth.getBalance(testDeposit.address)
-     
+
       expect(depositBalance).to.eq.BN(new BN(value))
       expect(new BN(signerBalanceDiff)).to.eq.BN(0)
       expect(new BN(withdrawable)).to.eq.BN(totalReward)

--- a/solidity/test/DepositUtilsTest.js
+++ b/solidity/test/DepositUtilsTest.js
@@ -642,6 +642,7 @@ describe("DepositUtils", async function() {
       )
     })
   })
+
   describe("enableWithdrawal()", async () => {
     beforeEach(async () => {
       await createSnapshot()
@@ -655,13 +656,18 @@ describe("DepositUtils", async function() {
       const value = new BN(10000)
       const beneficiary = accounts[1]
 
-      await testDeposit.enableWithdrawal(accounts[1], value)
-
-      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+      const initialWithdrawable = await testDeposit.getWithdrawAllowance.call({
         from: beneficiary,
       })
 
-      expect(withdrawable).to.eq.BN(value)
+      await testDeposit.enableWithdrawal(accounts[1], value)
+
+      const finalWithdrawable = await testDeposit.getWithdrawAllowance.call({
+        from: beneficiary,
+      })
+
+      expect(initialWithdrawable).to.eq.BN(new BN(0))
+      expect(finalWithdrawable).to.eq.BN(value)
     })
   })
 


### PR DESCRIPTION
Push models introduce security and stability concerns, a pull model allows for better security, as well as more flexibility and freedom to third-party contract fallbacks given `.call.value()`'s gas-forwarding.

- Accumulated Eth balance can only be withdrawn after the contract reaches an end-state.

Closes #551.