### PR TITLE
Tenderly: linky dinky

### DIFF
--- a/solidity/scripts/circleci-migrate-contracts.sh
+++ b/solidity/scripts/circleci-migrate-contracts.sh
@@ -61,6 +61,7 @@ ssh utilitybox << EOF
   # referenced at two paths due to older dependencies, leading to problems
   # resolving contracts during tenderly push.
   ln -s node_modules/@openzeppelin @openzeppelin
+  ln -s node_modules/@summa-tx @summa-tx
   tenderly login --authentication-method token --token $TENDERLY_TOKEN
   tenderly push --networks $ETH_NETWORK_ID --tag tbtc \
     --tag $GOOGLE_PROJECT_NAME --tag $BUILD_TAG || echo "tendery push failed :("


### PR DESCRIPTION
We've got another contract resolution issue on `tenderly push`.  Giving it the ol' symlink treatment so that we can push.

Gave this a shot from a migration folder on the keep-dev utility box and it worked.