### PR TITLE
Phased Single Shot: Make factory update a single-shot time-delayed change

### DIFF
--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -200,11 +200,11 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     {
         require(
             _signerFeeDivisor > 9,
-            "Signer fee divisor must be greater than 9, for a signer fee that is <= 10%."
+            "Signer fee divisor must be greater than 9, for a signer fee that is <= 10%"
         );
         require(
             _signerFeeDivisor < 2000,
-            "Signer fee divisor must be less than 2000, for a signer fee that is > 0.05%."
+            "Signer fee divisor must be less than 2000, for a signer fee that is > 0.05%"
         );
 
         newSignerFeeDivisor = _signerFeeDivisor;

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -39,6 +39,12 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         uint16 _severelyUndercollateralizedThresholdPercent,
         uint256 _timestamp
     );
+    event KeepFactorySingleShotUpdateStarted(
+        address _factorySelector,
+        address _ethBackedFactory,
+        uint256 _timestamp
+    );
+
 
     event EthBtcPriceFeedAdded(address _priceFeed);
     event LotSizesUpdated(uint64[] _lotSizes);
@@ -49,13 +55,16 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         uint16 _undercollateralizedThresholdPercent,
         uint16 _severelyUndercollateralizedThresholdPercent
     );
-
+    event KeepFactorySingleShotUpdated(
+        address _factorySelector,
+        address _ethBackedFactory
+    );
 
     bool _initialized = false;
     uint256 pausedTimestamp;
     uint256 constant pausedDuration = 10 days;
 
-    ISatWeiPriceFeed public  priceFeed;
+    ISatWeiPriceFeed public priceFeed;
     IRelay public relay;
 
     KeepFactorySelection.Storage keepFactorySelection;
@@ -73,12 +82,15 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     uint256 private signerFeeDivisorChangeInitiated;
     uint256 private lotSizesChangeInitiated;
     uint256 private collateralizationThresholdsChangeInitiated;
+    uint256 private keepFactorySingleShotUpdateInitiated;
 
     uint16 private newSignerFeeDivisor;
     uint64[] newLotSizesSatoshis;
     uint16 private newInitialCollateralizedPercent;
     uint16 private newUndercollateralizedThresholdPercent;
     uint16 private newSeverelyUndercollateralizedThresholdPercent;
+    address private newFactorySelector;
+    address private newEthBackedFactory;
 
     // price feed
     uint256 priceFeedGovernanceTimeDelay = 90 days;
@@ -161,34 +173,6 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         return (block.timestamp.sub(pausedTimestamp) >= pausedDuration)?
             0:
             pausedDuration.sub(block.timestamp.sub(pausedTimestamp));
-    }
-
-    /// @notice Sets the address of the fully backed ECDSA keep factory.
-    /// TBTCSystem uses two factories: the default one - using KEEP stake and
-    /// another using ETH-stake. When ETH-stake (fully backed) factory is not
-    /// set, KEEP-stake factory is the default choice. When both factories are
-    /// set, as well as keep factory selection strategy, TBTCSystem load
-    /// balances between two factories based on the selection strategy choices.
-    /// @dev Can be called only one time!
-    /// @param _fullyBackedFactory Address of the ETH-stake-based factory.
-    function setFullyBackedKeepFactory(
-        address _fullyBackedFactory
-    ) external onlyOwner {
-        keepFactorySelection.setFullyBackedKeepFactory(_fullyBackedFactory);
-    }
-
-    /// @notice Sets the address of the keep factory selection strategy.
-    /// TBTCSystem uses two factories: the default one - using KEEP stake and
-    /// another using ETH-stake. When ETH-stake (fully backed) factory is not
-    /// set, KEEP-stake factory is the default choice. When both factories are
-    /// set, as well as keep factory selection strategy, TBTCSystem load
-    /// balances between two factories based on the selection strategy choices.
-    /// @dev Can be called only one time!
-    /// @param _factorySelector Address of the keep factory selection strategy.
-    function setKeepFactorySelector(
-        address _factorySelector
-    ) external onlyOwner {
-        keepFactorySelection.setKeepFactorySelector(_factorySelector);
     }
 
     /// @notice Set the system signer fee divisor.
@@ -283,6 +267,51 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         );
     }
 
+    /// @notice Sets the address of the ETH-only-backed ECDSA keep factory and
+    ///         the selection strategy that will choose between it and the
+    ///         default KEEP-backed factory for new deposits. When the
+    ///         ETH-only-backed factory and strategy are set, TBTCSystem load
+    ///         balances between two factories based on the selection strategy.
+    /// @dev It can be finalized by calling `finalizeKeepFactorySingleShotUpdate`
+    ///      any time after `governanceTimeDelay` has elapsed. This can be
+    ///      called more than once until finalized to reset the values and
+    ///      timer, but it can only be finalized once!
+    /// @param _factorySelector Address of the keep factory selection strategy.
+    /// @param _ethBackedFactory Address of the ETH-stake-based factory.
+    function beginKeepFactorySingleShotUpdate(
+        address _factorySelector,
+        address _ethBackedFactory
+    )
+        external onlyOwner
+    {
+        require(
+            // Either an update is in progress,
+            keepFactorySingleShotUpdateInitiated != 0 ||
+            // or we're trying to start a fresh one, in which case we must not
+            // have an already-finalized one (indicated by newEthBackedFactory
+            // being set).
+            newEthBackedFactory == address(0),
+            "Keep factory data can only be updated once"
+        );
+        require(
+            _factorySelector != address(0),
+            "Factory selector must be a nonzero address"
+        );
+        require(
+            _ethBackedFactory != address(0),
+            "ETH-backed factory must be a nonzero address"
+        );
+
+        newFactorySelector = _factorySelector;
+        newEthBackedFactory = _ethBackedFactory;
+        keepFactorySingleShotUpdateInitiated = block.timestamp;
+        emit KeepFactorySingleShotUpdateStarted(
+            _factorySelector,
+            _ethBackedFactory,
+            block.timestamp
+        );
+    }
+
     /// @notice Add a new ETH/BTC price feed contract to the priecFeed.
     /// @dev This can be finalized by calling `finalizeEthBtcPriceFeedAddition`
     ///      anytime after `priceFeedGovernanceTimeDelay` has elapsed.
