### PR TITLE
Circle: exit^2

### DIFF
--- a/solidity/scripts/circleci-migrate-contracts.sh
+++ b/solidity/scripts/circleci-migrate-contracts.sh
@@ -65,10 +65,6 @@ ssh utilitybox << EOF
   tenderly push --networks $ETH_NETWORK_ID --tag tbtc \
     --tag $GOOGLE_PROJECT_NAME --tag $BUILD_TAG || echo "tendery push failed :("
   echo "<<<<<<FINISH Tenderly Push FINISH<<<<<<"
-
-  # Explicitly exit, in case something a backgrounded job is trying to keep this
-  # process running.
-  exit 0
 EOF
 
 echo "<<<<<<START Contract Copy START<<<<<<"


### PR DESCRIPTION
We had this idea to explicity exit on migration completion to prevent an
intermittent build timeout issue.  It turns out that running the
exit results in a failed build, every time.  I suspect it has something
to do with exiting inside of the heredoc, and it not terminating
correctly as a result.  Going to dig into it a bit, but rather than
experiment with different exit scenarios now we're going to remove the
exit to get the builds passing.