### PR TITLE
Expose collateralization functions and Keep address

### DIFF
--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -39,6 +39,13 @@ contract Deposit is DepositFactoryAuthority {
         require(msg.sender == self.keepAddress, "Deposit contract can only receive ETH from underlying keep");
     }
 
+    /// @notice     Get the keep contract address associated with the Deposit.
+    /// @dev        The keep contract address is saved on Deposit initialization.
+    /// @return     Address of the Keep contract.
+    function getKeepAddress() public view returns (address) {
+        return self.keepAddress;
+    }
+
     /// @notice     Get the integer representing the current state.
     /// @dev        We implement this because contracts don't handle foreign enums well.
     ///             see DepositStates for more info on states.
@@ -386,7 +393,7 @@ contract Deposit is DepositFactoryAuthority {
 
     /// @notice Get the current collateralization level for this Deposit.
     /// @dev    This value represents the percentage of the backing BTC value the signers
-    ///         currently must hold as bond. 
+    ///         currently must hold as bond.
     /// @return The severe collateralization level for this deposit.
     function getCollateralizationPercentage() public view returns (uint256) {
         return self.getCollateralizationPercentage();
@@ -402,7 +409,7 @@ contract Deposit is DepositFactoryAuthority {
     /// @notice Get the undercollateralization level for this Deposit.
     /// @dev    This collateralization level is semi-critical. If the collateralization level falls
     ///         below this percentage the Deposit can get courtesy-called. This value represents the percentage
-    ///         of the backing BTC value the signers must hold as bond in order to not be undercollateralized. 
+    ///         of the backing BTC value the signers must hold as bond in order to not be undercollateralized.
     /// @return The severe collateralization level for this deposit.
     function getUndercollateralizedThresholdPercent() public view returns (uint16) {
         return self.undercollateralizedThresholdPercent;
@@ -411,7 +418,7 @@ contract Deposit is DepositFactoryAuthority {
     /// @notice Get the severe undercollateralization level for this Deposit.
     /// @dev    This collateralization level is critical. If the collateralization level falls
     ///         below this percentage the Deposit can get liquidated. This value represents the percentage
-    ///         of the backing BTC value the signers must hold as bond in order to not be severely undercollateralized. 
+    ///         of the backing BTC value the signers must hold as bond in order to not be severely undercollateralized.
     /// @return The severe collateralization level for this deposit.
     function getSeverelyUndercollateralizedThresholdPercent() public view returns (uint16) {
         return self.severelyUndercollateralizedThresholdPercent;

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -384,6 +384,39 @@ contract Deposit is DepositFactoryAuthority {
     // LIQUIDATION
     //
 
+    /// @notice Get the current collateralization level for this Deposit.
+    /// @dev    This value represents the percentage of the backing BTC value the signers
+    ///         currently must hold as bond. 
+    /// @return The severe collateralization level for this deposit.
+    function getCollateralizationPercentage() public view returns (uint256) {
+        return self.getCollateralizationPercentage();
+    }
+
+    /// @notice Get the initial collateralization level for this Deposit.
+    /// @dev    This value represents the percentage of the backing BTC value the signers hold initially.
+    /// @return The initial collateralization level for this deposit.
+    function getInitialCollateralizedPercent() public view returns (uint16) {
+        return self.initialCollateralizedPercent;
+    }
+
+    /// @notice Get the undercollateralization level for this Deposit.
+    /// @dev    This collateralization level is semi-critical. If the collateralization level falls
+    ///         below this percentage the Deposit can get courtesy-called. This value represents the percentage
+    ///         of the backing BTC value the signers must hold as bond in order to not be undercollateralized. 
+    /// @return The severe collateralization level for this deposit.
+    function getUndercollateralizedThresholdPercent() public view returns (uint16) {
+        return self.undercollateralizedThresholdPercent;
+    }
+
+    /// @notice Get the severe undercollateralization level for this Deposit.
+    /// @dev    This collateralization level is critical. If the collateralization level falls
+    ///         below this percentage the Deposit can get liquidated. This value represents the percentage
+    ///         of the backing BTC value the signers must hold as bond in order to not be severely undercollateralized. 
+    /// @return The severe collateralization level for this deposit.
+    function getSeverelyUndercollateralizedThresholdPercent() public view returns (uint16) {
+        return self.severelyUndercollateralizedThresholdPercent;
+    }
+
     /// @notice     Closes an auction and purchases the signer bonds. Payout to buyer, funder, then signers if not fraud.
     /// @dev        For interface, reading auctionValue will give a past value. the current is better.
     /// @return     True if successful, revert otherwise.

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -85,14 +85,8 @@ contract TestDeposit is Deposit {
         self.initialCollateralizedPercent = _initialCollateralizedPercent;
     }
 
-    function getUndercollateralizedThresholdPercent() public view returns (uint16) { return self.undercollateralizedThresholdPercent; }
-
     function setSeverelyUndercollateralizedThresholdPercent(uint16 _severelyUndercollateralizedThresholdPercent) public {
         self.severelyUndercollateralizedThresholdPercent = _severelyUndercollateralizedThresholdPercent;
-    }
-
-    function getSeverelyUndercollateralizedThresholdPercent() public view returns (uint16) {
-        return self.severelyUndercollateralizedThresholdPercent;
     }
 
     function setLiquidationAndCourtesyInitated(

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -123,10 +123,6 @@ contract TestDeposit is Deposit {
         self.keepAddress = _keepAddress;
     }
 
-    function getKeepAddress() public view returns (address) {
-        return self.keepAddress;
-    }
-
     function setSigningGroupRequestedAt(uint256 _signingGroupRequestedAt) public {
         self.signingGroupRequestedAt = _signingGroupRequestedAt;
     }

--- a/solidity/test/DepositUtilsTest.js
+++ b/solidity/test/DepositUtilsTest.js
@@ -399,7 +399,7 @@ describe("DepositUtils", async function() {
     it("returns correct base percentage", async () => {
       const basePercentage = await testDeposit.getAuctionBasePercentage.call()
 
-      const initialCollateralization = await tbtcSystemStub.getInitialCollateralizedPercent()
+      const initialCollateralization = await testDeposit.getInitialCollateralizedPercent()
 
       // 10000 to avoid losing value to truncating in solidity.
       const expected = new BN(10000).div(initialCollateralization)


### PR DESCRIPTION
These functions return per-deposit collateralization details. Exposing these can be useful for monitoring and managing liquidation easily.
The Keep address can be useful in order to easily obtain useful info about the keep.