@@ -363,6 +392,35 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         newUndercollateralizedThresholdPercent = 0;
         newSeverelyUndercollateralizedThresholdPercent = 0;
         collateralizationThresholdsChangeInitiated = 0;
+    }
+
+    /// @notice Finish setting the address of the ETH-only-backed ECDSA keep
+    ///         factory and the selection strategy that will choose between it
+    ///         and the default KEEP-backed factory for new deposits.
+    /// @dev `beginKeepFactorySingleShotUpdate` must be called first; once
+    ///      `governanceTimeDelay` has passed, this function can be called to
+    ///      set the collateralization thresholds to the value set in
+    ///      `beginKeepFactorySingleShotUpdate`.
+    function finalizeKeepFactorySingleShotUpdate()
+        external
+        onlyOwner
+        onlyAfterGovernanceDelay(
+            keepFactorySingleShotUpdateInitiated,
+            governanceTimeDelay
+        ) {
+
+        keepFactorySelection.setKeepFactorySelector(newFactorySelector);
+        keepFactorySelection.setFullyBackedKeepFactory(newEthBackedFactory);
+
+        emit KeepFactorySingleShotUpdated(
+            newFactorySelector,
+            newEthBackedFactory
+        );
+
+        keepFactorySingleShotUpdateInitiated = 0;
+        newFactorySelector = address(0);
+        // Keep newEthBackedFactory set as a marker that the update has already
+        // occurred.
     }
 
     /// @notice Finish adding a new price feed contract to the priceFeed.
@@ -467,6 +525,16 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     function getRemainingCollateralizationThresholdsUpdateTime() external view returns (uint256) {
         return getRemainingChangeTime(
             collateralizationThresholdsChangeInitiated,
+            governanceTimeDelay
+        );
+    }
+
+    /// @notice Get the time remaining until the Keep ETH-only-backed ECDSA keep
+    ///         factory and the selection strategy that will choose between it
+    ///         and the KEEP-backed factory can be updated.
+    function getRemainingKeepFactorySingleShotUpdateTime() external view returns (uint256) {
+        return getRemainingChangeTime(
+            keepFactorySingleShotUpdateInitiated,
             governanceTimeDelay
         );
     }

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -362,12 +362,12 @@ describe("TBTCSystem", async function() {
         "smaller than or equal to 9": {
           parameters: [9],
           error:
-            "Signer fee divisor must be greater than 9, for a signer fee that is <= 10%.",
+            "Signer fee divisor must be greater than 9, for a signer fee that is <= 10%",
         },
         "greater than or equal to 2000": {
           parameters: [2000],
           error:
-            "Signer fee divisor must be less than 2000, for a signer fee that is > 0.05%.",
+            "Signer fee divisor must be less than 2000, for a signer fee that is > 0.05%",
         },
       },
       verifyFinalization: async (receipt, setDivisor) => {
@@ -396,11 +396,11 @@ describe("TBTCSystem", async function() {
       badInitializationTests: {
         "array is empty": {
           parameters: [[]],
-          error: "Lot size array must always contain 1 BTC.",
+          error: "Lot size array must always contain 1 BTC",
         },
         "array does not contain a 1 BTC lot size": {
           parameters: [[10 ** 7]],
-          error: "Lot size array must always contain 1 BTC.",
+          error: "Lot size array must always contain 1 BTC",
         },
         "array contains a lot size < 0.0005 BTC": {
           parameters: [[10 ** 7, 10 ** 8, 5 * 10 ** 3 - 1]],
@@ -418,6 +418,7 @@ describe("TBTCSystem", async function() {
         lotSizes.forEach((_, i) => expect(_).to.eq.BN(setLotSizes[i]))
       },
     })
+
     governanceTest({
       property: "collateralization thresholds",
       change: "CollateralizationThresholdsUpdate",
@@ -432,11 +433,11 @@ describe("TBTCSystem", async function() {
       badInitializationTests: {
         "contain initial collateralized percent > 300": {
           parameters: [301, 130, 120],
-          error: "a",
+          error: "Initial collateralized percent must be <= 300%",
         },
         "contain initial collateralized percent < 100": {
           parameters: [99, 130, 120],
-          error: "b",
+          error: "Initial collateralized percent must be >= 100%",
         },
         "contain undercollateralized threshold > initial collateralized percent": {
           parameters: [150, 160, 120],


### PR DESCRIPTION
Exactly what it says, moving #610 to a two-phase time-delayed update. Also ensure it only happens once, while allowing a replacement of the upcoming change. That is, the change can be begun as many times as desired, but can only be finalized once. Once it's finalized, it cannot be begun again.