### PR TITLE
Release 0.15.0-rc (Ropsten)

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.15.0-pre",
+  "version": "0.15.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.15.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.0.tgz",
-      "integrity": "sha512-cfrhRJX9+zkimYQ/6ASoX3inZIQ3V1dx2YDDgmoVzctm93yDKcz++fWiGSz6PXbYOUMq8Svj+a1Sv5KJSg2WLg==",
+      "version": "1.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-rc.0.tgz",
+      "integrity": "sha512-sXusNLPAPJFq9mYR5/eOYxgJKa0Kg4ezSvTtLaPjX0ul24rIPZ67kvpfbR5ePx4MCeD/XQisHvRmp/rEsXFAig==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",
@@ -50,11 +50,11 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "0.15.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-pre.1.tgz",
-      "integrity": "sha512-wB6JI6Cw6bwMVr57yITAk3vSK1mH3H+YIB1mgzvNbrIMyOlu4xLiQ+OXCJwA7/HLx7i6l5jbMd72XIZmNdXetg==",
+      "version": "0.15.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-0.15.0-rc.0.tgz",
+      "integrity": "sha512-oBqubG95bQoEGQPLnA7fGwm634o9Wyr2tThOeHyrxO2GrcVlsBqDnadxz7Q8rezKt7Ef0rPF2FtC8Cpy5G0tBQ==",
       "requires": {
-        "@keep-network/keep-core": ">0.15.0-pre <0.15.0-rc",
+        "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
         "@keep-network/sortition-pools": "0.3.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
@@ -152,9 +152,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.0.tgz",
-      "integrity": "sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.1.tgz",
+      "integrity": "sha512-qIy6tLx8rtybEsIOAlrM4J/85s2q2nPkDqj/Rx46VakBZ0LwtFhXIVub96LXHczQX0vaqmAueDqNPXtbSXSaYQ=="
     },
     "@openzeppelin/contracts-ethereum-package": {
       "version": "2.5.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "0.15.0-pre",
+  "version": "0.15.0-rc",
   "description": "The tBTC smart contracts implementing the TBTC trustlessly Bitcoin-backed ERC-20 token.",
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   },
   "homepage": "https://tbtc.network/",
   "dependencies": {
-    "@keep-network/keep-ecdsa": ">0.15.0-pre <0.15.0-rc",
+    "@keep-network/keep-ecdsa": ">0.15.0-rc <0.15.0",
     "@summa-tx/bitcoin-spv-sol": "^3.0.0",
     "@summa-tx/relay-sol": "^1.1.0",
     "openzeppelin-solidity": "2.3.0"


### PR DESCRIPTION
- Solidity contracts version bumped up to `0.15.0-rc`
- keep-ecdsa contracts dependency bumped up to `>0.15.0-rc <0.15.0`