### PR TITLE
keep-prd: Bcoin + Electrum

### DIFF
--- a/infrastructure/kube/keep-dev/bcoin-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/bcoin-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
               secretKeyRef:
                 name: bcoin
                 key: http-api-key
+          - name: BCOIN_INDEX_TX
+            value: 'true'
         volumeMounts:
           - name: bcoin-data
             mountPath: /mnt/.bcoin

--- a/infrastructure/kube/keep-prd/bcoin-service.yaml
+++ b/infrastructure/kube/keep-prd/bcoin-service.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bcoin
+  namespace: default
+  labels:
+    app: bitcoin-node
+    type: bcoin
+spec:
+  ports:
+  - port: 8332
+    targetPort: 8332
+    name: rpc
+  - port: 8333
+    targetPort: 8333
+    name: mainnet
+  selector:
+    app: bitcoin-node
+    type: bcoin

--- a/infrastructure/kube/keep-prd/bcoin-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/bcoin-statefulset.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: bcoin
+  namespace: default
+  labels:
+    app: bitcoin-node
+    type: bcoin
+spec:
+  replicas: 2
+  serviceName: bcoin
+  volumeClaimTemplates:
+  - metadata:
+      name: bcoin-data
+    spec:
+      storageClassName: bcoin
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests:
+          storage: 300Gi
+  selector:
+    matchLabels:
+      app: bitcoin-node
+      type: bcoin
+  template:
+    metadata:
+      labels:
+        app: bitcoin-node
+        type: bcoin
+    spec:
+      containers:
+      - name: bcoin
+        image:  gcr.io/keep-prd-210b/bcoin
+        ports:
+          - containerPort: 8332
+          - containerPort: 8333
+        env:
+          - name: BCOIN_NETWORK
+            value: main
+          - name: BCOIN_HTTP_HOST
+            value: '0.0.0.0'
+          - name: BCOIN_HTTP_PORT
+            value: '8332'
+          - name: BCOIN_PORT
+            value: '8333'
+          - name: BCOIN_LOG_LEVEL
+            value: info
+          - name: BCOIN_PREFIX
+            value: /mnt/.bcoin
+          - name: BCOIN_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: bcoin
+                key: http-api-key
+        volumeMounts:
+          - name: bcoin-data
+            mountPath: /mnt/.bcoin
+        command:
+          ["bcoin"]
+      volumes:
+      - name: bcoin-data
+        persistentVolumeClaim:
+          claimName: bcoin-data

--- a/infrastructure/kube/keep-prd/bcoin-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/bcoin-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
               secretKeyRef:
                 name: bcoin
                 key: http-api-key
+          - name: BCOIN_INDEX_TX
+            value: 'true'
         volumeMounts:
           - name: bcoin-data
             mountPath: /mnt/.bcoin

--- a/infrastructure/kube/keep-prd/bcoin-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/bcoin-statefulset.yaml
@@ -18,7 +18,7 @@ spec:
       accessModes: [ReadWriteOnce]
       resources:
         requests:
-          storage: 300Gi
+          storage: 450Gi
   selector:
     matchLabels:
       app: bitcoin-node

--- a/infrastructure/kube/keep-prd/bcoin-storageclass.yaml
+++ b/infrastructure/kube/keep-prd/bcoin-storageclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: bcoin
+  namespace: default
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+  replication-type: none
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+mountOptions:
+  - debug
+volumeBindingMode: Immediate

--- a/infrastructure/kube/keep-prd/electrumx-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/electrumx-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     app: bitcoin
     type: electrumx
 spec:
-  replicas: 1
+  replicas: 2
   serviceName: electrumx
   volumeClaimTemplates:
   - metadata:
@@ -65,12 +65,12 @@ spec:
         volumeMounts:
           - name: electrumx-data
             mountPath: /mnt/electrum/data
-          - name: cloudflare-origin-cert
+          - name: tbtc-network-cloudflare-origin-cert
             mountPath: /mnt/electrum/cert
       volumes:
       - name: electrumx-data
         persistentVolumeClaim:
           claimName: electrumx-data
-      - name: cloudflare-origin-cert
+      - name: tbtc-network-cloudflare-origin-cert
         secret:
