### PR TITLE
v0.13.0-rc release preparation

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.13.0-pre",
+  "version": "0.13.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-pre.9",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.9.tgz",
-      "integrity": "sha512-I8MsomNf8o5fhc02O6TkThpXnEkbHSjAgHPsL42k4EJbVkOfrxBLHDAc04Rg8LeNsFygpifmncoV6jtbiQwxbA==",
+      "version": "0.13.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.0.tgz",
+      "integrity": "sha512-hYZYnxo/T6a/TcJhfFAc4F+YTbj4iTGWZB39EhlGwecBZnNOWuwJnqw3l3Co7ZOuVLdPdxnkLyEy1f0NFlt+8g==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -50,24 +50,23 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.13.0-pre.10",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.13.0-pre.10.tgz",
-      "integrity": "sha512-Jry458+wwUgq47RM9KwKjdYvWp0gTf/f7aq45FnX28d4gqSs1R84C88Q84X4oBl29bnd+RoN8y7CduAA9ClYhg==",
+      "version": "0.13.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.13.0-rc.0.tgz",
+      "integrity": "sha512-ILedwG2XZ3pJ8hkN4irPbMW58TUbEip3iUgIF1xGrVw3RtuNzrDYRXpXGP1oVLNtIgJDrHJeTwhge9zpsvuTSA==",
       "requires": {
-        "@keep-network/keep-core": ">0.13.0-pre <0.13.0-rc",
-        "@keep-network/sortition-pools": "0.1.1",
+        "@keep-network/keep-core": ">0.13.0-rc <0.13.0",
+        "@keep-network/sortition-pools": "0.3.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
         "solidity-bytes-utils": "0.0.7"
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.1.1.tgz",
-      "integrity": "sha512-0A4N6wbtFfjWez7KwHEd2aMh6iB4kNaxI5fGDUCaCkeo2zP/FHOFcI9POIYLQ/17bL71EK/WxM5CnZJz4n/9vg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.3.0.tgz",
+      "integrity": "sha512-1nr1Wq3wmKYxtkWynB/xMHEYpVAOSCL5XBcHMlsUBGuG9rw+JhbDUNYbbxHNYUZ7sMRq0S0pOrzQVWb5M+ZUig==",
       "requires": {
-        "@openzeppelin/contracts": "^2.4.0",
-        "solidity-bytes-utils": "0.0.7"
+        "@openzeppelin/contracts": "^2.4.0"
       }
     },
     "@openzeppelin/contract-loader": {
@@ -1007,9 +1006,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.34",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
-          "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g=="
+          "version": "12.12.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
+          "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ=="
         },
         "bignumber.js": {
           "version": "7.2.1",
@@ -1080,6 +1079,11 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
+    },
+    "@solidity-parser/parser": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.5.2.tgz",
+      "integrity": "sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ=="
     },
     "@summa-tx/bitcoin-spv-sol": {
       "version": "3.0.0",
@@ -26621,11 +26625,6 @@
         "truffle-hdwallet-provider": "0.0.3"
       }
     },
-    "solidity-parser-antlr": {
-      "version": "0.4.11",
-      "resolved": "https://registry.npmjs.org/solidity-parser-antlr/-/solidity-parser-antlr-0.4.11.tgz",
-      "integrity": "sha512-4jtxasNGmyC0midtjH/lTFPZYvTTUMy6agYcF+HoMnzW8+cqo3piFrINb4ZCzpPW+7tTVFCGa5ubP34zOzeuMg=="
-    },
     "solidity-parser-diligence": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/solidity-parser-diligence/-/solidity-parser-diligence-0.4.18.tgz",
@@ -27532,24 +27531,21 @@
       }
     },
     "truffle-flattener": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.2.tgz",
