### PR TITLE
What is time? Adjust the emergency pause and supply cap schedules

### DIFF
--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -173,8 +173,8 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @notice One-time-use emergency function to disallow future deposit creation for 10 days.
     function emergencyPauseNewDeposits() external onlyOwner {
         require(pausedTimestamp == 0, "emergencyPauseNewDeposits can only be called once");
-        uint256 diff = block.timestamp - initializedTimestamp;
-        require(diff < 365 days, "emergencyPauseNewDeposits can only be called within 365 days of initialization");
+        uint256 sinceInit = block.timestamp - initializedTimestamp;
+        require(sinceInit < 180 days, "emergencyPauseNewDeposits can only be called within 180 days of initialization");
         pausedTimestamp = block.timestamp;
         allowNewDeposits = false;
         emit AllowNewDepositsUpdated(false);

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -153,9 +153,8 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @return True if new deposits should be allowed, both by the emergency pause button
     ///         and respected the max supply schedule.
     function getAllowNewDeposits() external view returns (bool) {
-        if (!allowNewDeposits) {return false;}
-
-        return vendingMachine.canMint(getMaxLotSize().mul(10 ** 10));
+        return allowNewDeposits &&
+            vendingMachine.canMint(getMaxLotSize().mul(10 ** 10));
     }
 
     /// @notice Return the largest lot size currently enabled for deposits.

--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -35,7 +35,7 @@ contract VendingMachine is TBTCSystemAuthority{
 
     /// @notice Get the maximum TBTC token supply based on the age of the contract
     ///         deployment. The supply cap starts at 2 BTC for the first day, 100 for
-    ///         the first 30 days, 250 for the next 30, 500 for the kast 30... then
+    ///         the first 30 days, 250 for the next 30, 500 for the last 30... then
     ///         finally removes the restriction, returning 21M BTC as a sanity check.
     /// @return The max supply in weitoshis (BTC * 10 ** 18)
     function getMaxSupply() public view returns (uint256) {

--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -28,16 +28,15 @@ contract VendingMachine is TBTCSystemAuthority{
         createdAt = block.timestamp;
     }
 
-    /// @notice return the outstanding minted TBTC supply
+    /// @notice Return the minted TBTC supply in weitoshis (BTC * 10 ** 18)
     function getMintedSupply() public view returns (uint256) {
         return tbtcToken.totalSupply();
     }
 
     /// @notice Get the maximum TBTC token supply based on the age of the contract
     ///         deployment. The supply cap starts at 2 BTC for the first day, 100 for
-    ///         the first 30 days, 250 for the next 30, 500 for the next 30, 1000 for
-    ///         the last 30... then finally removes the restriction, returning 21M BTC
-    ///         as a sanity check.
+    ///         the first 30 days, 250 for the next 30, 500 for the kast 30... then
+    ///         finally removes the restriction, returning 21M BTC as a sanity check.
     /// @return The max supply in weitoshis (BTC * 10 ** 18)
     function getMaxSupply() public view returns (uint256) {
         uint256 age = block.timestamp - createdAt;
@@ -56,10 +55,6 @@ contract VendingMachine is TBTCSystemAuthority{
 
         if (age < 90 days) {
             return 500 * 10 ** 18;
-        }
-
-        if (age < 120 days) {
-            return 1000 * 10 ** 18;
         }
 
         return 21000000 * 10 ** 18;

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -225,7 +225,7 @@ describe("DepositFunding", async function() {
 
       await increaseTime(15 * 24 * 60 * 60) // 15 days, into the 1st month
       await createNewDeposit(fullBtc)
-      await mint(98 * fullBtc) // should new be at 100 BTC - 1000 sats
+      await mint(98 * fullBtc) // should now be at 100 BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
         "New deposits aren't allowed.",
@@ -233,7 +233,7 @@ describe("DepositFunding", async function() {
 
       await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 2nd month
       await createNewDeposit(fullBtc)
-      await mint(150 * fullBtc) // should new be at 250 BTC - 1000 sats
+      await mint(150 * fullBtc) // should now be at 250 BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
         "New deposits aren't allowed.",
@@ -241,7 +241,7 @@ describe("DepositFunding", async function() {
 
       await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 3rd month
       await createNewDeposit(fullBtc)
-      await mint(250 * fullBtc) // should new be at 500 BTC - 1000 sats
+      await mint(250 * fullBtc) // should now be at 500 BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
         "New deposits aren't allowed.",
@@ -249,15 +249,10 @@ describe("DepositFunding", async function() {
 
       await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 4th month
       await createNewDeposit(fullBtc)
-      await mint(500 * fullBtc) // should new be at 1000 BTC - 1000 sats
-      await expectRevert(
-        createNewDeposit(fullBtc),
-        "New deposits aren't allowed.",
-      )
+      await mint(1500 * fullBtc) // should now be at 1000 BTC - 1000 sats
 
-      await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 5th month
       await createNewDeposit(fullBtc)
-      await mint("2099900000000000") // should new be at 21M BTC - 1000 sats
+      await mint("2099850000000000") // should now be at 21M BTC - 1000 sats
       await expectRevert(
         createNewDeposit(fullBtc),
         "New deposits aren't allowed.",

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -114,14 +114,14 @@ describe("TBTCSystem governance", async function() {
       expect(allowNewDeposits).to.equal(false)
     })
 
-    it("doesn't pause new deposit creation after a year has passed", async () => {
+    it("doesn't pause new deposit creation after 6 months have passed", async () => {
       let allowNewDeposits = await tbtcSystem.getAllowNewDeposits()
       expect(allowNewDeposits).to.equal(true)
 
-      await increaseTime(365 * 24 * 60 * 60 + 1)
+      await increaseTime(180 * 24 * 60 * 60 + 1)
       await expectRevert(
         tbtcSystem.emergencyPauseNewDeposits(),
-        "emergencyPauseNewDeposits can only be called within 365 days of initialization",
+        "emergencyPauseNewDeposits can only be called within 180 days of initialization",
       )
 
       allowNewDeposits = await tbtcSystem.getAllowNewDeposits()

--- a/solidity/test/VendingMachineTest.js
+++ b/solidity/test/VendingMachineTest.js
@@ -767,22 +767,8 @@ describe("VendingMachine", async function() {
       expect(maxSupply).to.not.eq.BN(btcToTbtc(500))
     })
 
-    it("has a max supply of 1000 BTC between the 90th day and 120th day", async () => {
-      await increaseTime(90 * 24 * 60 * 60 + 1) // 90 days and 1 second
-      let maxSupply = await vendingMachine.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToTbtc(1000))
-
-      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
-      maxSupply = await vendingMachine.getMaxSupply()
-      expect(maxSupply).to.eq.BN(btcToTbtc(1000))
-
-      await increaseTime(60 * 60) // one hour
-      maxSupply = await vendingMachine.getMaxSupply()
-      expect(maxSupply).to.not.eq.BN(btcToTbtc(1000))
-    })
-
-    it("has a max supply of 21M BTC after the 120th day", async () => {
-      await increaseTime(120 * 24 * 60 * 60 + 1) // 120 days and 1 second
+    it("has a max supply of 21M BTC after the 90th day", async () => {
+      await increaseTime(90 * 24 * 60 * 60 + 1) // 120 days and 1 second
       let maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(21000000))
 


### PR DESCRIPTION
Instead of allowing the emergency pause for 365 days, cut it down to 180. Instead of a supply cap for 4 months, move it to 3.

I've gone back and forth on these schedules and [other approaches](https://github.com/keep-network/tbtc/pull/688) to handle all the demand we're getting. Rather that increase the caps, I think removing the last 1000 BTC limit- which doesn't buy us much- is the right call.