### PR TITLE
A Bit Sale - Clear dirty bits

### DIFF
--- a/solidity/contracts/scripts/FundingScript.sol
+++ b/solidity/contracts/scripts/FundingScript.sol
@@ -40,7 +40,9 @@ contract FundingScript {
 
         // Verify _extraData is a call to unqualifiedDepositToTbtc.
         bytes4 functionSignature;
-        assembly { functionSignature := mload(add(_extraData, 0x20)) }
+        assembly {
+            functionSignature := and(mload(add(_extraData, 0x20)), not(0xff))
+        }
         require(
             functionSignature == vendingMachine.unqualifiedDepositToTbtc.selector,
             "Bad _extraData signature. Call must be to unqualifiedDepositToTbtc."

--- a/solidity/contracts/scripts/RedemptionScript.sol
+++ b/solidity/contracts/scripts/RedemptionScript.sol
@@ -41,7 +41,9 @@ contract RedemptionScript {
 
         // Verify _extraData is a call to tbtcToBtc.
         bytes4 functionSignature;
-        assembly { functionSignature := mload(add(_extraData, 0x20)) }
+        assembly {
+            functionSignature := and(mload(add(_extraData, 0x20)), not(0xff))
+        }
         require(
             functionSignature == vendingMachine.tbtcToBtc.selector,
             "Bad _extraData signature. Call must be to tbtcToBtc."


### PR DESCRIPTION
FundingScript and RedemptionScript use mload to cast the first bytes of a byte array to bytes4. Because mload deals with 32-byte chunks, the resulting bytes4 value may contain dirty lower-order bits.

Closes: https://github.com/keep-network/tbtc/issues/557