-          secretName: cloudflare-origin-cert
+          secretName: tbtc-network-cloudflare-origin-cert

--- a/infrastructure/kube/keep-prd/electrumx-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/electrumx-statefulset.yaml
@@ -1,0 +1,76 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: electrumx
+  namespace: default
+  labels:
+    app: bitcoin
+    type: electrumx
+spec:
+  replicas: 1
+  serviceName: electrumx
+  volumeClaimTemplates:
+  - metadata:
+      name: electrumx-data
+    spec:
+      storageClassName: electrumx
+      accessModes: [ReadWriteOnce]
+      resources:
+        requests:
+          storage: 450Gi
+  selector:
+    matchLabels:
+      app: bitcoin
+      type: electrumx
+  template:
+    metadata:
+      labels:
+        app: bitcoin
+        type: electrumx
+    spec:
+      containers:
+      - name: electrumx-server
+        image: lukechilds/electrumx:v1.14.0
+        ports:
+          - containerPort: 443
+          - containerPort: 8080
+          - containerPort: 8443
+          - containerPort: 8000
+        # Full list of env vars: https://electrumx.readthedocs.io/en/latest/environment.html
+        env:
+          - name: DB_DIRECTORY
+            value: /mnt/electrum/data
+          - name: SSL_CERTFILE
+            value: /mnt/electrum/cert/tls.crt
+          - name: SSL_KEYFILE
+            value: /mnt/electrum/cert/tls.key
+          - name: DAEMON_URL
+            valueFrom:
+              secretKeyRef:
+                name: bcoin
+                key: bcoin-url
+          - name: SERVICES
+            value: ssl://:443,ws://:8080,wss://:8443,rpc://localhost:8000
+          - name: COIN
+            value: BitcoinSegwit
+          - name: NET
+            value: mainnet
+          - name: COST_SOFT_LIMIT
+            value: '0'
+          - name: COST_HARD_LIMIT
+            value: '0'
+          - name: LOG_LEVEL
+            value: debug
+        volumeMounts:
+          - name: electrumx-data
+            mountPath: /mnt/electrum/data
+          - name: cloudflare-origin-cert
+            mountPath: /mnt/electrum/cert
+      volumes:
+      - name: electrumx-data
+        persistentVolumeClaim:
+          claimName: electrumx-data
+      - name: cloudflare-origin-cert
+        secret:
+          secretName: cloudflare-origin-cert

--- a/infrastructure/kube/keep-prd/electrumx-storageclass.yaml
+++ b/infrastructure/kube/keep-prd/electrumx-storageclass.yaml
@@ -1,0 +1,14 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: electrumx
+  namespace: default
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+  replication-type: none
+reclaimPolicy: Retain
+allowVolumeExpansion: true
+mountOptions:
+  - debug
+volumeBindingMode: Immediate

--- a/infrastructure/kube/keep-test/bcoin-statefulset.yaml
+++ b/infrastructure/kube/keep-test/bcoin-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
               secretKeyRef:
                 name: bcoin
                 key: http-api-key
+          - name: BCOIN_INDEX_TX
+            value: 'true'
         volumeMounts:
           - name: bcoin-data
             mountPath: /mnt/.bcoin


### PR DESCRIPTION
Fresh on the heels of https://github.com/keep-network/tbtc/pull/575 we're setting up some mainnet Bcoin deployments.

### Bcoin

This is more or less the same as what we did ^ with some beefcaked configs:

1. Custom StorageClass with SSD's
2. 2 replica StatefulSet
3. Enabled tx indexing on all 3 environments.  This is required by Electrum.  See https://electrumx.readthedocs.io/en/latest/HOWTO.html

### Electrum

Here we provide a production deployment for Electrum.  This looks much like our lesser environments except I've stripped all of the `tbtc` referencing in the resource names.  Notably the Service config is missing.  I'll do this in the next step when we're ready to expose to the internet.

Something else to note here.  keep-dev and keep-test configs are absent from this PR.  This is due to us maintaining those configs with the tbtc-maintainers repo.  As we phase out maintainers I'll shift the Electrum configs, with naming refactors to this repo.