### PR TITLE
Final initial governance values

### DIFF
--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -186,8 +186,8 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             "Signer fee divisor must be greater than 9, for a signer fee that is <= 10%"
         );
         require(
-            _signerFeeDivisor < 2000,
-            "Signer fee divisor must be less than 2000, for a signer fee that is > 0.05%"
+            _signerFeeDivisor < 5000,
+            "Signer fee divisor must be less than 5000, for a signer fee that is > 0.02%"
         );
 
         newSignerFeeDivisor = _signerFeeDivisor;

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -76,7 +76,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     uint16 private severelyUndercollateralizedThresholdPercent = 110; // percent
     uint64[] lotSizesSatoshis = [10**5, 10**6, 10**7, 2 * 10**7, 5 * 10**7, 10**8]; // [0.001, 0.01, 0.1, 0.2, 0.5, 1.0] BTC
 
-    uint256 constant governanceTimeDelay = 6 hours;
+    uint256 constant governanceTimeDelay = 48 hours;
 
     uint256 private signerFeeDivisorChangeInitiated;
     uint256 private lotSizesChangeInitiated;

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -455,10 +455,10 @@ describe("TBTCSystem", async function() {
           error:
             "Signer fee divisor must be greater than 9, for a signer fee that is <= 10%",
         },
-        "greater than or equal to 2000": {
-          parameters: [2000],
+        "greater than or equal to 5000": {
+          parameters: [5000],
           error:
-            "Signer fee divisor must be less than 2000, for a signer fee that is > 0.05%",
+            "Signer fee divisor must be less than 5000, for a signer fee that is > 0.02%",
         },
       },
       verifyFinalization: async (receipt, setDivisor) => {


### PR DESCRIPTION
Two tweaks:
- Governance time delay goes from 6 hours to 48 hours.
- Signing fees are allowed as low as 2 basis points/0.02%.