### PR TITLE
Liquidation-entry refactor

### DIFF
--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -71,21 +71,21 @@ library DepositLiquidation {
     function startLiquidation(DepositUtils.Deposit storage _d, bool _wasFraud) internal {
         _d.logStartedLiquidation(_wasFraud);
 
-        uint256 _seized = _d.seizeSignerBonds();
+        uint256 seized = _d.seizeSignerBonds();
+        address redeemerAddress = _d.redeemerAddress;
+
+        // Reclaim used state for gas savings
+        _d.redemptionTeardown();
 
         // if we come from the redemption flow we shouldn't go to auction.
         // Instead give the signer bonds to redeemer
         if (_d.inRedemption()) {
             _d.setLiquidated();
-            _d.enableWithdrawal(_d.redeemerAddress, _seized);
+            _d.enableWithdrawal(redeemerAddress, seized);
             _d.logLiquidated();
-            // Reclaim used state for gas savings
-            _d.redemptionTeardown();
             return;
         }
 
-        // Reclaim used state for gas savings
-        _d.redemptionTeardown();
         _d.liquidationInitiator = msg.sender;
         _d.liquidationInitiated = block.timestamp;  // Store the timestamp for auction
 

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -61,9 +61,12 @@ library DepositLiquidation {
         return (_bondValue.mul(100).div(_lotValue));
     }
 
-    /// @notice           Starts signer liquidation due to abort, undercollateralization, or fraud
-    /// @dev              Liquidation is done by auction.
-    /// @param _wasFraud  Boolean checking liquidation cause. True if fraud, false otherwise.
+    /// @dev              Starts signer liquidation by seizing signer bonds.
+    ///                   If the deposit is currently being redeemed, the redeemer
+    ///                   receives the full bond value; otherwise, a falling price auction
+    ///                   begins to buy 1 TBTC in exchange for a portion of the seized bonds;
+    ///                   see purchaseSignerBondsAtAuction().
+    /// @param _wasFraud  True if liquidation is being started due to fraud, false if for any other reason.
     /// @param _d         Deposit storage pointer.
     function startLiquidation(DepositUtils.Deposit storage _d, bool _wasFraud) internal {
         _d.logStartedLiquidation(_wasFraud);

--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -360,7 +360,7 @@ library DepositRedemption {
     function notifySignatureTimeout(DepositUtils.Deposit storage _d) public {
         require(_d.inAwaitingWithdrawalSignature(), "Not currently awaiting a signature");
         require(block.timestamp > _d.withdrawalRequestTime.add(TBTCConstants.getSignatureTimeout()), "Signature timer has not elapsed");
-        _d.startSignerAbortLiquidation();  // not fraud, just failure
+        _d.startLiquidation(false);  // not fraud, just failure
     }
 
     /// @notice     Anyone may notify the contract that the signers have failed to produce a redemption proof.
@@ -369,6 +369,6 @@ library DepositRedemption {
     function notifyRedemptionProofTimeout(DepositUtils.Deposit storage _d) public {
         require(_d.inAwaitingWithdrawalProof(), "Not currently awaiting a redemption proof");
         require(block.timestamp > _d.withdrawalRequestTime.add(TBTCConstants.getRedemptionProofTimeout()), "Proof timer has not elapsed");
-        _d.startSignerAbortLiquidation();  // not fraud, just failure
+        _d.startLiquidation(false);  // not fraud, just failure
     }
 }

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -356,11 +356,11 @@ library DepositUtils {
     /// @notice     Deletes state after termination of redemption process.
     /// @dev        We keep around the redeemer address so we can pay them out.
     function redemptionTeardown(Deposit storage _d) public {
-        // don't 0 redeemerAddress because we use it to calculate auctionTBTCAmount
         _d.redeemerOutputScript = "";
         _d.initialRedemptionFee = 0;
         _d.withdrawalRequestTime = 0;
         _d.lastRequestedDigest = bytes32(0);
+        _d.redeemerAddress = address(0);
     }
 
 

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -260,17 +260,6 @@ library DepositUtils {
         return lotSizeTbtc(_d).div(_d.signerFeeDivisor);
     }
 
-    /// @notice     Determines the amount of TBTC accepted in the auction.
-    /// @dev        If redeemerAddress is non-0, that means we came from redemption, and no auction should happen.
-    /// @return     The amount of TBTC that must be paid at auction for the signer's bond.
-    function auctionTBTCAmount(Deposit storage _d) public view returns (uint256) {
-        if (_d.redeemerAddress == address(0)) {
-            return lotSizeTbtc(_d);
-        } else {
-            return 0;
-        }
-    }
-
     /// @notice             Determines the prefix to the compressed public key.
     /// @dev                The prefix encodes the parity of the Y coordinate.
     /// @param  _pubkeyY    The Y coordinate of the public key.

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -215,12 +215,8 @@ contract TestDeposit is Deposit {
         self.approvedDigests[_digest] = _timestamp;
     }
 
-    function startSignerFraudLiquidation() public {
-        self.startSignerFraudLiquidation();
-    }
-
-    function startSignerAbortLiquidation() public {
-        self.startSignerAbortLiquidation();
+    function startLiquidation(bool _wasFraud) public {
+        self.startLiquidation(_wasFraud);
     }
 
     // passthrough for direct testing

--- a/solidity/test/DepositFraudTest.js
+++ b/solidity/test/DepositFraudTest.js
@@ -114,7 +114,7 @@ describe("DepositFraud", async function() {
     })
   })
 
-  describe("startSignerFraudLiquidation", async () => {
+  describe("startLiquidation - fraud", async () => {
     let signerBond
     before(async () => {
       signerBond = 10000000
@@ -132,7 +132,7 @@ describe("DepositFraud", async function() {
     it("executes and emits StartedLiquidation event", async () => {
       const block = await web3.eth.getBlock("latest")
 
-      await testDeposit.startSignerFraudLiquidation({from: owner})
+      await testDeposit.startLiquidation(true, {from: owner})
 
       const events = await tbtcSystemStub.getPastEvents("StartedLiquidation", {
         fromBlock: block.number,
@@ -153,10 +153,11 @@ describe("DepositFraud", async function() {
     it("liquidates immediately with bonds going to the redeemer if we came from the redemption flow", async () => {
       // setting redeemer address suggests we are coming from redemption flow
       testDeposit.setRedeemerAddress(owner)
+      await testDeposit.setState(states.AWAITING_WITHDRAWAL_SIGNATURE)
 
       const currentBond = await web3.eth.getBalance(ecdsaKeepStub.address)
       const block = await web3.eth.getBlock("latest")
-      await testDeposit.startSignerFraudLiquidation()
+      await testDeposit.startLiquidation(true)
 
       const events = await tbtcSystemStub.getPastEvents("Liquidated", {
         fromBlock: block.number,
@@ -175,7 +176,7 @@ describe("DepositFraud", async function() {
     })
   })
 
-  describe("startSignerAbortLiquidation", async () => {
+  describe("startLiquidation - not fraud", async () => {
     let signerBond
     before(async () => {
       signerBond = 10000000
@@ -193,7 +194,7 @@ describe("DepositFraud", async function() {
     it("executes and emits StartedLiquidation event", async () => {
       const block = await web3.eth.getBlock("latest")
 
-      await testDeposit.startSignerAbortLiquidation({from: owner})
+      await testDeposit.startLiquidation(false, {from: owner})
 
       const events = await tbtcSystemStub.getPastEvents("StartedLiquidation", {
         fromBlock: block.number,


### PR DESCRIPTION
- `startSignerFraudLiquidatoin` and `StartSignerAbortLiquidation` have been consolidated to a single `startLiquidation` method. a boolean is passed to  differentiate between abort and fraud.

- if coming from redemption, always `setLiquidated` and make the signer bonds redeemer-withdrawable. Check the deposit state directly rather than relying on `redeemerAddress` being set to determine if we're coming from the liquidation flow.

closes: #553 

draft untill: 
- ~~ensure redeemable state `startLiquidation` path doesn't introduce any holes~~ -> moved to #319 .