### PR TITLE
Enforce receiveApproval caller is associated token

### DIFF
--- a/solidity/contracts/scripts/FundingScript.sol
+++ b/solidity/contracts/scripts/FundingScript.sol
@@ -34,6 +34,8 @@ contract FundingScript {
     /// @param _tokenId Approved TDT for the transfer.
     /// @param _extraData Encoded function call to `VendingMachine.unqualifiedDepositToTbtc`.
     function receiveApproval(address _from, uint256 _tokenId, address, bytes memory _extraData) public {
+        require(msg.sender == address(tbtcDepositToken), "Only token contract can call receiveApproval");
+
         tbtcDepositToken.transferFrom(_from, address(this), _tokenId);
         tbtcDepositToken.approve(address(vendingMachine), _tokenId);
 

--- a/solidity/contracts/scripts/RedemptionScript.sol
+++ b/solidity/contracts/scripts/RedemptionScript.sol
@@ -35,6 +35,8 @@ contract RedemptionScript {
     /// @param _amount Approved TBTC amount for the transfer.
     /// @param _extraData Encoded function call to `VendingMachine.tbtcToBtc`.
     function receiveApproval(address _from, uint256 _amount, address, bytes memory _extraData) public {
+        require(msg.sender == address(tbtcToken), "Only token contract can call receiveApproval");
+
         tbtcToken.transferFrom(_from, address(this), _amount);
         tbtcToken.approve(address(vendingMachine), _amount);
 

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -153,7 +153,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @return True if new deposits should be allowed, both by the emergency pause button
     ///         and respected the max supply schedule.
     function getAllowNewDeposits() external view returns (bool) {
-        if (!allowNewDeposits) { return false; }
+        if (!allowNewDeposits) {return false;}
 
         return vendingMachine.canMint(getMaxLotSize().mul(10 ** 10));
     }

--- a/solidity/test/VendingMachineTest.js
+++ b/solidity/test/VendingMachineTest.js
@@ -527,20 +527,12 @@ describe("VendingMachine", async function() {
       })
 
       it("protects receiveApproval from external callers", async () => {
-        const tbtcToBtc = vendingMachine.abi.find(x => x.name == "tbtcToBtc")
-        const calldata = web3.eth.abi.encodeFunctionCall(tbtcToBtc, [
-          testDeposit.address,
-          "0x1111111100000000",
-          redeemerOutputScript,
-          owner,
-        ])
-
         await expectRevert(
           redemptionScript.receiveApproval(
             redemptionScript.address,
             tdtId,
             owner,
-            calldata,
+            "0x00",
             {from: owner},
           ),
           "Only token contract can call receiveApproval",

--- a/solidity/test/VendingMachineTest.js
+++ b/solidity/test/VendingMachineTest.js
@@ -435,9 +435,7 @@ describe("VendingMachine", async function() {
 
         await testDeposit.setSigningGroupPublicKey(keepPubkeyX, keepPubkeyY)
 
-        const tbtcToBtc = vendingMachine.abi.filter(
-          x => x.name == "tbtcToBtc",
-        )[0]
+        const tbtcToBtc = vendingMachine.abi.find(x => x.name == "tbtcToBtc")
         const calldata = web3.eth.abi.encodeFunctionCall(tbtcToBtc, [
           testDeposit.address,
           "0x1111111100000000",
@@ -470,9 +468,7 @@ describe("VendingMachine", async function() {
         await tbtcDepositToken.forceMint(vendingMachine.address, tdtId)
         await tbtcToken.forceMint(owner, depositValue.add(signerFee))
         await feeRebateToken.forceMint(owner, tdtId)
-        const tbtcToBtc = vendingMachine.abi.filter(
-          x => x.name == "tbtcToBtc",
-        )[0]
+        const tbtcToBtc = vendingMachine.abi.find(x => x.name == "tbtcToBtc")
         const calldata = web3.eth.abi.encodeFunctionCall(tbtcToBtc, [
           testDeposit.address,
           "0x1111111100000000",
@@ -495,9 +491,7 @@ describe("VendingMachine", async function() {
         await tbtcDepositToken.forceMint(vendingMachine.address, tdtId)
         await tbtcToken.forceMint(owner, depositValue.add(signerFee))
         await feeRebateToken.forceMint(owner, tdtId)
-        const tbtcToBtc = vendingMachine.abi.filter(
-          x => x.name == "tbtcToBtc",
-        )[0]
+        const tbtcToBtc = vendingMachine.abi.find(x => x.name == "tbtcToBtc")
         const nonexistentDeposit = "0000000000000000000000000000000000000000"
         const calldata = web3.eth.abi.encodeFunctionCall(tbtcToBtc, [
           nonexistentDeposit,
@@ -533,9 +527,7 @@ describe("VendingMachine", async function() {
       })
 
       it("protects receiveApproval from external callers", async () => {
-        const tbtcToBtc = vendingMachine.abi.filter(
-          x => x.name == "tbtcToBtc",
-        )[0]
+        const tbtcToBtc = vendingMachine.abi.find(x => x.name == "tbtcToBtc")
         const calldata = web3.eth.abi.encodeFunctionCall(tbtcToBtc, [
           testDeposit.address,
           "0x1111111100000000",
@@ -578,9 +570,9 @@ describe("VendingMachine", async function() {
     })
 
     it("calls unqualifiedDepositToTbtcABI", async () => {
-      const unqualifiedDepositToTbtcABI = vendingMachine.abi.filter(
+      const unqualifiedDepositToTbtcABI = vendingMachine.abi.find(
         x => x.name == "unqualifiedDepositToTbtc",
-      )[0]
+      )
       const calldata = web3.eth.abi.encodeFunctionCall(
         unqualifiedDepositToTbtcABI,
         [
@@ -615,9 +607,9 @@ describe("VendingMachine", async function() {
     })
 
     it("returns true on success", async () => {
-      const unqualifiedDepositToTbtcABI = vendingMachine.abi.filter(
+      const unqualifiedDepositToTbtcABI = vendingMachine.abi.find(
         x => x.name == "unqualifiedDepositToTbtc",
-      )[0]
+      )
       const calldata = web3.eth.abi.encodeFunctionCall(
         unqualifiedDepositToTbtcABI,
         [
@@ -644,9 +636,9 @@ describe("VendingMachine", async function() {
     })
 
     it("forwards nested revert error messages", async () => {
-      const unqualifiedDepositToTbtcABI = vendingMachine.abi.filter(
+      const unqualifiedDepositToTbtcABI = vendingMachine.abi.find(
         x => x.name == "unqualifiedDepositToTbtc",
-      )[0]
+      )
       const calldata = web3.eth.abi.encodeFunctionCall(
         unqualifiedDepositToTbtcABI,
         [
@@ -691,9 +683,9 @@ describe("VendingMachine", async function() {
     })
 
     it("protects receiveApproval from external callers", async () => {
-      const unqualifiedDepositToTbtcABI = vendingMachine.abi.filter(
+      const unqualifiedDepositToTbtcABI = vendingMachine.abi.find(
         x => x.name == "unqualifiedDepositToTbtc",
-      )[0]
+      )
       const calldata = web3.eth.abi.encodeFunctionCall(
         unqualifiedDepositToTbtcABI,
         [


### PR DESCRIPTION
Token holders can approve “infinitely”, which is to say they can approve a spender
to spend on their behalf for a balance greater than their current amount. In these
cases, that approval continues to apply when they gain a later balance. Some users
use this function to reduce the number of approval transactions they have to
perform.

If that is used in conjunction with the `RedemptionScript`, a third party can call
`RedemptionScript`'s `receiveApproval` directly to redeem another user's inifinitely
approved TBTC. To guard against this, this PR restricts `receiveApproval` caller to
only be the token handling approval.

Closes #670.