### PR TITLE
Mitigate supply cap exhaustion attacks

### DIFF
--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -20,7 +20,7 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./KeepFactorySelection.sol";
 
-/// @title  TBTC System.
+/// @title TBTC System.
 /// @notice This contract acts as a central point for access control,
 ///         value governance, and price feed.
 /// @dev    Governable values should only affect new deposit creation.
@@ -61,8 +61,6 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     uint256 initializedTimestamp = 0;
     uint256 pausedTimestamp;
     uint256 constant pausedDuration = 10 days;
-
-    VendingMachine public vendingMachine;
 
     ISatWeiPriceFeed public priceFeed;
     IRelay public relay;
@@ -110,7 +108,6 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @param _tbtcToken         TBTCToken. More info in `TBTCToken`.
     /// @param _tbtcDepositToken  TBTCDepositToken (TDT). More info in `TBTCDepositToken`.
     /// @param _feeRebateToken    FeeRebateToken (FRT). More info in `FeeRebateToken`.
-    /// @param _vendingMachine    Vending Machine. More info in `VendingMachine`.
     /// @param _keepThreshold     Signing group honesty threshold.
     /// @param _keepSize          Signing group size.
     function initialize(
@@ -143,18 +140,15 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             _keepThreshold,
             _keepSize
         );
-        vendingMachine = _vendingMachine;
         setTbtcDepositToken(_tbtcDepositToken);
         initializedTimestamp = block.timestamp;
         allowNewDeposits = true;
     }
 
     /// @notice Returns whether new deposits should be allowed.
-    /// @return True if new deposits should be allowed, both by the emergency pause button
-    ///         and respected the max supply schedule.
+    /// @return True if new deposits should be allowed by the emergency pause button
     function getAllowNewDeposits() external view returns (bool) {
-        return allowNewDeposits &&
-            vendingMachine.canMint(getMaxLotSize().mul(10 ** 10));
+        return allowNewDeposits;
     }
 
     /// @notice Return the largest lot size currently enabled for deposits.

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -1,5 +1,5 @@
 const {deployAndLinkAll} = require("./helpers/testDeployer.js")
-const {states, fundingTx, increaseTime} = require("./helpers/utils.js")
+const {states, fundingTx} = require("./helpers/utils.js")
 const {createSnapshot, restoreSnapshot} = require("./helpers/snapshot.js")
 const {accounts, contract, web3} = require("@openzeppelin/test-environment")
 const {BN, constants, expectRevert} = require("@openzeppelin/test-helpers")
@@ -178,78 +178,6 @@ describe("DepositFunding", async function() {
           1,
           fullBtc,
         ),
-        "New deposits aren't allowed.",
-      )
-    })
-
-    it("respects the supply cap schedule", async () => {
-      const depositFee = await tbtcSystemStub.getNewDepositFeeEstimate()
-
-      await ecdsaKeepStub.send(depositFee)
-      await ecdsaKeepStub.setBondAmount(depositFee)
-
-      const bn = web3.utils.toBN
-
-      const mint = amountInSats =>
-        tbtcToken.forceMint(
-          testDeposit.address,
-          bn(amountInSats).mul(bn(10).pow(bn(10))),
-        )
-
-      const createNewDeposit = amountInSats => {
-        return testDeposit.createNewDeposit.call(
-          tbtcSystemStub.address,
-          tbtcToken.address,
-          tbtcDepositToken.address,
-          ZERO_ADDRESS,
-          ZERO_ADDRESS,
-          1, // m
-          1,
-          amountInSats,
-        )
-      }
-
-      await mint(fullBtc - 1000)
-      await createNewDeposit(fullBtc)
-      await mint(fullBtc) // should now be at 2 BTC - 1000 sats
-
-      await expectRevert(
-        createNewDeposit(fullBtc),
-        "New deposits aren't allowed.",
-      )
-
-      await increaseTime(15 * 24 * 60 * 60) // 15 days, into the 1st month
-      await createNewDeposit(fullBtc)
-      await mint(98 * fullBtc) // should now be at 100 BTC - 1000 sats
-      await expectRevert(
-        createNewDeposit(fullBtc),
-        "New deposits aren't allowed.",
-      )
-
-      await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 2nd month
-      await createNewDeposit(fullBtc)
-      await mint(150 * fullBtc) // should now be at 250 BTC - 1000 sats
-      await expectRevert(
-        createNewDeposit(fullBtc),
-        "New deposits aren't allowed.",
-      )
-
-      await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 3rd month
-      await createNewDeposit(fullBtc)
-      await mint(250 * fullBtc) // should now be at 500 BTC - 1000 sats
-      await expectRevert(
-        createNewDeposit(fullBtc),
-        "New deposits aren't allowed.",
-      )
-
-      await increaseTime(30 * 24 * 60 * 60) // 30 days, into the 4th month
-      await createNewDeposit(fullBtc)
-      await mint(1500 * fullBtc) // should now be at 1000 BTC - 1000 sats
-
-      await createNewDeposit(fullBtc)
-      await mint("2099850000000000") // should now be at 21M BTC - 1000 sats
-      await expectRevert(
-        createNewDeposit(fullBtc),
         "New deposits aren't allowed.",
       )
     })


### PR DESCRIPTION
The additional deposit restriction opened up the system to a variety of subtle cap exhaustion attacks. This PR removes the deposit restriction, so racing to the cap to prevent additional deposit creation can no longer be used to game distribution.

Note that depositing "past the cap" has always been possible- if at system instantiation I opened 100 1-BTC deposits but never minted, there could be 200 BTC in the system in the first 30 days. This PR just removes the edge case where 100 TBTC have been minted, allowing deposits to be opened and closed independently.

Original discussion on #698.