### PR TITLE
Restraining Bolt: Limit the TBTC supply for the first 4 months

### DIFF
--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -55,7 +55,7 @@ library DepositFunding {
         uint16 _n,
         uint64 _lotSizeSatoshis
     ) public returns (bool) {
-        require(_d.tbtcSystem.getAllowNewDeposits(), "Opening new deposits is currently disabled.");
+        require(_d.tbtcSystem.getAllowNewDeposits(), "New deposits aren't allowed.");
         require(_d.inStart(), "Deposit setup already requested");
         require(_d.tbtcSystem.isAllowedLotSize(_lotSizeSatoshis), "provided lot size not supported");
 

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -156,35 +156,40 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             return false;
         }
 
-        uint256 age = block.timestamp - initializedTimestamp;
-
         uint256 supply = tbtcToken.totalSupply();
         uint256 bufferedSupply = supply.add(getMaxLotSize().mul(10 ** 10));
 
+        return bufferedSupply <= getMaxSupply() && allowNewDeposits;
+    }
+
+    // @notice get the maximum TBTC token supply in BTC * 10 ** 18
+    function getMaxSupply() public view returns (uint256) {
+        uint256 age = block.timestamp - initializedTimestamp;
+
         if(age < 1 days) {
-            return bufferedSupply < 2 * 10 ** 18;
+            return 2 * 10 ** 18;
         }
 
         if (age < 30 days) {
-            return bufferedSupply < 100 * 10 ** 18;
+            return 100 * 10 ** 18;
         }
 
         if (age < 60 days) {
-            return bufferedSupply < 250 * 10 ** 18;
+            return 250 * 10 ** 18;
         }
 
         if (age < 90 days) {
-            return bufferedSupply < 500 * 10 ** 18;
+            return 500 * 10 ** 18;
         }
 
         if (age < 120 days) {
-            return bufferedSupply < 1000 * 10 ** 18;
+            return 1000 * 10 ** 18;
         }
 
-        return allowNewDeposits;
+        return 21000000 * 10 ** 18;
     }
 
-    // @notice get the largest lot size currently enabled for deposits.
+    // @notice get the largest lot size currently enabled for deposits, in satoshis
     function getMaxLotSize() public view returns (uint256) {
         uint256 max = 0;
         for (uint i = 0; i<lotSizesSatoshis.length; i++) {

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -59,7 +59,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         address _ethBackedFactory
     );
 
-    bool _initialized = false;
+    uint256 initializedTimestamp = 0;
     uint256 pausedTimestamp;
     uint256 constant pausedDuration = 10 days;
 
@@ -123,7 +123,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         uint16 _keepThreshold,
         uint16 _keepSize
     ) external onlyOwner {
-        require(!_initialized, "already initialized");
+        require(initializedTimestamp == 0, "already initialized");
 
         keepFactorySelection.initialize(_defaultKeepFactory);
 
@@ -143,7 +143,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             _keepSize
         );
         setTbtcDepositToken(_tbtcDepositToken);
-        _initialized = true;
+        initializedTimestamp = block.timestamp;
         allowNewDeposits = true;
     }
 

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -153,10 +153,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     function getAllowNewDeposits() external view returns (bool) {
         if (!allowNewDeposits) { return false; }
 
-        uint256 supply = vendingMachine.getMintedSupply();
-        uint256 bufferedSupply = supply.add(getMaxLotSize().mul(10 ** 10));
-
-        return bufferedSupply <= vendingMachine.getMaxSupply();
+        return vendingMachine.canMint(getMaxLotSize().mul(10 ** 10));
     }
 
     // @notice get the largest lot size currently enabled for deposits, in satoshis

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -149,14 +149,17 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         allowNewDeposits = true;
     }
 
-    /// @notice returns whether new deposits should be allowed.
+    /// @notice Returns whether new deposits should be allowed.
+    /// @return True if new deposits should be allowed, both by the emergency pause button
+    ///         and respected the max supply schedule.
     function getAllowNewDeposits() external view returns (bool) {
         if (!allowNewDeposits) { return false; }
 
         return vendingMachine.canMint(getMaxLotSize().mul(10 ** 10));
     }
 
