### PR TITLE
0.14.0-rc release preparation

### DIFF
--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -131,10 +131,8 @@ module.exports = (deployer, network, accounts) => {
       await deployer.deploy(Relay, genesis, height, epochStart)
       difficultyRelay = await Relay.deployed()
     } else if (network == "ropsten") {
-      const {genesis, height, epochStart} = bitcoinTest
-
-      await deployer.deploy(Relay, genesis, height, epochStart)
-      difficultyRelay = await Relay.deployed()
+      await deployer.deploy(MockRelay)
+      difficultyRelay = await MockRelay.deployed()
     } else if (network == "keep_dev") {
       const {genesis, height, epochStart} = bitcoinTest
 

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.14.0-rc",
+  "version": "0.15.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -50,9 +50,9 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.14.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.14.0-rc.0.tgz",
-      "integrity": "sha512-VqFQ805cbzb4uQa36Dpdc3S6rAMWkD/gdkuneF83T/oEmM3Neu34pbAklEmsyefbxSaQWtiY+S/FCSH69g1Qdg==",
+      "version": "0.15.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-pre.0.tgz",
+      "integrity": "sha512-MY4pBIWbRM2Jg8I7DhL6UB1wVJB4HG369L9QQWKLAI1N2MpcnPoxbKyBWXdgucdMX/SOz6cyRL63PCa462O61A==",
       "requires": {
         "@keep-network/keep-core": ">0.14.0-rc <0.14.0",
         "@keep-network/sortition-pools": "0.3.0",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.14.0-pre",
+  "version": "0.14.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.14.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-pre.0.tgz",
-      "integrity": "sha512-etiQWKwtxTCA7QFQ/wsvYAu8owdddEDOEGZ3H1QMPljbyKiDuvHmdAdzeuGsou1+i9fL/XzZPv32ctWob5xT/w==",
+      "version": "0.14.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-rc.0.tgz",
+      "integrity": "sha512-9K2oeuCvDK4Q1BsPghouOdEF7Ad8iCiuX7RblIaka2h8sLRBs6proyrue+KDjfKTreOZgfqb938yiyaGnyMTEQ==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -50,11 +50,11 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.14.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.14.0-pre.0.tgz",
-      "integrity": "sha512-jicgVWg1Onei583NpzL2x81u5pU9y83JekjaO7TEnRwvv4kxae1F+oWLlcXvzyxDkHu2kbNrlUYG8/JVUIVocA==",
+      "version": "0.14.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.14.0-rc.0.tgz",
+      "integrity": "sha512-VqFQ805cbzb4uQa36Dpdc3S6rAMWkD/gdkuneF83T/oEmM3Neu34pbAklEmsyefbxSaQWtiY+S/FCSH69g1Qdg==",
       "requires": {
-        "@keep-network/keep-core": ">0.14.0-pre <0.14.0-rc",
+        "@keep-network/keep-core": ">0.14.0-rc <0.14.0",
         "@keep-network/sortition-pools": "0.3.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
@@ -1006,9 +1006,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.35",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.35.tgz",
-          "integrity": "sha512-ASYsaKecA7TUsDrqIGPNk3JeEox0z/0XR/WsJJ8BIX/9+SkMSImQXKWfU/yBrSyc7ZSE/NPqLu36Nur0miCFfQ=="
+          "version": "12.12.37",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.37.tgz",
+          "integrity": "sha512-4mXKoDptrXAwZErQHrLzpe0FN/0Wmf5JRniSVIdwUrtDf9wnmEV1teCNLBo/TwuXhkK/bVegoEn/wmb+x0AuPg=="
         },
         "bignumber.js": {
           "version": "7.2.1",
@@ -26871,9 +26871,9 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "spdx-expression-parse": {
       "version": "3.0.0",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -33,9 +33,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.14.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-rc.0.tgz",
-      "integrity": "sha512-9K2oeuCvDK4Q1BsPghouOdEF7Ad8iCiuX7RblIaka2h8sLRBs6proyrue+KDjfKTreOZgfqb938yiyaGnyMTEQ==",
+      "version": "0.15.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.0.tgz",
+      "integrity": "sha512-cfrhRJX9+zkimYQ/6ASoX3inZIQ3V1dx2YDDgmoVzctm93yDKcz++fWiGSz6PXbYOUMq8Svj+a1Sv5KJSg2WLg==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -50,11 +50,11 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.15.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-pre.0.tgz",
-      "integrity": "sha512-MY4pBIWbRM2Jg8I7DhL6UB1wVJB4HG369L9QQWKLAI1N2MpcnPoxbKyBWXdgucdMX/SOz6cyRL63PCa462O61A==",
+      "version": "0.15.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-pre.1.tgz",
+      "integrity": "sha512-wB6JI6Cw6bwMVr57yITAk3vSK1mH3H+YIB1mgzvNbrIMyOlu4xLiQ+OXCJwA7/HLx7i6l5jbMd72XIZmNdXetg==",
       "requires": {
-        "@keep-network/keep-core": ">0.14.0-rc <0.14.0",
+        "@keep-network/keep-core": ">0.15.0-pre <0.15.0-rc",
         "@keep-network/sortition-pools": "0.3.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.14.0-pre",
+  "version": "0.14.0-rc",
   "description": "The tBTC smart contracts implementing the TBTC trustlessly Bitcoin-backed ERC-20 token.",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://tbtc.network/",
   "dependencies": {
-    "@keep-network/keep-ecdsa": ">0.14.0-pre <0.14.0-rc",
+    "@keep-network/keep-ecdsa": ">0.14.0-rc <0.14.0",
     "@summa-tx/bitcoin-spv-sol": "^3.0.0",
     "@summa-tx/relay-sol": "^1.1.0",
     "openzeppelin-solidity": "2.3.0"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.14.0-rc",
+  "version": "0.15.0-pre",
   "description": "The tBTC smart contracts implementing the TBTC trustlessly Bitcoin-backed ERC-20 token.",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://tbtc.network/",
   "dependencies": {
-    "@keep-network/keep-ecdsa": ">0.14.0-rc <0.14.0",
+    "@keep-network/keep-ecdsa": ">0.15.0-pre <0.15.0-rc",
     "@summa-tx/bitcoin-spv-sol": "^3.0.0",
     "@summa-tx/relay-sol": "^1.1.0",
     "openzeppelin-solidity": "2.3.0"


### PR DESCRIPTION
1. Bumped up Solidity contracts version to `0.14.0-rc`, `keep-ecdsa` contracts dependency set to `>0.14.0-rc <0.14.0`. Tagged [`v0.14.0-rc`](https://github.com/keep-network/tbtc/releases/tag/v0.14.0-rc)
2. Bumped up Solidity contracts version to `0.15.0-pre`, `keep-ecdsa` contracts dependency set to `>0.15.0-pre <0.15.0-rc`