### PR TITLE
Bcoin: Enable replace-by-fee

### DIFF
--- a/infrastructure/kube/keep-prd/bcoin-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/bcoin-statefulset.yaml
@@ -55,6 +55,8 @@ spec:
                 key: http-api-key
           - name: BCOIN_INDEX_TX
             value: 'true'
+          - name: BCOIN_REPLACE_BY_FEE
+            value: 'true'
         volumeMounts:
           - name: bcoin-data
             mountPath: /mnt/.bcoin

--- a/infrastructure/kube/keep-test/bcoin-statefulset.yaml
+++ b/infrastructure/kube/keep-test/bcoin-statefulset.yaml
@@ -54,6 +54,8 @@ spec:
                 key: http-api-key
           - name: BCOIN_INDEX_TX
             value: 'true'
+          - name: BCOIN_REPLACE_BY_FEE
+            value: 'true'
         volumeMounts:
           - name: bcoin-data
             mountPath: /mnt/.bcoin


### PR DESCRIPTION
Default settings reject replace-by-fee transactions from the mempool.  With tBTC we want to ack the pending tx ASAP.  Enabling replace-by-fee gets us there sooner in case the deposit tx is replace-by-fee'd.

This has been deployed to both keep-test and keep-prd.