### PR TITLE
Give Ropsten development constants

### DIFF
--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -73,7 +73,11 @@ const all = [
 module.exports = (deployer, network, accounts) => {
   deployer.then(async () => {
     let constantsContract = TBTCConstants
-    if (network == "keep_dev" || network == "development") {
+    if (
+      network == "keep_dev" ||
+      network == "development" ||
+      network == "ropsten"
+    ) {
       // For keep_dev and development, replace constants with testnet constants.
       // Masquerade as TBTCConstants like a sinister fellow.
       TBTCDevelopmentConstants._json.contractName = "TBTCConstants"


### PR DESCRIPTION
Currently, TBTCConstants requires proof of 6 blocks; unfortunately, for
BTC testnet this can be a challenge with the difficulty continuity that the
contracts impose. Shifting Ropsten to development constants makes this
feasible again.