### PR TITLE
Ropsten Price Feed Tweaks: Allow testnet price fiddling for live tests

### DIFF
--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -18,7 +18,7 @@ const Deposit = artifacts.require("Deposit")
 const VendingMachine = artifacts.require("VendingMachine")
 
 // price feed
-const MockSatWeiPriceFeed = artifacts.require("ETHBTCPriceFeedMock")
+const ETHBTCPriceFeedMock = artifacts.require("ETHBTCPriceFeedMock")
 const prices = require("./prices")
 const SatWeiPriceFeed = artifacts.require("SatWeiPriceFeed")
 
@@ -120,9 +120,9 @@ module.exports = (deployer, network, accounts) => {
       // See: https://github.com/makerdao/oracles-v2#live-mainnet-oracles
       // Otherwise, we deploy our own mock price feeds, which are simpler
       // to maintain.
-      await deployer.deploy(MockSatWeiPriceFeed)
-      const satWeiPriceFeed = await MockSatWeiPriceFeed.deployed()
-      await satWeiPriceFeed.setValue(prices.satwei)
+      await deployer.deploy(ETHBTCPriceFeedMock)
+      const ethBtcPriceFeedMock = await ETHBTCPriceFeedMock.deployed()
+      await ethBtcPriceFeedMock.setValue(prices.satwei)
     }
 
     // On mainnet and Ropsten, we use the Summa-built, Keep-operated relay;

--- a/solidity/migrations/3_initialize.js
+++ b/solidity/migrations/3_initialize.js
@@ -1,7 +1,7 @@
 const TBTCSystem = artifacts.require("TBTCSystem")
 
 const SatWeiPriceFeed = artifacts.require("SatWeiPriceFeed")
-const MockSatWeiPriceFeed = artifacts.require("ETHBTCPriceFeedMock")
+const ETHBTCPriceFeedMock = artifacts.require("ETHBTCPriceFeedMock")
 
 const DepositFactory = artifacts.require("DepositFactory")
 const Deposit = artifacts.require("Deposit")
@@ -62,10 +62,10 @@ module.exports = async function(deployer, network) {
     await satWeiPriceFeed.initialize(tbtcSystem.address, RopstenETHBTCPriceFeed)
   } else {
     // Inject mock price feeds.
-    const mockSatWeiPriceFeed = await MockSatWeiPriceFeed.deployed()
+    const ethBtcPriceFeedMock = await ETHBTCPriceFeedMock.deployed()
     await satWeiPriceFeed.initialize(
       tbtcSystem.address,
-      mockSatWeiPriceFeed.address,
+      ethBtcPriceFeedMock.address,
     )
   }
 }

--- a/solidity/migrations/3_initialize.js
+++ b/solidity/migrations/3_initialize.js
@@ -58,8 +58,18 @@ module.exports = async function(deployer, network) {
     // Inject mainnet price feeds.
     await satWeiPriceFeed.initialize(tbtcSystem.address, ETHBTCMedianizer)
   } else if (network === "ropsten") {
-    // Inject medianizer intermediary.
-    await satWeiPriceFeed.initialize(tbtcSystem.address, RopstenETHBTCPriceFeed)
+    // Inject mock price feed as base.
+    const ethBtcPriceFeedMock = await ethBtcPriceFeedMock.deployed()
+    await satWeiPriceFeed.initialize(
+      tbtcSystem.address,
+      ethBtcPriceFeedMock.address,
+    )
+
+    // Add medianizer intermediary.
+    await satWeiPriceFeed.addEthBtcFeed(RopstenETHBTCPriceFeed)
+    // Disable mock feed so medianizer intermediary is active feed until we
+    // choose to muck with the price.
+    await ethBtcPriceFeedMock.setValue(0)
   } else {
     // Inject mock price feeds.
     const ethBtcPriceFeedMock = await ETHBTCPriceFeedMock.deployed()


### PR DESCRIPTION
We're gonna run some Ropsten price variation tests tomorrow, and to do that we have to be able to manipulate price. We inject a mock price feed before the Ropsten Maker medianizer and immediately disable it, letting the medianizer be the primary feed until we decide to set the mock's value to something for testing purposes.