### PR TITLE
Remove FRT holder check from distributeFeeRebate

### DIFF
--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -421,9 +421,6 @@ library DepositUtils {
     function distributeFeeRebate(Deposit storage _d) internal {
         address rebateTokenHolder = feeRebateTokenHolder(_d);
 
-        // We didn't escrow a rebate if the redeemer is also the Fee Rebate Token holder
-        if(_d.redeemerAddress == rebateTokenHolder) return;
-
         // pay out the rebate if it is available
         if(_d.tbtcToken.balanceOf(address(this)) >= signerFee(_d)) {
             _d.tbtcToken.transfer(rebateTokenHolder, signerFee(_d));

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -23,7 +23,9 @@ const prices = require("./prices")
 const SatWeiPriceFeed = artifacts.require("SatWeiPriceFeed")
 
 // Bitcoin difficulty relays.
-const OnDemandSPV = artifacts.require("@summa-tx/relay-sol/contracts/OnDemandSPV")
+const OnDemandSPV = artifacts.require(
+  "@summa-tx/relay-sol/contracts/OnDemandSPV",
+)
 const TestnetRelay = artifacts.require(
   "@summa-tx/relay-sol/contracts/TestnetRelay",
 )


### PR DESCRIPTION
Removing this check should be okay since distributing the fee rebate happens as the last value
transfer before an end-state.
This also means that calling distributeFeeRebate needs to be done more carefully.

The reason for this change was to allow for the funding script to correctly return the fee rebate even when `redeemerAddress == rebateTokenHolder.`