### PR TITLE
Suspicious Factory: Add validation for KeepFactorySelection refreshes

### DIFF
--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -114,6 +114,12 @@ library KeepFactorySelection {
             _self.keepStakeFactory,
             _self.ethStakeFactory
         );
+
+        require(
+            _self.selectedFactory == _self.keepStakeFactory ||
+                _self.selectedFactory == _self.ethStakeFactory,
+            "Factory selector returned unknown factory"
+        );
     }
 
     /// @notice Sets the address of the fully backed, ETH-stake based keep

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -32,17 +32,28 @@ contract KeepFactorySelectionStub {
 contract KeepFactorySelectorStub is KeepFactorySelector {
 
     bool internal defaultMode = true;
+    bool internal maliciousMode = false;
 
     function selectFactory(
         uint256 _seed,
         IBondedECDSAKeepFactory _defaultFactory,
         IBondedECDSAKeepFactory _fullyBackedFactory
     ) external view returns (IBondedECDSAKeepFactory) {
-        if (defaultMode) {
+        if (maliciousMode) {
+            return IBondedECDSAKeepFactory(0xaFacEbadfAceCffeeFaceacebacEAfAceCfFEeA0);
+        } else if (defaultMode) {
             return _defaultFactory;
         } else {
             return _fullyBackedFactory;
         }
+    }
+
+    function setMaliciousMode() public {
+        maliciousMode = true;
+    }
+
+    function unsetMaliciousMode() public {
+        maliciousMode = false;
     }
 
     function setDefaultMode() public {

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -195,6 +195,23 @@ describe("KeepFactorySelection", async () => {
         keepStakeFactory.address,
       )
     })
+
+    it("reverts if the returned factory is not one of the set factories", async () => {
+      await keepFactorySelection.setFullyBackedKeepFactory(
+        ethStakeFactory.address,
+      )
+      await keepFactorySelection.setKeepFactorySelector(
+        keepFactorySelector.address,
+      )
+
+      await keepFactorySelector.setMaliciousMode()
+
+      // refresh the choice; it should be the default factory now
+      await expectRevert(
+        keepFactorySelection.selectFactoryAndRefresh(),
+        "Factory selector returned unknown factory",
+      )
+    })
   })
 
   describe("setFullyBackedKeepFactory", async () => {


### PR DESCRIPTION
Refreshes did not validate that the updated factory was one of the two
possible factories enumerated by KeepFactorySelection. That requirement
is now in place, validating that the set factory selector can only
return one of the two factories it receives.

Fixes #649.