-    // @notice get the largest lot size currently enabled for deposits, in satoshis
+    /// @notice Return the largest lot size currently enabled for deposits.
+    /// @return The largest lot size, in satoshis.
     function getMaxLotSize() public view returns (uint256) {
         uint256 max = 0;
         for (uint i = 0; i<lotSizesSatoshis.length; i++) {

--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -29,7 +29,7 @@ contract VendingMachine is TBTCSystemAuthority{
     }
 
     /// @notice return the outstanding minted TBTC supply
-    function getMintedSupply() external view returns (uint256) {
+    function getMintedSupply() public view returns (uint256) {
         return tbtcToken.totalSupply();
     }
 
@@ -111,11 +111,13 @@ contract VendingMachine is TBTCSystemAuthority{
 
         tbtcDepositToken.transferFrom(msg.sender, address(this), _tdtId);
 
-        // If the backing Deposit does not have a signer fee in escrow, mint it.
         Deposit deposit = Deposit(address(uint160(_tdtId)));
         uint256 signerFee = deposit.signerFee();
         uint256 depositValue = deposit.lotSizeTbtc();
 
+        require(getMintedSupply() + depositValue < getMaxSupply(), "Can't mint more than the max supply cap");
+
+        // If the backing Deposit does not have a signer fee in escrow, mint it.
         if(tbtcToken.balanceOf(address(_tdtId)) < signerFee) {
             tbtcToken.mint(msg.sender, depositValue.sub(signerFee));
             tbtcToken.mint(address(_tdtId), signerFee);

--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -20,9 +20,46 @@ contract VendingMachine is TBTCSystemAuthority{
     TBTCDepositToken tbtcDepositToken;
     FeeRebateToken feeRebateToken;
 
+    uint256 createdAt;
+
     constructor(address _systemAddress)
         TBTCSystemAuthority(_systemAddress)
-    public {}
+    public {
+        createdAt = block.timestamp;
+    }
+
+    /// @notice return the outstanding minted TBTC supply
+    function getMintedSupply() external view returns (uint256) {
+        return tbtcToken.totalSupply();
+    }
+
+    /// @notice get the maximum TBTC token supply in BTC * 10 ** 18 based on the
+    /// age of the contract deployment
+    function getMaxSupply() public view returns (uint256) {
+        uint256 age = block.timestamp - createdAt;
+
+        if(age < 1 days) {
+            return 2 * 10 ** 18;
+        }
+
+        if (age < 30 days) {
+            return 100 * 10 ** 18;
+        }
+
+        if (age < 60 days) {
+            return 250 * 10 ** 18;
+        }
+
+        if (age < 90 days) {
+            return 500 * 10 ** 18;
+        }
+
+        if (age < 120 days) {
+            return 1000 * 10 ** 18;
+        }
+
+        return 21000000 * 10 ** 18;
+    }
 
     /// @notice Set external contracts needed by the Vending Machine.
     /// @dev    Addresses are used to update the local contract instance.

--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -115,7 +115,7 @@ contract VendingMachine is TBTCSystemAuthority{
         uint256 signerFee = deposit.signerFee();
         uint256 depositValue = deposit.lotSizeTbtc();
 
-        require(getMintedSupply() + depositValue < getMaxSupply(), "Can't mint more than the max supply cap");
+        require(canMint(depositValue), "Can't mint more than the max supply cap");
 
         // If the backing Deposit does not have a signer fee in escrow, mint it.
         if(tbtcToken.balanceOf(address(_tdtId)) < signerFee) {
@@ -130,6 +130,14 @@ contract VendingMachine is TBTCSystemAuthority{
         if(!feeRebateToken.exists(_tdtId)){
             feeRebateToken.mint(msg.sender, _tdtId);
         }
+    }
+
+    /// @notice Return whether an amount of TBTC can be minted according to the supply cap
+    ///         schedule
+    /// @dev This function is also used by TBTCSystem to decide whether to allow a new deposit.
+    /// @return True if the amount can be minted without hitting the max supply, false otherwise.
+    function canMint(uint256 amount) public view returns(bool) {
+        return getMintedSupply().add(amount) < getMaxSupply();
     }
 
     // WRAPPERS

--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -33,8 +33,12 @@ contract VendingMachine is TBTCSystemAuthority{
         return tbtcToken.totalSupply();
     }
 
-    /// @notice get the maximum TBTC token supply in BTC * 10 ** 18 based on the
-    /// age of the contract deployment
+    /// @notice Get the maximum TBTC token supply based on the age of the contract
+    ///         deployment. The supply cap starts at 2 BTC for the first day, 100 for
+    ///         the first 30 days, 250 for the next 30, 500 for the next 30, 1000 for
+    ///         the last 30... then finally removes the restriction, returning 21M BTC
+    ///         as a sanity check.
+    /// @return The max supply in weitoshis (BTC * 10 ** 18)
     function getMaxSupply() public view returns (uint256) {
         uint256 age = block.timestamp - createdAt;
 

--- a/solidity/test/DepositFactoryTest.js
+++ b/solidity/test/DepositFactoryTest.js
@@ -22,7 +22,7 @@ describe("DepositFactory", async function() {
     before(async () => {
       // To properly test createDeposit, we deploy the real Deposit contract and
       // make sure we don't get hit by the ACL hammer.
-      ;({depositFactory} = await deployAndLinkAll([], {
+      ({depositFactory} = await deployAndLinkAll([], {
         TestDeposit: Deposit,
       }))
     })

--- a/solidity/test/DepositFactoryTest.js
+++ b/solidity/test/DepositFactoryTest.js
@@ -22,7 +22,7 @@ describe("DepositFactory", async function() {
     before(async () => {
       // To properly test createDeposit, we deploy the real Deposit contract and
       // make sure we don't get hit by the ACL hammer.
-      ({depositFactory} = await deployAndLinkAll([], {
+      ;({depositFactory} = await deployAndLinkAll([], {
         TestDeposit: Deposit,
       }))
     })

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -157,7 +157,7 @@ describe("DepositFunding", async function() {
           1,
           fullBtc,
         ),
-        "Opening new deposits is currently disabled.",
+        "New deposits aren't allowed.",
       )
     })
 
@@ -189,7 +189,7 @@ describe("DepositFunding", async function() {
 
       await expectRevert(
         createNewDeposit(fullBtc),
-        "Opening new deposits is currently disabled.",
+        "New deposits aren't allowed.",
       )
 
       await increaseTime(15 * 24 * 60 * 60) // 15 days, into the 1st month
@@ -197,7 +197,7 @@ describe("DepositFunding", async function() {
       await mint(98 * fullBtc) // should new be at 100 BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
-        "Opening new deposits is currently disabled.",
+        "New deposits aren't allowed.",
       )
 
       await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 2nd month
@@ -205,7 +205,7 @@ describe("DepositFunding", async function() {
       await mint(150 * fullBtc) // should new be at 250 BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
-        "Opening new deposits is currently disabled.",
+        "New deposits aren't allowed.",
       )
 
       await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 3rd month
@@ -213,7 +213,7 @@ describe("DepositFunding", async function() {
       await mint(250 * fullBtc) // should new be at 500 BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
-        "Opening new deposits is currently disabled.",
+        "New deposits aren't allowed.",
       )
 
       await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 4th month
@@ -221,7 +221,7 @@ describe("DepositFunding", async function() {
       await mint(500 * fullBtc) // should new be at 1000 BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
-        "Opening new deposits is currently disabled.",
+        "New deposits aren't allowed.",
       )
 
       await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 5th month
@@ -229,7 +229,7 @@ describe("DepositFunding", async function() {
       await mint("2099900000000000") // should new be at 21M BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
-        "Opening new deposits is currently disabled.",
+        "New deposits aren't allowed.",
       )
     })
   })

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -388,13 +388,6 @@ describe("TBTCSystem", async function() {
       await restoreSnapshot()
     })
 
-    it("pauses new deposit creation", async () => {
-      await tbtcSystem.emergencyPauseNewDeposits()
-
-      const allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
-      expect(allowNewDeposits).to.equal(false)
-    })
-
     it("does not revert if beginKeepFactorySingleShotUpdate has already been called", async () => {
       await tbtcSystem.beginKeepFactorySingleShotUpdate(
         "0x0000000000000000000000000000000000000001",

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -9,10 +9,6 @@ const TBTCSystem = contract.fromArtifact("TBTCSystem")
 const SatWeiPriceFeed = contract.fromArtifact("SatWeiPriceFeed")
 const MockMedianizer = contract.fromArtifact("MockMedianizer")
 
-function btcToBTC18(n) {
-  return new BN(10).pow(new BN(18)).mul(new BN(n))
-}
-
 describe("TBTCSystem", async function() {
   let tbtcSystem
   let ecdsaKeepFactory
@@ -321,85 +317,6 @@ describe("TBTCSystem", async function() {
       })
     })
   }
-
-  describe("getMaxSupply", async () => {
-    beforeEach(async () => {
-      await createSnapshot()
-    })
-
-    afterEach(async () => {
-      await restoreSnapshot()
-    })
-
-    it("has a max supply of 2 on the first day", async () => {
-      let maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(2))
-
-      await increaseTime(23.5 * 60 * 60) // 23.5 hours
-
-      maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(2))
-
-      await increaseTime(60 * 60) // 1 hour
-
-      maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.not.eq.BN(btcToBTC18(2))
-    })
-
-    it("has a max supply of 100 BTC between the first day and 30th day", async () => {
-      await increaseTime(24 * 60 * 60 + 1) // 1 day and 1 second
-      let maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(100))
-
-      await increaseTime(15 * 24 * 60 * 60) // 15 days
-      maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(100))
-
-      await increaseTime(14 * 24 * 60 * 60 - 10 * 600) // 14 days minus 10 minutes
-      maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(100))
-    })
-
-    it("has a max supply of 250 BTC between the 30th day and 60th day", async () => {
-      await increaseTime(30 * 24 * 60 * 60 + 1) // 30 days and 1 second
-      let maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(250))
-
-      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
-      maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(250))
-    })
-
-    it("has a max supply of 500 BTC between the 60th day and 90th day", async () => {
-      await increaseTime(60 * 24 * 60 * 60 + 1) // 60 days and 1 second
-      let maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(500))
-
-      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
-      maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(500))
-    })
-
-    it("has a max supply of 1000 BTC between the 90th day and 120th day", async () => {
-      await increaseTime(90 * 24 * 60 * 60 + 1) // 90 days and 1 second
-      let maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(1000))
-
-      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
-      maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(1000))
-    })
-
-    it("has a max supply of 21M BTC after the 120th day", async () => {
-      await increaseTime(120 * 24 * 60 * 60 + 1) // 120 days and 1 second
-      let maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(21000000))
-
-      await increaseTime(30 * 24 * 60 * 60) // 30 days
-      maxSupply = await tbtcSystem.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToBTC18(21000000))
-    })
-  })
 
   describe("emergencyPauseNewDeposits", async () => {
     let term

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -330,17 +330,45 @@ describe("TBTCSystem", async function() {
     })
 
     it("pauses new deposit creation", async () => {
+      let allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
+      expect(allowNewDeposits).to.equal(true)
+
       await tbtcSystem.emergencyPauseNewDeposits()
 
-      const allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
+      allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
       expect(allowNewDeposits).to.equal(false)
     })
 
-    it("pauses new deposit creation after the 1-day grace period", async () => {
+    it("pauses new deposit creation a day out", async () => {
+      let allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
+      expect(allowNewDeposits).to.equal(true)
+
       await increaseTime(24 * 60 * 60 + 1)
       await tbtcSystem.emergencyPauseNewDeposits()
 
-      const allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
+      allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
+      expect(allowNewDeposits).to.equal(false)
+    })
+
+    it("pauses new deposit creation 31 days out", async () => {
+      let allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
+      expect(allowNewDeposits).to.equal(true)
+
+      await increaseTime(31 * 24 * 60 * 60 + 1)
+      await tbtcSystem.emergencyPauseNewDeposits()
+
+      allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
+      expect(allowNewDeposits).to.equal(false)
+    })
+
+    it("pauses new deposit creation 61 days out", async () => {
+      let allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
+      expect(allowNewDeposits).to.equal(true)
+
+      await increaseTime(61 * 24 * 60 * 60 + 1)
+      await tbtcSystem.emergencyPauseNewDeposits()
+
+      allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
       expect(allowNewDeposits).to.equal(false)
     })
 

--- a/solidity/test/VendingMachineTest.js
+++ b/solidity/test/VendingMachineTest.js
@@ -1,5 +1,5 @@
 const {deployAndLinkAll} = require("./helpers/testDeployer.js")
-const {states, fundingTx} = require("./helpers/utils.js")
+const {increaseTime, states, fundingTx} = require("./helpers/utils.js")
 const {AssertBalance} = require("./helpers/assertBalance.js")
 const {createSnapshot, restoreSnapshot} = require("./helpers/snapshot.js")
 const {accounts, web3} = require("@openzeppelin/test-environment")
@@ -7,6 +7,10 @@ const [owner] = accounts
 const {BN, constants, expectRevert} = require("@openzeppelin/test-helpers")
 const {ZERO_ADDRESS} = constants
 const {expect} = require("chai")
+
+function btcToTbtc(n) {
+  return new BN(10).pow(new BN(18)).mul(new BN(n))
+}
 
 describe("VendingMachine", async function() {
   let vendingMachine
@@ -624,6 +628,85 @@ describe("VendingMachine", async function() {
         ),
         "Bad _extraData signature. Call must be to unqualifiedDepositToTbtc.",
       )
+    })
+  })
+
+  describe("getMaxSupply", async () => {
+    beforeEach(async () => {
+      await createSnapshot()
+    })
+
+    afterEach(async () => {
+      await restoreSnapshot()
+    })
+
+    it("has a max supply of 2 on the first day", async () => {
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(2))
+
+      await increaseTime(23.5 * 60 * 60) // 23.5 hours
+
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(2))
+
+      await increaseTime(60 * 60) // 1 hour
+
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(2))
+    })
+
+    it("has a max supply of 100 BTC between the first day and 30th day", async () => {
+      await increaseTime(24 * 60 * 60 + 1) // 1 day and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(100))
+
+      await increaseTime(15 * 24 * 60 * 60) // 15 days
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(100))
+
+      await increaseTime(14 * 24 * 60 * 60 - 10 * 600) // 14 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(100))
+    })
+
+    it("has a max supply of 250 BTC between the 30th day and 60th day", async () => {
+      await increaseTime(30 * 24 * 60 * 60 + 1) // 30 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(250))
+
+      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(250))
+    })
+
+    it("has a max supply of 500 BTC between the 60th day and 90th day", async () => {
+      await increaseTime(60 * 24 * 60 * 60 + 1) // 60 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(500))
+
+      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(500))
+    })
+
+    it("has a max supply of 1000 BTC between the 90th day and 120th day", async () => {
+      await increaseTime(90 * 24 * 60 * 60 + 1) // 90 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(1000))
+
+      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(1000))
+    })
+
+    it("has a max supply of 21M BTC after the 120th day", async () => {
+      await increaseTime(120 * 24 * 60 * 60 + 1) // 120 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(21000000))
+
+      await increaseTime(30 * 24 * 60 * 60) // 30 days
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(21000000))
     })
   })
 })

--- a/solidity/test/VendingMachineTest.js
+++ b/solidity/test/VendingMachineTest.js
@@ -697,13 +697,13 @@ describe("VendingMachine", async function() {
       let maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(100))
 
-      await increaseTime(15 * 24 * 60 * 60) // 15 days
+      await increaseTime(29 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
       maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(100))
 
-      await increaseTime(14 * 24 * 60 * 60 - 10 * 600) // 14 days minus 10 minutes
+      await increaseTime(1 * 60 * 60) // one hour
       maxSupply = await vendingMachine.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToTbtc(100))
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(100))
     })
 
     it("has a max supply of 250 BTC between the 30th day and 60th day", async () => {
@@ -714,6 +714,10 @@ describe("VendingMachine", async function() {
       await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
       maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(250))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(250))
     })
 
     it("has a max supply of 500 BTC between the 60th day and 90th day", async () => {
@@ -724,6 +728,10 @@ describe("VendingMachine", async function() {
       await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
       maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(500))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(500))
     })
 
     it("has a max supply of 1000 BTC between the 90th day and 120th day", async () => {
@@ -734,6 +742,10 @@ describe("VendingMachine", async function() {
       await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
       maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(1000))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(1000))
     })
 
     it("has a max supply of 21M BTC after the 120th day", async () => {

--- a/solidity/test/states/run.js
+++ b/solidity/test/states/run.js
@@ -188,7 +188,7 @@ const StateRunner = {
      * @param {Promise<object>} baseStatePromise Promise to the base state for
      *        these tessts, after any prior state transitions.
      * @param {StateDefinition<BaseState>} stateDefinition
-     * 
+     *
      * @return {Promise<void>} A promise to the completion of the tests set up
      *         by this function. It will be resolved after tests have finished
      *         running, and allows the chaining of future state tests.
@@ -347,7 +347,7 @@ const StateRunner = {
      * @param {object} baseState
      * @param {string} firstStateName
      * @param {...string} path
-     * 
+     *
      * @return {Promise<void>} A promise to the full completion of all tests
      *         in the state path.
      */


### PR DESCRIPTION
> [Restraining bolts](https://starwars.fandom.com/wiki/Restraining_bolt) were small, cylindrical devices that could be affixed to a droid in order to limit its functions and enforce its obedience.

-- [Wookipedia](https://starwars.fandom.com/wiki/Restraining_bolt)

Limit the TBTC supply to the following schedule, as well as adding a 1-day "grace period" to allow signers to ramp up.

| Month | Cap (BTC) |
| ----- | --------- |
| 1     | 100       |
| 2     | 250       |
| 3     | 500       |
| 4     | 1000      |
| 5+    | 21M       |

This approach limits the fungible supply cap, but doesn't prevent an unlimited number of deposits, so long as the TDTs are held. Restricted deposits based on TDTs would be more robust to circumvention, but the complexity costs more than the assurance, IMO.

I ended up storing the `TBTCToken` contract reference directly on `TBTCSystem`. Open to refactoring if anyone has an issue with that.