### PR TITLE
Check rebateTokenHolder value before sending rebate

### DIFF
--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -421,6 +421,11 @@ library DepositUtils {
     function distributeFeeRebate(Deposit storage _d) internal {
         address rebateTokenHolder = feeRebateTokenHolder(_d);
 
+        // exit the function if there is nobody to send the rebate to
+        if(rebateTokenHolder == address(0)){
+            return;
+        }
+
         // pay out the rebate if it is available
         if(_d.tbtcToken.balanceOf(address(this)) >= signerFee(_d)) {
             _d.tbtcToken.transfer(rebateTokenHolder, signerFee(_d));

--- a/solidity/contracts/test/system/TestFeeRebateToken.sol
+++ b/solidity/contracts/test/system/TestFeeRebateToken.sol
@@ -13,9 +13,17 @@ contract TestFeeRebateToken is FeeRebateToken {
     ///                  Mints a token and assigns it to an account.
     ///                  Uses the internal _mint function.
     /// @param _account  The account that will receive the token.
-    /// @param _tdtId    The tBTC Deposit Token ID. This is the Deposit address cast to a uint256.
-    function forceMint(address _account, uint256 _tdtId) public returns (bool) {
-        _mint(_account, _tdtId);
+    /// @param _frtId    The Fee Rebate Token ID.
+    function forceMint(address _account, uint256 _frtId) public returns (bool) {
+        _mint(_account, _frtId);
         return true;
+    }
+
+    /// @dev             Delete a feeRebateToken. This function is used to
+    ///                  to test cases where the existance of an FRT impacts test outcomes.
+    ///                  Must be called my the token owner.
+    /// @param _frtId    The Fee Rebate Token ID.
+    function burn(uint256 _frtId) public {
+        _burn(msg.sender, _frtId);
     }
 }

--- a/solidity/contracts/test/system/TestFeeRebateToken.sol
+++ b/solidity/contracts/test/system/TestFeeRebateToken.sol
@@ -20,7 +20,7 @@ contract TestFeeRebateToken is FeeRebateToken {
     }
 
     /// @dev             Delete a feeRebateToken. This function is used to
-    ///                  to test cases where the existance of an FRT impacts test outcomes.
+    ///                  test cases where the existence of an FRT impacts test outcomes.
     ///                  Must be called my the token owner.
     /// @param _frtId    The Fee Rebate Token ID.
     function burn(uint256 _frtId) public {

--- a/solidity/test/DepositUtilsTest.js
+++ b/solidity/test/DepositUtilsTest.js
@@ -770,6 +770,14 @@ describe("DepositUtils", async function() {
   })
 
   describe("distributeFeeRebate()", async () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
     it("checks that beneficiary is rewarded", async () => {
       // min an arbitrary reward value to the funding contract
       const reward = await testDeposit.signerFee.call()
@@ -785,6 +793,22 @@ describe("DepositUtils", async function() {
         finalTokenBalance,
         "tokens not rewarded to beneficiary correctly",
       ).to.eq.BN(tokenCheck)
+    })
+
+    it("does not revert if feeRebateToken does not exist and balance > signerFee", async () => {
+      feeRebateToken.burn(web3.utils.toBN(testDeposit.address), {
+        from: beneficiary,
+      })
+      // min an arbitrary reward value to the funding contract
+      const reward = await testDeposit.signerFee.call()
+      await tbtcToken.forceMint(testDeposit.address, reward)
+
+      const initialTokenBalance = await tbtcToken.balanceOf(beneficiary)
+
+      await testDeposit.distributeFeeRebate()
+
+      const finalTokenBalance = await tbtcToken.balanceOf(beneficiary)
+      expect(initialTokenBalance).to.eq.BN(finalTokenBalance)
     })
   })
 


### PR DESCRIPTION
if `rebateTokenHolder` is zero, do not attempt a value send as this will revert the transaction.