-      "integrity": "sha512-7qUIzaW8a4vI4nui14wsytht2oaqvqnZ1Iet2wRq2T0bCJ0wb6HByMKQhZKpU46R+n5BMTY4K5n+0ITyeNlmuQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/truffle-flattener/-/truffle-flattener-1.4.3.tgz",
+      "integrity": "sha512-r29fkSkV8i9oMW35KbpKR0bP4iPnzIJqlW2S+CL3BjLsxq6YnlMn9+e0BpiJIJPmeXJgeYHQvCGceucpM0Dovg==",
       "requires": {
         "@resolver-engine/imports-fs": "^0.2.2",
+        "@solidity-parser/parser": "^0.5.2",
         "find-up": "^2.1.0",
-        "mkdirp": "^0.5.1",
-        "solidity-parser-antlr": "^0.4.11",
+        "mkdirp": "^1.0.4",
         "tsort": "0.0.1"
       },
       "dependencies": {
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-          "requires": {
-            "minimist": "^1.2.5"
-          }
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.13.0-rc",
+  "version": "0.14.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.0.tgz",
-      "integrity": "sha512-hYZYnxo/T6a/TcJhfFAc4F+YTbj4iTGWZB39EhlGwecBZnNOWuwJnqw3l3Co7ZOuVLdPdxnkLyEy1f0NFlt+8g==",
+      "version": "0.14.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-pre.0.tgz",
+      "integrity": "sha512-etiQWKwtxTCA7QFQ/wsvYAu8owdddEDOEGZ3H1QMPljbyKiDuvHmdAdzeuGsou1+i9fL/XzZPv32ctWob5xT/w==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -50,11 +50,11 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.13.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.13.0-rc.0.tgz",
-      "integrity": "sha512-ILedwG2XZ3pJ8hkN4irPbMW58TUbEip3iUgIF1xGrVw3RtuNzrDYRXpXGP1oVLNtIgJDrHJeTwhge9zpsvuTSA==",
+      "version": "0.14.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.14.0-pre.0.tgz",
+      "integrity": "sha512-jicgVWg1Onei583NpzL2x81u5pU9y83JekjaO7TEnRwvv4kxae1F+oWLlcXvzyxDkHu2kbNrlUYG8/JVUIVocA==",
       "requires": {
-        "@keep-network/keep-core": ">0.13.0-rc <0.13.0",
+        "@keep-network/keep-core": ">0.14.0-pre <0.14.0-rc",
         "@keep-network/sortition-pools": "0.3.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.13.0-rc",
+  "version": "0.14.0-pre",
   "description": "The tBTC smart contracts implementing the TBTC trustlessly Bitcoin-backed ERC-20 token.",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://tbtc.network/",
   "dependencies": {
-    "@keep-network/keep-ecdsa": ">0.13.0-rc <0.13.0",
+    "@keep-network/keep-ecdsa": ">0.14.0-pre <0.14.0-rc",
     "@summa-tx/bitcoin-spv-sol": "^3.0.0",
     "@summa-tx/relay-sol": "^1.1.0",
     "openzeppelin-solidity": "2.3.0"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.13.0-pre",
+  "version": "0.13.0-rc",
   "description": "The tBTC smart contracts implementing the TBTC trustlessly Bitcoin-backed ERC-20 token.",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://tbtc.network/",
   "dependencies": {
-    "@keep-network/keep-ecdsa": ">0.13.0-pre <0.13.0-rc",
+    "@keep-network/keep-ecdsa": ">0.13.0-rc <0.13.0",
     "@summa-tx/bitcoin-spv-sol": "^3.0.0",
     "@summa-tx/relay-sol": "^1.1.0",
     "openzeppelin-solidity": "2.3.0"


### PR DESCRIPTION
1. Bumped up Solidity contracts version to `0.13.0-rc`, `keep-ecdsa` contracts dependency set to `>0.13.0-rc <0.13.0`. Tagged [`v0.13.0-rc`](https://github.com/keep-network/tbtc/releases/tag/v0.13.0-rc)
2. Bumped up Solidity contracts version to `0.14.0-pre`, `keep-ecdsa` contracts dependency set to `>0.14.0-pre <0.14.0-rc`