### PR TITLE
fix: Deposit no longer reverts if ETH transfer is not from Keep

### DIFF
--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -36,7 +36,8 @@ contract Deposit is DepositFactoryAuthority {
     }
 
     function () external payable {
-        require(msg.sender == self.keepAddress, "Deposit contract can only receive ETH from underlying keep");
+        // Contract supports basic ETH transfers only.
+        require(msg.data.length == 0, "Deposit contract was called with unknown function selector.");
     }
 
     /// @notice     Get the keep contract address associated with the Deposit.


### PR DESCRIPTION
We changed the value transfer semantics of the Keep bond. Now the seized bonds originate from the KeepBonding contract. Rather than adding an additional variable to enforce strict transfers from only the KeepBonding contract, we are going to remove the restriction for now.