### PR TITLE
Renaming of notifyUndercollateralizedLiquidation

### DIFF
--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -425,10 +425,10 @@ contract Deposit is DepositFactoryAuthority {
         self.exitCourtesyCall();
     }
 
-    /// @notice     Notify the contract that the signers are undercollateralized.
+    /// @notice     Notify the contract that the signers are severely undercollateralized.
     /// @dev        Calls out to the system for oracle info.
-    function notifyUndercollateralizedLiquidation() public {
-        self.notifyUndercollateralizedLiquidation();
+    function notifySevereUndercollateralizedLiquidation() public {
+        self.notifySevereUndercollateralizedLiquidation();
     }
 
     /// @notice     Notifies the contract that the courtesy period has elapsed.

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -202,10 +202,10 @@ library DepositLiquidation {
         _d.logExitedCourtesyCall();
     }
 
-    /// @notice     Notify the contract that the signers are undercollateralized.
+    /// @notice     Notify the contract that the signers are severely undercollateralized.
     /// @dev        Calls out to the system for oracle info.
     /// @param  _d  Deposit storage pointer.
-    function notifyUndercollateralizedLiquidation(DepositUtils.Deposit storage _d) public {
+    function notifySevereUndercollateralizedLiquidation(DepositUtils.Deposit storage _d) public {
         require(_d.inRedeemableState(), "Deposit not in active or courtesy call");
         require(getCollateralizationPercentage(_d) < _d.severelyUndercollateralizedThresholdPercent, "Deposit has sufficient collateral");
         startLiquidation(_d, false);


### PR DESCRIPTION
The function `notifyUndercollateralizedLiquidation` can initially create confusion as it's actually callable when the Deposit is **severely** undercollateralized.

My proposition is to rename it from `notifyUndercollateralizedLiquidation` to `notifySevereUndercollateralizedLiquidation`.