### PR TITLE
Raise the upper governable lot size to 100 BTC

### DIFF
--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -219,7 +219,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @notice Set the allowed deposit lot sizes.
     /// @dev    Lot size array should always contain 10**8 satoshis (1 BTC) and
     ///         cannot contain values less than 50000 satoshis (0.0005 BTC) or
-    ///         greater than 10**9 satoshis (10 BTC).
+    ///         greater than 10**10 satoshis (100 BTC).
     ///         This can be finalized by calling `finalizeLotSizesUpdate`
     ///         anytime after `governanceTimeDelay` has elapsed.
     /// @param _lotSizes Array of allowed lot sizes.
@@ -233,9 +233,9 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             } else if (_lotSizes[i] < 50 * 10**3) {
                 // Failed the minimum requirement, break on out.
                 revert("Lot sizes less than 0.0005 BTC are not allowed");
-            } else if (_lotSizes[i] > 10 * 10**8) {
+            } else if (_lotSizes[i] > 10 * 10**9) {
                 // Failed the maximum requirement, break on out.
-                revert("Lot sizes greater than 10 BTC are not allowed");
+                revert("Lot sizes greater than 100 BTC are not allowed");
             }
         }
 

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -265,7 +265,7 @@ describe("TBTCSystem governance", async function() {
           value: [
             new BN(10 ** 8), // required
             new BN(10 ** 6),
-            new BN(10 ** 9), // upper bound
+            new BN(10 ** 10), // upper bound
             new BN(50 * 10 ** 3), // lower bound
           ],
         },
@@ -283,9 +283,9 @@ describe("TBTCSystem governance", async function() {
           parameters: [[10 ** 7, 10 ** 8, 5 * 10 ** 3 - 1]],
           error: "Lot sizes less than 0.0005 BTC are not allowed",
         },
-        "array contains a lot size > 10 BTC": {
-          parameters: [[10 ** 7, 10 ** 9 + 1, 10 ** 8]],
-          error: "Lot sizes greater than 10 BTC are not allowed",
+        "array contains a lot size > 100 BTC": {
+          parameters: [[10 ** 7, 10 ** 10 + 1, 10 ** 8]],
+          error: "Lot sizes greater than 100 BTC are not allowed",
         },
       },
       verifyFinalizationEvents: (receipt, setLotSizes) => {


### PR DESCRIPTION
Considering gas costs of the beacon and DKG, allowing larger lot sizes in the future will likely make sense.