### PR TITLE
Removed TestnetRelay import from TBTCSystem

### DIFF
--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -7,7 +7,6 @@ import {VendingMachine} from "./VendingMachine.sol";
 import {DepositFactory} from "../proxy/DepositFactory.sol";
 
 import {IRelay} from "@summa-tx/relay-sol/contracts/Relay.sol";
-import "@summa-tx/relay-sol/contracts/TestnetRelay.sol";
 import "../external/IMedianizer.sol";
 
 import {ITBTCSystem} from "../interfaces/ITBTCSystem.sol";


### PR DESCRIPTION
Removed import of `TestnetRelay` as it seems to be a leftover from development. We are not referring to this contract anymore. We use the `IRelay` interface defined in the `@summa-tx/relay-sol` package.