### PR TITLE
Fix fee bump

### DIFF
--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -229,7 +229,7 @@ library DepositRedemption {
         require(block.timestamp >= _d.withdrawalRequestTime.add(TBTCConstants.getIncreaseFeeTimer()), "Fee increase not yet permitted");
 
         uint256 _newOutputValue = checkRelationshipToPrevious(_d, _previousOutputValueBytes, _newOutputValueBytes);
-        _d.latestRedemptionFee = _newOutputValue;
+        _d.latestRedemptionFee = _d.utxoSize().sub(_newOutputValue);
         // Calculate the next sighash
         bytes32 _sighash = CheckBitcoinSigs.wpkhSpendSighash(
             _d.utxoOutpoint,

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -163,6 +163,10 @@ contract TestDeposit is Deposit {
         self.latestRedemptionFee = _latestRedemptionFee;
     }
 
+    function getLatestRedemptionFee() public returns (uint256) {
+        return self.latestRedemptionFee;
+    }
+
     function setRedeemerAddress(
         address payable _redeemerAddress
     ) public {

--- a/solidity/test/DepositRedemptionTest.js
+++ b/solidity/test/DepositRedemptionTest.js
@@ -916,16 +916,17 @@ describe("DepositRedemption", async function() {
       )
     })
 
-    it("approves a new digest for signing, updates the state, and logs RedemptionRequested", async () => {
+    it("correctly increases fee, approves a new digest for signing, updates the state, and logs RedemptionRequested", async () => {
       const blockNumber = await web3.eth.getBlockNumber()
       await testDeposit.increaseRedemptionFee(
         previousOutputBytes,
         newOutputBytes,
       )
-
       const requestInfo = await testDeposit.getRequestInfo.call()
       expect(requestInfo[4]).to.equal(nextSighash)
 
+      const updatedFee = await testDeposit.getLatestRedemptionFee.call()
+      expect(updatedFee).to.eq.BN(new BN(initialFee).mul(new BN(2)))
       // fired an event
       const eventList = await tbtcSystemStub.getPastEvents(
         "RedemptionRequested",

--- a/solidity/test/DepositRedemptionTest.js
+++ b/solidity/test/DepositRedemptionTest.js
@@ -1114,6 +1114,23 @@ describe("DepositRedemption", async function() {
         "Tx merkle proof is not valid for provided header",
       )
     })
+
+    it("reverts if a higher fee is sent", async () => {
+      const currentFee = await testDeposit.getLatestRedemptionFee.call()
+      await testDeposit.setLatestRedemptionFee(currentFee.sub(new BN(1)))
+      await expectRevert(
+        testDeposit.provideRedemptionProof(
+          fundingTx.version,
+          fundingTx.txInputVector,
+          fundingTx.txOutputVector,
+          fundingTx.txLocktime,
+          fundingTx.merkleProof,
+          fundingTx.txIndexInBlock,
+          fundingTx.bitcoinHeaders,
+        ),
+        "Incorrect fee amount",
+      )
+    })
   })
 
   describe("redemptionTransactionChecks", async () => {


### PR DESCRIPTION
closes: #652 

`latestRedemptionFee` was assigned the value sent to the user instead of the updated redemption fee after the bump. This could lead to some possible attack vectors described in the linked issue. 