### PR TITLE
How low can you go?

### DIFF
--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -62,7 +62,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
 
     // Parameters governed by the TBTCSystem owner
     bool private allowNewDeposits = false;
-    uint16 private signerFeeDivisor = 200; // 1/200 == 50bps == 0.5% == 0.005
+    uint16 private signerFeeDivisor = 2000; // 1/200 == 50bps == 0.5% == 0.005
     uint16 private initialCollateralizedPercent = 150; // percent
     uint16 private undercollateralizedThresholdPercent = 125;  // percent
     uint16 private severelyUndercollateralizedThresholdPercent = 110; // percent

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -62,7 +62,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
 
     // Parameters governed by the TBTCSystem owner
     bool private allowNewDeposits = false;
-    uint16 private signerFeeDivisor = 2000; // 1/200 == 50bps == 0.5% == 0.005
+    uint16 private signerFeeDivisor = 2000; // 1/2000 == 5bps == 0.05% == 0.0005
     uint16 private initialCollateralizedPercent = 150; // percent
     uint16 private undercollateralizedThresholdPercent = 125;  // percent
     uint16 private severelyUndercollateralizedThresholdPercent = 110; // percent

--- a/solidity/test/DepositUtilsTest.js
+++ b/solidity/test/DepositUtilsTest.js
@@ -499,7 +499,7 @@ describe("DepositUtils", async function() {
   describe("signerFee()", async () => {
     it("returns a derived constant", async () => {
       const signerFee = await testDeposit.signerFee.call()
-      expect(signerFee).to.eq.BN(5000000000000000)
+      expect(signerFee).to.eq.BN(500000000000000)
     })
   })
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/427505/81778568-1f1fd400-94c1-11ea-937e-56e800483923.png)

Set the initial signing fee to 5 bps by setting the signing fee divisor to 2000.

Keeping a low fee and subsidizing outside the core tBTC system will allow better bootstrapping of liquidity. After deployment, this will be the lowest fee rate the system ever charges, as the signing fee divisor update method doesn't allow a divisor of 2000 or greater.