### PR TITLE
Locked Price Feed: Lock down Bitcoin price access

### DIFF
--- a/solidity/contracts/price-feed/SatWeiPriceFeed.sol
+++ b/solidity/contracts/price-feed/SatWeiPriceFeed.sol
@@ -38,7 +38,7 @@ contract SatWeiPriceFeed is Ownable, ISatWeiPriceFeed {
     /// @dev This does not account for any 'Flippening' event.
     /// @return The price of one satoshi in wei.
     function getPrice()
-        external view returns (uint256)
+        external onlyTbtcSystem view returns (uint256)
     {
         bool ethBtcActive;
         uint256 ethBtc;

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -483,10 +483,16 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     }
 
     /// @notice Get the price of one satoshi in wei.
-    /// @dev Reverts if the price of one satoshi is 0 wei, or
-    ///      if the price of one satoshi is 1 ether.
+    /// @dev Reverts if the price of one satoshi is 0 wei, or if the price of
+    ///      one satoshi is 1 ether. Can only be called by a deposit with minted
+    ///      TDT.
     /// @return The price of one satoshi in wei.
     function fetchBitcoinPrice() external view returns (uint256) {
+        require(
+            tbtcDepositToken.exists(uint256(msg.sender)),
+            "Caller must be a Deposit contract"
+        );
+
         uint256 price = priceFeed.getPrice();
         if (price == 0 || price > 10 ** 18) {
             // This is if a sat is worth 0 wei, or is worth >1 ether. Revert at

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -13,6 +13,7 @@ describe("TBTCSystem", async function() {
   let tbtcSystem
   let ecdsaKeepFactory
   let tdt
+  let satWeiPriceFeed
   let ethBtcMedianizer
   let badEthBtcMedianizer
   let newEthBtcMedianizer
@@ -39,10 +40,11 @@ describe("TBTCSystem", async function() {
     tbtcSystem = tbtcSystemStub
     ecdsaKeepFactory = ecdsaKeepFactoryStub
     tdt = tbtcDepositToken
+    satWeiPriceFeed = mockSatWeiPriceFeed
 
     ethBtcMedianizer = await MockMedianizer.new()
     await ethBtcMedianizer.setValue(100000000000)
-    mockSatWeiPriceFeed.initialize(tbtcSystem.address, ethBtcMedianizer.address)
+    satWeiPriceFeed.initialize(tbtcSystem.address, ethBtcMedianizer.address)
 
     badEthBtcMedianizer = await MockMedianizer.new()
     await badEthBtcMedianizer.setValue(0)
@@ -592,8 +594,8 @@ describe("TBTCSystem", async function() {
         await ethBtcMedianizer.setValue(0)
 
         // check new feed
-        expect(await tbtcSystem.fetchBitcoinPrice()).to.eq.BN(
-          new BN(10).pow(new BN(28)).div(new BN(NEW_PRICE_FEED_VALUE)),
+        expect(await satWeiPriceFeed.getWorkingEthBtcFeed()).to.equal(
+          newEthBtcMedianizer.address,
         )
 
         expectEvent(receipt, "EthBtcPriceFeedAdded", {


### PR DESCRIPTION
With the intent of using an access-controlled Maker feed, the price has
to be guarded in our contracts in turn.

Access control happens on `SatWeiPriceFeed` (which only allows `TBTCSystem`
to call `getPrice`) and on `TBTCSystem` (which only allows deposits to call
`fetchBitcoinPrice`).