### PR TITLE
Notification Station: Host of changes to deposit public API

### DIFF
--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -208,7 +208,7 @@ contract Deposit is DepositFactoryAuthority {
     ///      state.
     /// @return The withdraw allowance in wei.
     function withdrawableAmount() public view returns (uint256) {
-        return self.getWithdrawAllowance();
+        return self.getWithdrawableAmount();
     }
 
 //------------------------------ FUNDING FLOW --------------------------------//

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -154,13 +154,18 @@ contract Deposit is DepositFactoryAuthority {
     }
 
     /// @notice Get the value of the funding UTXO.
-    /// @dev This call will return 0 if the deposit is not in a state where the
+    /// @dev This call will revert if the deposit is not in a state where the
     ///      UTXO info should be valid. In particular, before funding proof is
     ///      successfully submitted (i.e. in states START,
     ///      AWAITING_SIGNER_SETUP, and AWAITING_BTC_FUNDING_PROOF), this value
     ///      would not be valid.
     /// @return The value of the funding UTXO in satoshis.
     function utxoValue() public view returns (uint256){
+        require(
+            ! self.inFunding(),
+            "Deposit has not yet been funded and has no available funding info"
+        );
+
         return self.utxoValue();
     }
 

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -192,6 +192,11 @@ contract Deposit is DepositFactoryAuthority {
     ///         deposit's lot size in TBTC if `purchaseSignerBondsAtAuction`
     ///         were called at the time this function is called.
     function auctionValue() public view returns (uint256) {
+        require(
+            self.inSignerLiquidation(),
+            "Deposit has no funds currently at auction"
+        );
+
         return self.auctionValue();
     }
 

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -88,7 +88,7 @@ contract Deposit is DepositFactoryAuthority {
     }
 
     /// @notice Check if the Deposit is in ACTIVE state.
-    /// @return True if state is ACTIVE, fale otherwise.
+    /// @return True if state is ACTIVE, false otherwise.
     function inActive() public view returns (bool) {
         return self.inActive();
     }
@@ -383,8 +383,6 @@ contract Deposit is DepositFactoryAuthority {
         self.notifyUndercollateralizedLiquidation();
     }
 
-    /// @notice Anyone can provide a signature that was not requested to prove
-    ///         fraud.
     /// @notice Anyone can provide a signature corresponding to the signers'
     ///         public key that was not requested to prove fraud. A redemption
     ///         request and a redemption fee increase are the only ways to

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -589,7 +589,7 @@ contract Deposit is DepositFactoryAuthority {
     ///                         required to send. This is also the amount of
     ///                         TBTC the TDT holder will be eligible to mint:
     ///                         (10**7 satoshi == 0.1 BTC == 0.1 TBTC).
-    function createNewDeposit(
+    function initializeDeposit(
         ITBTCSystem _tbtcSystem,
         TBTCToken _tbtcToken,
         IERC721 _tbtcDepositToken,
@@ -604,7 +604,7 @@ contract Deposit is DepositFactoryAuthority {
         self.tbtcDepositToken = _tbtcDepositToken;
         self.feeRebateToken = _feeRebateToken;
         self.vendingMachineAddress = _vendingMachineAddress;
-        self.createNewDeposit(_m, _n, _lotSizeSatoshis);
+        self.initialize(_m, _n, _lotSizeSatoshis);
     }
 
     /// @notice This function can only be called by the vending machine.

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -212,9 +212,9 @@ contract Deposit is DepositFactoryAuthority {
 
 //------------------------------ FUNDING FLOW --------------------------------//
 
-    /// @notice Anyone may notify the contract that signing group setup has
-    ///         timed out if retrieveSignerPubkey is not successfully called
-    ///         within the allotted time.
+    /// @notice Notify the contract that signing group setup has timed out if
+    ///         retrieveSignerPubkey is not successfully called within the
+    ///         allotted time.
     /// @dev This
     ///      RegisteredPubkey event with the two components. Reverts if the
     ///      deposit is not awaiting signer setup, if the generated public key
@@ -224,8 +224,8 @@ contract Deposit is DepositFactoryAuthority {
         self.notifySignerSetupFailed();
     }
 
-    /// @notice Anyone may notify the contract that the ECDSA keep has generated
-    ///         a public key so the deposit contract can pull it in.
+    /// @notice Notify the contract that the ECDSA keep has generated a public
+    ///         key so the deposit contract can pull it in.
     /// @dev Stores the pubkey as 2 bytestrings, X and Y. Emits a
     ///      RegisteredPubkey event with the two components. Reverts if the
     ///      deposit is not awaiting signer setup, if the generated public key
@@ -235,13 +235,12 @@ contract Deposit is DepositFactoryAuthority {
         self.retrieveSignerPubkey();
     }
 
-    /// @notice Anyone may notify the contract that the funding phase of the
-    ///         deposit has timed out if provideBTCFundingProof is not
-    ///         successfully called within the allotted time. Any sent BTC is
-    ///         left under control of the signer group, and the funder can
-    ///         use `requestFunderAbort` to request an at-signer-discretion
-    ///         return of any BTC sent to a deposit that has been notified of
-    ///         a funding timeout.
+    /// @notice Notify the contract that the funding phase of the deposit has
+    ///         timed out if `provideBTCFundingProof` is not successfully called
+    ///         within the allotted time. Any sent BTC is left under control of
+    ///         the signer group, and the funder can use `requestFunderAbort` to
+    ///         request an at-signer-discretion return of any BTC sent to a
+    ///         deposit that has been notified of a funding timeout.
     /// @dev This is considered a funder fault, and the funder's payment for
     ///      opening the deposit is not refunded. Emits a SetupFailed event.
     ///      Reverts if the funding timeout has not yet elapsed, or if the
@@ -353,8 +352,8 @@ contract Deposit is DepositFactoryAuthority {
         self.exitCourtesyCall();
     }
 
-    /// @notice Notifies the contract that the courtesy period has expired and
-    ///         the deposit should move into liquidation.
+    /// @notice Notify the contract that the courtesy period has expired and the
+    ///         deposit should move into liquidation.
     /// @dev This call will revert if the courtesy call period has not in fact
     ///      expired or is not in the courtesy call state. Courtesy call
     ///      expiration is treated as an abort, and is handled by seizing signer
@@ -409,9 +408,8 @@ contract Deposit is DepositFactoryAuthority {
         self.provideECDSAFraudProof(_v, _r, _s, _signedDigest, _preimage);
     }
 
-    /// @notice Anyone may notify the contract that the signers have failed to
-    ///         produce a signature for a redemption request in the allotted
-    ///         time.
+    /// @notice Notify the contract that the signers have failed to produce a
+    ///         signature for a redemption request in the allotted time.
     /// @dev This is considered an abort, and is punished by seizing signer
     ///      bonds and putting them up for auction. Emits a LiquidationStarted
     ///      event and a Liquidated event and sends the full signer bond to the
@@ -423,8 +421,8 @@ contract Deposit is DepositFactoryAuthority {
         self.notifyRedemptionSignatureTimedOut();
     }
 
-    /// @notice Anyone may notify the contract that the deposit has failed to
-    ///         receive a redemption proof in the allotted time.
+    /// @notice Notify the contract that the deposit has failed to receive a
+    ///         redemption proof in the allotted time.
     /// @dev This call will revert if the deposit is not currently awaiting a
     ///      signature or if the allotted time has not yet elapsed. This is
     ///      considered an abort, and is punished by seizing signer bonds and

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -28,8 +28,9 @@ import "../system/DepositFactoryAuthority.sol";
 ///       - `TBTCConstants`
 ///
 ///      Where these libraries require deposit state, this contract's state
-///      variable `self` is used, a struct of type `DepositUtils.Deposit` that
-///      contains all aspects of the deposit state itself.
+///      variable `self` is used. `self` is a struct of type
+///      `DepositUtils.Deposit` that contains all aspects of the deposit state
+///      itself.
 contract Deposit is DepositFactoryAuthority {
 
     using DepositRedemption for DepositUtils.Deposit;

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -220,8 +220,8 @@ contract Deposit is DepositFactoryAuthority {
     ///      deposit is not awaiting signer setup, if the generated public key
     ///      is unset or has incorrect length, or if the public key has a 0
     ///      X or Y value.
-    function notifySignerSetupFailure() public {
-        self.notifySignerSetupFailure();
+    function notifySignerSetupFailed() public {
+        self.notifySignerSetupFailed();
     }
 
     /// @notice Anyone may notify the contract that the ECDSA keep has generated
@@ -246,8 +246,8 @@ contract Deposit is DepositFactoryAuthority {
     ///      opening the deposit is not refunded. Emits a SetupFailed event.
     ///      Reverts if the funding timeout has not yet elapsed, or if the
     ///      deposit is not currently awaiting funding proof.
-    function notifyFundingTimeout() public {
-        self.notifyFundingTimeout();
+    function notifyFundingTimedOut() public {
+        self.notifyFundingTimedOut();
     }
 
     /// @notice Requests a funder abort for a failed-funding deposit; that is,
@@ -363,8 +363,8 @@ contract Deposit is DepositFactoryAuthority {
     ///      LiquidationStarted event. The caller is captured as the liquidation
     ///      initiator, and is eligible for 50% of any bond left after the
     ///      auction is completed.
-    function notifyCourtesyTimeout() public {
-        self.notifyCourtesyTimeout();
+    function notifyCourtesyCallExpired() public {
+        self.notifyCourtesyCallExpired();
     }
 
     /// @notice Notify the contract that the signers are undercollateralized.
@@ -419,8 +419,8 @@ contract Deposit is DepositFactoryAuthority {
     ///      signature or if the allotted time has not yet elapsed. The caller
     ///      is captured as the liquidation initiator, and is eligible for 50%
     ///      of any bond left after the auction is completed.
-    function notifySignatureTimeout() public {
-        self.notifySignatureTimeout();
+    function notifyRedemptionSignatureTimedOut() public {
+        self.notifyRedemptionSignatureTimedOut();
     }
 
     /// @notice Anyone may notify the contract that the deposit has failed to
@@ -433,8 +433,8 @@ contract Deposit is DepositFactoryAuthority {
     ///      The caller is captured as the liquidation initiator, and
     ///      is eligible for 50% of any bond left after the auction is
     ///     completed.
-    function notifyRedemptionProofTimeout() public {
-        self.notifyRedemptionProofTimeout();
+    function notifyRedemptionProofTimedOut() public {
+        self.notifyRedemptionProofTimedOut();
     }
 
     /// @notice Closes an auction and purchases the signer bonds by transferring

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -630,7 +630,7 @@ contract Deposit is DepositFactoryAuthority {
         );
     }
 
-    /// @notice Withdraw caller's allowance.
+    /// @notice Withdraw the ETH balance of the deposit allotted to the caller.
     /// @dev Withdrawals can only happen when a contract is in an end-state.
     function withdrawFunds() public {
         self.withdrawFunds();

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -12,13 +12,24 @@ import {FeeRebateToken} from "../system/FeeRebateToken.sol";
 
 import "../system/DepositFactoryAuthority.sol";
 
-/// @title  Deposit.
-/// @notice This is the main contract for tBTC. It is the state machine
-/// that (through various libraries) handles bitcoin funding,
-/// bitcoin-spv proofs, redemption, liquidation, and fraud logic.
-/// @dev This is the execution context for libraries:
-/// `DepositFunding`, `DepositLiquidaton`, `DepositRedemption`,
-/// `DepositStates`, `DepositUtils`, `OutsourceDepositLogging`, and `TBTCConstants`.
+/// @title  tBTC Deposit
+/// @notice This is the main contract for tBTC. It is the state machine that
+///         (through various libraries) handles bitcoin funding, bitcoin-spv
+///         proofs, redemption, liquidation, and fraud logic.
+/// @dev This contract presents a public API that exposes the following
+///      libraries:
+///
+///       - `DepositFunding`
+///       - `DepositLiquidaton`
+///       - `DepositRedemption`,
+///       - `DepositStates`
+///       - `DepositUtils`
+///       - `OutsourceDepositLogging`
+///       - `TBTCConstants`
+///
+///      Where these libraries require deposit state, this contract's state
+///      variable `self` is used, a struct of type `DepositUtils.Deposit` that
+///      contains all aspects of the deposit state itself.
 contract Deposit is DepositFactoryAuthority {
 
     using DepositRedemption for DepositUtils.Deposit;
@@ -29,74 +40,80 @@ contract Deposit is DepositFactoryAuthority {
 
     DepositUtils.Deposit self;
 
-    // We separate the constructor from createNewDeposit to make proxy factories easier.
-    /* solium-disable-next-line no-empty-blocks */
+    /// @dev Deposit should only be _constructed_ once. New deposits are created
+    ///      using the `DepositFactory.createDeposit` method, and are clones of
+    ///      the constructed deposit. The factory will set the initial values
+    ///      for a new clone using `initializeDeposit`.
     constructor () public {
         initialize(address(0));
     }
 
+    /// @notice Deposits do not accept arbitrary ETH.
     function () external payable {
         require(msg.data.length == 0, "Deposit contract was called with unknown function selector.");
     }
 
-    /// @notice     Get the keep contract address associated with the Deposit.
-    /// @dev        The keep contract address is saved on Deposit initialization.
-    /// @return     Address of the Keep contract.
+    /// @notice Get the contract address of the BondedECDSAKeep associated with
+    ///         this Deposit.
+    /// @dev The keep contract address is saved on Deposit initialization.
+    /// @return Address of the Keep contract.
     function getKeepAddress() public view returns (address) {
         return self.keepAddress;
     }
 
-    /// @notice     Get the integer representing the current state.
-    /// @dev        We implement this because contracts don't handle foreign enums well.
-    ///             see DepositStates for more info on states.
-    /// @return     The 0-indexed state from the DepositStates enum.
+    /// @notice Get the integer representing the current state.
+    /// @dev We implement this because contracts don't handle foreign enums
+    ///      well. See `DepositStates` for more info on states.
+    /// @return The 0-indexed state from the DepositStates enum.
     function getCurrentState() public view returns (uint256) {
         return uint256(self.currentState);
     }
 
-    /// @notice     Check if the Deposit is in ACTIVE state.
-    /// @return     True if state is ACTIVE, fale otherwise.
+    /// @notice Check if the Deposit is in ACTIVE state.
+    /// @return True if state is ACTIVE, fale otherwise.
     function inActive() public view returns (bool) {
         return self.inActive();
     }
 
     /// @notice Retrieve the remaining term of the deposit in seconds.
-    /// @dev    The value accuracy is not guaranteed since block.timestmap can
-    ///         be lightly manipulated by miners.
-    /// @return The remaining term of the deposit in seconds. 0 if already at term.
+    /// @dev The value accuracy is not guaranteed since block.timestmap can be
+    ///      lightly manipulated by miners.
+    /// @return The remaining term of the deposit in seconds. 0 if already at
+    ///         term.
     function remainingTerm() public view returns(uint256){
         return self.remainingTerm();
     }
 
-    /// @notice     Get the signer fee for the Deposit.
-    /// @dev        This is the one-time fee required by the signers to perform .
-    ///             the tasks needed to maintain a decentralized and trustless
-    ///             model for tBTC. It is a percentage of the lotSize (deposit size).
-    /// @return     Fee amount in tBTC.
+    /// @notice Get the signer fee for this deposit, in TBTC.
+    /// @dev This is the one-time fee required by the signers to perform the
+    ///      tasks needed to maintain a decentralized and trustless model for
+    ///      tBTC. It is a percentage of the deposit's lot size.
+    /// @return Fee amount in TBTC.
     function signerFeeTbtc() public view returns (uint256) {
         return self.signerFeeTbtc();
     }
 
-    /// @notice     Get the deposit's BTC lot size in satoshi.
-    /// @return     uint64 lot size in satoshi.
+    /// @notice Get this deposit's BTC lot size in satoshis.
+    /// @return uint64 lot size in satoshis.
     function lotSizeSatoshis() public view returns (uint64){
         return self.lotSizeSatoshis;
     }
 
-    /// @notice     Get the Deposit ERC20 lot size.
-    /// @dev        This is the same as lotSizeSatoshis(),
-    ///             but is multiplied to scale to ERC20 decimal.
-    /// @return     uint256 lot size in erc20 decimal (max 18 decimal places).
+    /// @notice Get this deposit's lot size in TBTC.
+    /// @dev This is the same as lotSizeSatoshis(), but is multiplied to scale
+    ///      to 18 decimal places.
+    /// @return uint256 lot size in TBTC precision (max 18 decimal places).
     function lotSizeTbtc() public view returns (uint256){
         return self.lotSizeTbtc();
     }
 
-    /// @notice     Get the value of the funding UTXO.
-    /// @dev        This will only return 0 unless
-    ///             the funding transaction has been confirmed on-chain.
-    ///             See `provideBTCFundingProof` for more info on the funding proof.
-    /// @return     Uint256 UTXO value in satoshi.
-    ///             0 if no funding proof has been provided.
+    /// @notice Get the value of the funding UTXO.
+    /// @dev This call will return 0 if the deposit is not in a state where the
+    ///      UTXO info should be valid. In particular, before funding proof is
+    ///      successfully submitted (i.e. in states START,
+    ///      AWAITING_SIGNER_SETUP, and AWAITING_BTC_FUNDING_PROOF), this value
+    ///      would not be valid.
+    /// @return The value of the funding UTXO in satoshis.
     function utxoValue() public view returns (uint256){
         return self.utxoValue();
     }
@@ -117,18 +134,23 @@ contract Deposit is DepositFactoryAuthority {
         return (self.utxoValueBytes, self.fundedAt, self.utxoOutpoint);
     }
 
-    // THIS IS THE INIT FUNCTION
-    /// @notice        The Deposit Factory can spin up a new deposit.
-    /// @dev           Only the Deposit factory can call this.
-    /// @param _tbtcSystem        `TBTCSystem` contract. More info in `TBTCSystem`.
-    /// @param _tbtcToken         `TBTCToken` contract. More info in TBTCToken`.
-    /// @param _tbtcDepositToken  `TBTCDepositToken` (TDT) contract. More info in `TBTCDepositToken`.
-    /// @param _feeRebateToken    `FeeRebateToken` (FRT) contract. More info in `FeeRebateToken`.
-    /// @param _vendingMachineAddress    `VendingMachine` address. More info in `VendingMachine`.
-    /// @param _m           Signing group honesty threshold.
-    /// @param _n           Signing group size.
-    /// @param _lotSizeSatoshis The minimum amount of satoshi the funder is required to send.
-    ///                         This is also the amount of TBTC the TDT holder will receive:
+    /// @notice This function can only be called by the deposit factory; use
+    ///         `DepositFactory.createDeposit` to create a new deposit.
+    /// @dev Initializes a new deposit clone with the base state for the
+    ///      deposit.
+    /// @param _tbtcSystem `TBTCSystem` contract. More info in `TBTCSystem`.
+    /// @param _tbtcToken `TBTCToken` contract. More info in TBTCToken`.
+    /// @param _tbtcDepositToken `TBTCDepositToken` (TDT) contract. More info in
+    ///        `TBTCDepositToken`.
+    /// @param _feeRebateToken `FeeRebateToken` (FRT) contract. More info in
+    ///        `FeeRebateToken`.
+    /// @param _vendingMachineAddress `VendingMachine` address. More info in
+    ///        `VendingMachine`.
+    /// @param _m Signing group honesty threshold.
+    /// @param _n Signing group size.
+    /// @param _lotSizeSatoshis The minimum amount of satoshi the funder is
+    ///                         required to send. This is also the amount of
+    ///                         TBTC the TDT holder will be eligible to mint:
     ///                         (10**7 satoshi == 0.1 BTC == 0.1 TBTC).
     function createNewDeposit(
         ITBTCSystem _tbtcSystem,
@@ -148,13 +170,19 @@ contract Deposit is DepositFactoryAuthority {
         self.createNewDeposit(_m, _n, _lotSizeSatoshis);
     }
 
-    /// @notice                     Deposit owner (TDT holder) can request redemption.
-    ///                             Once redemption is requested
-    ///                             a proof with sufficient accumulated difficulty is
-    ///                             required to complete redemption.
-    /// @dev                        The redeemer specifies details about the Bitcoin redemption tx.
-    /// @param  _outputValueBytes   The 8-byte Little Endian output size.
-    /// @param  _redeemerOutputScript The redeemer's length-prefixed output script.
+    /// @notice Requests redemption of this deposit, meaning the transmission,
+    ///         by the signers, of the deposit's UTXO to the specified Bitocin
+    ///         output script. Requires approving the deposit to spend the
+    ///         amount of TBTC needed to redeem.
+    /// @dev The amount of TBTC needed to redeem can be looked up using the
+    ///      `getRedemptionTbtcRequirement` or `getOwnerRedemptionTbtcRequirement`
+    ///      functions.
+    /// @param  _outputValueBytes The 8-byte little-endian output size. The
+    ///         difference between this value and the lot size of the deposit
+    ///         will be paid as a fee to the Bitcoin miners when the signed
+    ///         transaction is broadcast.
+    /// @param  _redeemerOutputScript The redeemer's length-prefixed output
+    ///         script.
     function requestRedemption(
         bytes8 _outputValueBytes,
         bytes memory _redeemerOutputScript
@@ -162,14 +190,12 @@ contract Deposit is DepositFactoryAuthority {
         self.requestRedemption(_outputValueBytes, _redeemerOutputScript);
     }
 
-    /// @notice                     Deposit owner (TDT holder) can request redemption.
-    ///                             Once redemption is requested a proof with
-    ///                             sufficient accumulated difficulty is required
-    ///                             to complete redemption.
-    /// @dev                        The caller specifies details about the Bitcoin redemption tx and pays
-    ///                             for the redemption. The TDT (deposit ownership) is transfered to _finalRecipient, and
-    ///                             _finalRecipient is marked as the deposit redeemer.
-    /// @param  _outputValueBytes   The 8-byte LE output size.
+    /// @notice This function can only be called by the vending machine.
+    /// @dev Performs the same action as requestRedemption, but transfers
+    ///      ownership of the deposit to the specified _finalRecipient. Used as
+    ///      a utility helper for the vending machine's shortcut
+    ///      TBTC->redemption path.
+    /// @param  _outputValueBytes The 8-byte little-endian output size.
     /// @param  _redeemerOutputScript The redeemer's length-prefixed output script.
     /// @param  _finalRecipient     The address to receive the TDT and later be recorded as deposit redeemer.
     function transferAndRequestRedemption(
@@ -188,29 +214,35 @@ contract Deposit is DepositFactoryAuthority {
         );
     }
 
-    /// @notice             Get TBTC amount required for redemption by a specified _redeemer.
-    /// @dev                Will revert if redemption is not possible by _redeemer.
-    /// @param _redeemer    The deposit redeemer.
-    /// @return             The amount in TBTC needed to redeem the deposit.
+    /// @notice Get TBTC amount required for redemption by a specified
+    ///         _redeemer.
+    /// @dev This call will revert if redemption is not possible by _redeemer.
+    /// @param _redeemer The deposit redeemer whose TBTC requirement is being
+    ///        requested.
+    /// @return The amount in TBTC needed by the `_redeemer` to redeem the
+    ///         deposit.
     function getRedemptionTbtcRequirement(address _redeemer) public view returns (uint256){
         (uint256 tbtcPayment,,) = self.calculateRedemptionTbtcAmounts(_redeemer, false);
         return tbtcPayment;
     }
 
-    /// @notice             Get TBTC amount required for redemption assuming _redeemer
-    ///                     is this deposit's owner (TDT holder).
-    /// @param _redeemer    The assumed owner of the deposit's TDT .
-    /// @return             The amount in TBTC needed to redeem the deposit.
+    /// @notice Get TBTC amount required for redemption assuming _redeemer
+    ///         is this deposit's owner (TDT holder).
+    /// @param _redeemer The assumed owner of the deposit's TDT .
+    /// @return The amount in TBTC needed to redeem the deposit.
     function getOwnerRedemptionTbtcRequirement(address _redeemer) public view returns (uint256){
         (uint256 tbtcPayment,,) = self.calculateRedemptionTbtcAmounts(_redeemer, true);
         return tbtcPayment;
     }
 
-    /// @notice     Anyone may provide a withdrawal signature if it was requested.
-    /// @dev        The signers will be penalized if this (or provideRedemptionProof) is not called.
-    /// @param  _v  Signature recovery value.
-    /// @param  _r  Signature R value.
-    /// @param  _s  Signature S value. Should be in the low half of secp256k1 curve's order.
+    /// @notice Anyone may provide a withdrawal signature if it was requested.
+    /// @dev The signers will be penalized if this function is not called
+    ///      correctly within `TBTCConstants.REDEMPTION_SIGNATURE_TIMEOUT`
+    ///      seconds of a redemption request or fee increase being received.
+    /// @param _v Signature recovery value.
+    /// @param _r Signature R value.
+    /// @param _s Signature S value. Should be in the low half of secp256k1
+    ///        curve's order.
     function provideRedemptionSignature(
         uint8 _v,
         bytes32 _r,
@@ -219,10 +251,17 @@ contract Deposit is DepositFactoryAuthority {
         self.provideRedemptionSignature(_v, _r, _s);
     }
 
-    /// @notice                             Anyone may notify the contract that a fee bump is needed.
-    /// @dev                                This sends us back to AWAITING_WITHDRAWAL_SIGNATURE.
-    /// @param  _previousOutputValueBytes   The previous output's value.
-    /// @param  _newOutputValueBytes        The new output's value.
+    /// @notice Anyone may request a signature for a transaction with an
+    ///         increased Bitcoin transaction fee.
+    /// @dev This call will revert if the fee is already at its maximum, or if
+    ///      the new requested fee is not a multiple of the initial requested
+    ///      fee. Transaction fees can only be bumped by the amount of the
+    ///      initial requested fee. Calling this sends the deposit back to
+    ///      the `AWAITING_WITHDRAWAL_SIGNATURE` state and requires the signers
+    ///      to `provideRedemptionSignature` for the new output value in a
+    ///      timely fashion.
+    /// @param _previousOutputValueBytes The previous output's value.
+    /// @param _newOutputValueBytes The new output's value.
     function increaseRedemptionFee(
         bytes8 _previousOutputValueBytes,
         bytes8 _newOutputValueBytes
@@ -230,15 +269,27 @@ contract Deposit is DepositFactoryAuthority {
         self.increaseRedemptionFee(_previousOutputValueBytes, _newOutputValueBytes);
     }
 
-    /// @notice                 Anyone may provide a withdrawal proof to prove redemption.
-    /// @dev                    The signers will be penalized if this is not called.
-    /// @param  _txVersion      Transaction version number (4-byte Little Endian).
-    /// @param  _txInputVector  All transaction inputs prepended by the number of inputs encoded as a VarInt, max 0xFC(252) inputs.
-    /// @param  _txOutputVector All transaction outputs prepended by the number of outputs encoded as a VarInt, max 0xFC(252) outputs.
-    /// @param  _txLocktime     Final 4 bytes of the transaction.
-    /// @param  _merkleProof    The merkle proof of inclusion of the tx in the bitcoin block.
-    /// @param  _txIndexInBlock The index of the tx in the Bitcoin block (0-indexed).
-    /// @param  _bitcoinHeaders An array of tightly-packed bitcoin headers.
+    /// @notice Anyone may submit a redemption proof to the deposit showing that
+    ///         a transaction was submitted and sufficiently confirmed on the
+    ///         Bitcoin chain transferring the deposit lot size's amount of BTC
+    ///         from the signer-controlled private key corresponding to this
+    ///         deposit to the requested redemption output script. This will
+    ///         move the deposit into a redeemed state.
+    /// @dev Takes a pre-parsed transaction and calculates values needed to
+    ///      verify funding. Signers can have their bonds seized if this is not
+    ///      called within `TBTCConstants.REDEMPTION_PROOF_TIMEOUT` seconds of
+    ///      a redemption signature being provided.
+    /// @param _txVersion Transaction version number (4-byte little-endian).
+    /// @param _txInputVector All transaction inputs prepended by the number of
+    ///        inputs encoded as a VarInt, max 0xFC(252) inputs.
+    /// @param _txOutputVector All transaction outputs prepended by the number
+    ///         of outputs encoded as a VarInt, max 0xFC(252) outputs.
+    /// @param _txLocktime Final 4 bytes of the transaction.
+    /// @param _merkleProof The merkle proof of transaction inclusion in a
+    ///        block.
+    /// @param _txIndexInBlock Transaction index in the block (0-indexed).
+    /// @param _bitcoinHeaders Single bytestring of 80-byte bitcoin headers,
+    ///        lowest height first.
     function provideRedemptionProof(
         bytes4 _txVersion,
         bytes memory _txInputVector,
@@ -259,14 +310,30 @@ contract Deposit is DepositFactoryAuthority {
         );
     }
 
-    /// @notice     Anyone may notify the contract that the signers have failed to produce a signature.
-    /// @dev        This is considered fraud, and is punished.
+    /// @notice Anyone may notify the contract that the signers have failed to
+    ///         produce a signature for a redemption request in the allotted
+    ///         time.
+    /// @dev This is considered an abort, and is punished by seizing signer
+    ///      bonds and putting them up for auction. Emits a LiquidationStarted
+    ///      event and a Liquidated event and sends the full signer bond to the
+    ///      redeemer. Reverts if the deposit is not currently awaiting a
+    ///      signature or if the allotted time has not yet elapsed. The caller
+    ///      is captured as the liquidation initiator, and is eligible for 50%
+    ///      of any bond left after the auction is completed.
     function notifySignatureTimeout() public {
         self.notifySignatureTimeout();
     }
 
-    /// @notice     Anyone may notify the contract that the signers have failed to produce a redemption proof.
-    /// @dev        This is considered fraud, and is punished.
+    /// @notice Anyone may notify the contract that the deposit has failed to
+    ///         receive a redemption proof in the allotted time.
+    /// @dev This call will revert if the deposit is not currently awaiting a
+    ///      signature or if the allotted time has not yet elapsed. This is
+    ///      considered an abort, and is punished by seizing signer bonds and
+    ///      putting them up for auction for the lot size amount in TBTC (see
+    ///      `purchaseSignerBondsAtAuction`). Emits a LiquidationStarted event.
+    ///      The caller is captured as the liquidation initiator, and
+    ///      is eligible for 50% of any bond left after the auction is
+    ///     completed.
     function notifyRedemptionProofTimeout() public {
         self.notifyRedemptionProofTimeout();
     }
@@ -275,19 +342,40 @@ contract Deposit is DepositFactoryAuthority {
     // FUNDING FLOW
     //
 
-    /// @notice     Anyone may notify the contract that signing group setup has timed out.
+    /// @notice Anyone may notify the contract that signing group setup has
+    ///         timed out if retrieveSignerPubkey is not successfully called
+    ///         within the allotted time.
+    /// @dev This
+    ///      RegisteredPubkey event with the two components. Reverts if the
+    ///      deposit is not awaiting signer setup, if the generated public key
+    ///      is unset or has incorrect length, or if the public key has a 0
+    ///      X or Y value.
     function notifySignerSetupFailure() public {
         self.notifySignerSetupFailure();
     }
 
-    /// @notice             Poll the Keep contract to retrieve our pubkey.
-    /// @dev                Store the pubkey as 2 bytestrings, X and Y.
+    /// @notice Anyone may notify the contract that the ECDSA keep has generated
+    ///         a public key so the deposit contract can pull it in.
+    /// @dev Stores the pubkey as 2 bytestrings, X and Y. Emits a
+    ///      RegisteredPubkey event with the two components. Reverts if the
+    ///      deposit is not awaiting signer setup, if the generated public key
+    ///      is unset or has incorrect length, or if the public key has a 0
+    ///      X or Y value.
     function retrieveSignerPubkey() public {
         self.retrieveSignerPubkey();
     }
 
-    /// @notice     Anyone may notify the contract that the funder has failed to send BTC.
-    /// @dev        This is considered a funder fault, and we revoke their bond.
+    /// @notice Anyone may notify the contract that the funding phase of the
+    ///         deposit has timed out if provideBTCFundingProof is not
+    ///         successfully called within the allotted time. Any sent BTC is
+    ///         left under control of the signer group, and the funder can
+    ///         use `requestFunderAbort` to request an at-signer-discretion
+    ///         return of any BTC sent to a deposit that has been notified of
+    ///         a funding timeout.
+    /// @dev This is considered a funder fault, and the funder's payment for
+    ///      opening the deposit is not refunded. Emits a SetupFailed event.
+    ///      Reverts if the funding timeout has not yet elapsed, or if the
+    ///      deposit is not currently awaiting funding proof.
     function notifyFundingTimeout() public {
         self.notifyFundingTimeout();
     }
@@ -313,14 +401,16 @@ contract Deposit is DepositFactoryAuthority {
         self.requestFunderAbort(_abortOutputScript);
     }
 
-    /// @notice                 Anyone can provide a signature that was not requested to prove fraud during funding.
-    /// @dev                    Calls out to the keep to verify if there was fraud.
-    /// @param  _v              Signature recovery value.
-    /// @param  _r              Signature R value.
-    /// @param  _s              Signature S value.
-    /// @param _signedDigest    The digest signed by the signature vrs tuple.
-    /// @param _preimage        The sha256 preimage of the digest.
-    /// @return                 True if successful, otherwise revert.
+    /// @notice Anyone can provide a signature corresponding to the signers'
+    ///         public key to prove fraud during funding. Note that during
+    ///         funding no signature has been requested from the signers, so
+    ///         any signature is effectively fraud.
+    /// @dev Calls out to the keep to verify if there was fraud.
+    /// @param _v Signature recovery value.
+    /// @param _r Signature R value.
+    /// @param _s Signature S value.
+    /// @param _signedDigest The digest signed by the signature (v,r,s) tuple.
+    /// @param _preimage The sha256 preimage of the digest.
     function provideFundingECDSAFraudProof(
         uint8 _v,
         bytes32 _r,
@@ -331,17 +421,26 @@ contract Deposit is DepositFactoryAuthority {
         self.provideFundingECDSAFraudProof(_v, _r, _s, _signedDigest, _preimage);
     }
 
-    /// @notice                     Anyone may notify the deposit of a funding proof to activate the deposit.
-    ///                             This is the happy-path of the funding flow. It means that we have succeeded.
-    /// @dev                        Takes a pre-parsed transaction and calculates values needed to verify funding.
-    /// @param _txVersion           Transaction version number (4-byte LE).
-    /// @param _txInputVector       All transaction inputs prepended by the number of inputs encoded as a VarInt, max 0xFC(252) inputs.
-    /// @param _txOutputVector      All transaction outputs prepended by the number of outputs encoded as a VarInt, max 0xFC(252) outputs.
-    /// @param _txLocktime          Final 4 bytes of the transaction.
-    /// @param _fundingOutputIndex  Index of funding output in _txOutputVector (0-indexed).
-    /// @param _merkleProof         The merkle proof of transaction inclusion in a block.
-    /// @param _txIndexInBlock      Transaction index in the block (0-indexed).
-    /// @param _bitcoinHeaders      Single bytestring of 80-byte bitcoin headers, lowest height first.
+    /// @notice Anyone may submit a funding proof to the deposit showing that
+    ///         a transaction was submitted and sufficiently confirmed on the
+    ///         Bitcoin chain transferring the deposit lot size's amount of BTC
+    ///         to the signer-controlled private key corresopnding to this
+    ///         deposit. This will move the deposit into an active state.
+    /// @dev Takes a pre-parsed transaction and calculates values needed to
+    ///      verify funding.
+    /// @param _txVersion Transaction version number (4-byte little-endian).
+    /// @param _txInputVector All transaction inputs prepended by the number of
+    ///        inputs encoded as a VarInt, max 0xFC(252) inputs.
+    /// @param _txOutputVector All transaction outputs prepended by the number
+    ///         of outputs encoded as a VarInt, max 0xFC(252) outputs.
+    /// @param _txLocktime Final 4 bytes of the transaction.
+    /// @param _fundingOutputIndex Index of funding output in _txOutputVector
+    ///        (0-indexed).
+    /// @param _merkleProof The merkle proof of transaction inclusion in a
+    ///        block.
+    /// @param _txIndexInBlock Transaction index in the block (0-indexed).
+    /// @param _bitcoinHeaders Single bytestring of 80-byte bitcoin headers,
+    ///        lowest height first.
     function provideBTCFundingProof(
         bytes4 _txVersion,
         bytes memory _txInputVector,
@@ -368,13 +467,24 @@ contract Deposit is DepositFactoryAuthority {
     // FRAUD
     //
 
-    /// @notice                 Anyone can provide a signature that was not requested to prove fraud.
-    /// @dev                    Calls out to the keep to verify if there was fraud.
-    /// @param  _v              Signature recovery value.
-    /// @param  _r              Signature R value.
-    /// @param  _s              Signature S value.
-    /// @param _signedDigest    The digest signed by the signature vrs tuple.
-    /// @param _preimage        The sha256 preimage of the digest.
+    /// @notice Anyone can provide a signature that was not requested to prove
+    ///         fraud.
+    /// @notice Anyone can provide a signature corresponding to the signers'
+    ///         public key that was not requested to prove fraud. A redemption
+    ///         request and a redemption fee increase are the only ways to
+    ///         request a signature from the signers.
+    /// @dev This call will revert if the underlying keep cannot verify that
+    ///      there was fraud. Fraud is handled by seizing signer bonds and
+    ///      putting them up for auction in exchange for the lot size amount in
+    ///      TBTC (see `purchaseSignerBondsAtAuction`). Emits a
+    ///      LiquidationStarted event. The caller is captured as the liquidation
+    ///      initiator, and is eligible for any bond left after the auction is
+    ///      completed.
+    /// @param  _v Signature recovery value.
+    /// @param  _r Signature R value.
+    /// @param  _s Signature S value.
+    /// @param _signedDigest The digest signed by the signature (v,r,s) tuple.
+    /// @param _preimage The sha256 preimage of the digest.
     function provideECDSAFraudProof(
         uint8 _v,
         bytes32 _r,
@@ -390,83 +500,131 @@ contract Deposit is DepositFactoryAuthority {
     //
 
     /// @notice Get the current collateralization level for this Deposit.
-    /// @dev    This value represents the percentage of the backing BTC value the signers
-    ///         currently must hold as bond.
+    /// @dev This value represents the percentage of the backing BTC value the
+    ///      signers currently must hold as bond.
     /// @return The current collateralization level for this deposit.
     function getCollateralizationPercentage() public view returns (uint256) {
         return self.getCollateralizationPercentage();
     }
 
     /// @notice Get the initial collateralization level for this Deposit.
-    /// @dev    This value represents the percentage of the backing BTC value the signers hold initially.
+    /// @dev This value represents the percentage of the backing BTC value
+    ///      the signers hold initially. It is set at creation time.
     /// @return The initial collateralization level for this deposit.
     function getInitialCollateralizedPercent() public view returns (uint16) {
         return self.initialCollateralizedPercent;
     }
 
     /// @notice Get the undercollateralization level for this Deposit.
-    /// @dev    This collateralization level is semi-critical. If the collateralization level falls
-    ///         below this percentage the Deposit can get courtesy-called. This value represents the percentage
-    ///         of the backing BTC value the signers must hold as bond in order to not be undercollateralized.
+    /// @dev This collateralization level is semi-critical. If the
+    ///      collateralization level falls below this percentage the Deposit can
+    ///      be courtesy-called by calling `notifyCourtesyCall`. This value
+    ///      represents the percentage of the backing BTC value the signers must
+    ///      hold as bond in order to not be undercollateralized. It is set at
+    ///      creation time. Note that the value for new deposits in TBTCSystem
+    ///      can be changed by governance, but the value for a particular
+    ///      deposit is static once the deposit is created.
     /// @return The undercollateralized level for this deposit.
     function getUndercollateralizedThresholdPercent() public view returns (uint16) {
         return self.undercollateralizedThresholdPercent;
     }
 
     /// @notice Get the severe undercollateralization level for this Deposit.
-    /// @dev    This collateralization level is critical. If the collateralization level falls
-    ///         below this percentage the Deposit can get liquidated. This value represents the percentage
-    ///         of the backing BTC value the signers must hold as bond in order to not be severely undercollateralized.
+    /// @dev This collateralization level is critical. If the collateralization
+    ///      level falls below this percentage the Deposit can get liquidated.
+    ///      This value represents the percentage of the backing BTC value the
+    ///      signers must hold as bond in order to not be severely
+    ///      undercollateralized. It is set at creation time. Note that the
+    ///      value for new deposits in TBTCSystem can be changed by governance,
+    ///      but the value for a particular deposit is static once the deposit
+    ///      is created.
     /// @return The severely undercollateralized level for this deposit.
     function getSeverelyUndercollateralizedThresholdPercent() public view returns (uint16) {
         return self.severelyUndercollateralizedThresholdPercent;
     }
 
-    /// @notice     Calculates the amount of value at auction right now.
-    /// @dev        We calculate the % of the auction that has elapsed, then scale the value up.
-    /// @return     The value in wei to distribute in the auction at the current time.
+    /// @notice Calculates the amount of value at auction right now.
+    /// @dev This call will revert if the deposit is not in a state where an
+    ///      auction is currently in progress.
+    /// @return The value in wei that would be received in exchange for the
+    ///         deposit's lot size in TBTC if `purchaseSignerBondsAtAuction`
+    ///         were called at the time this function is called.
     function auctionValue() public view returns (uint256) {
         return self.auctionValue();
     }
 
-    /// @notice     Closes an auction and purchases the signer bonds. Payout to buyer, funder, then signers if not fraud.
-    /// @dev        For interface, reading auctionValue will give a past value. the current is better.
+    /// @notice Closes an auction and purchases the signer bonds by transferring
+    ///         the lot size in TBTC to the redeemer, if there is one, or to the
+    ///         TDT holder if not. Any bond amount that is not currently up for
+    ///         auction is either made available for the liquidation initiator
+    ///         to withdraw (for fraud) or split 50-50 between the initiator and
+    ///         the signers (for abort or collateralization issues).
+    /// @dev The amount of ETH given for the transferred TBTC can be read using
+    ///      the `auctionValue` function; note, however, that the function's
+    ///      value is only static during the specific block it is queried, as it
+    ///      varies by block timestamp.
     function purchaseSignerBondsAtAuction() public {
         self.purchaseSignerBondsAtAuction();
     }
 
-    /// @notice     Notify the contract that the signers are undercollateralized.
-    /// @dev        Calls out to the system for oracle info.
+    /// @notice Notify the contract that the signers are undercollateralized.
+    /// @dev This call will revert if the signers are not in fact
+    ///      undercollateralized according to the price feed. After
+    ///      TBTCConstants.COURTESY_CALL_DURATION, courtesy call times out and
+    ///      regular abort liquidation occurs; see
+    ///      `notifyCourtesyTimedOut`.
     function notifyCourtesyCall() public {
         self.notifyCourtesyCall();
     }
 
-    /// @notice     Goes from courtesy call to active.
-    /// @dev        Only callable if collateral is sufficient and the deposit is not expiring.
+    /// @notice Notify the contract that the signers' bond value has recovered
+    ///         enough to be considered sufficiently collateralized.
+    /// @dev This call will revert if collateral is still below the
+    ///      undercollateralized threshold according to the price feed.
     function exitCourtesyCall() public {
         self.exitCourtesyCall();
     }
 
-    /// @notice     Notify the contract that the signers are undercollateralized.
-    /// @dev        Calls out to the system for oracle info.
+    /// @notice Notify the contract that the signers are undercollateralized.
+    /// @dev Calls out to the system for oracle info.
+    /// @dev This call will revert if the signers are not in fact severely
+    ///      undercollateralized according to the price feed. Severe
+    ///      undercollateralization is treated as an abort, and is handled by
+    ///      seizing signer bonds and putting them up for auction in exchange
+    ///      for the lot size amount in TBTC (see
+    ///      `purchaseSignerBondsAtAuction`). Emits a LiquidationStarted event.
+    ///      The caller is captured as the liquidation initiator, and is
+    ///      eligible for 50% of any bond left after the auction is completed.
     function notifyUndercollateralizedLiquidation() public {
         self.notifyUndercollateralizedLiquidation();
     }
 
-    /// @notice     Notifies the contract that the courtesy period has elapsed.
-    /// @dev        This is treated as an abort, rather than fraud.
+    /// @notice Notifies the contract that the courtesy period has expired and
+    ///         the deposit should move into liquidation.
+    /// @dev This call will revert if the courtesy call period has not in fact
+    ///      expired or is not in the courtesy call state. Courtesy call
+    ///      expiration is treated as an abort, and is handled by seizing signer
+    ///      bonds and putting them up for auction for the lot size amount in
+    ///      TBTC (see `purchaseSignerBondsAtAuction`). Emits a
+    ///      LiquidationStarted event. The caller is captured as the liquidation
+    ///      initiator, and is eligible for 50% of any bond left after the
+    ///      auction is completed.
     function notifyCourtesyTimeout() public {
         self.notifyCourtesyTimeout();
     }
 
-    /// @notice     Withdraw caller's allowance.
-    /// @dev        Withdrawals can only happen when a contract is in an end-state.
+    /// @notice Withdraw caller's allowance.
+    /// @dev Withdrawals can only happen when a contract is in an end-state.
     function withdrawFunds() public {
         self.withdrawFunds();
     }
 
-    /// @notice     Get caller's withdraw allowance.
-    /// @return     The withdraw allowance in wei.
+    /// @notice Get caller's ETH withdraw allowance.
+    /// @dev Generally ETH is only available to withdraw after the deposit
+    ///      reaches a closed state. The amount reported is for the sender, and
+    ///      can be withdrawn using `withdrawFunds` if the deposit is in an end
+    ///      state.
+    /// @return The withdraw allowance in wei.
     function getWithdrawAllowance() public view returns (uint256) {
         return self.getWithdrawAllowance();
     }

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -215,11 +215,13 @@ contract Deposit is DepositFactoryAuthority {
     /// @notice Notify the contract that signing group setup has timed out if
     ///         retrieveSignerPubkey is not successfully called within the
     ///         allotted time.
-    /// @dev This
-    ///      RegisteredPubkey event with the two components. Reverts if the
-    ///      deposit is not awaiting signer setup, if the generated public key
-    ///      is unset or has incorrect length, or if the public key has a 0
-    ///      X or Y value.
+    /// @dev This is considered a signer fault, and the signers' bonds are used
+    ///      to make the deposit setup fee available for withdrawal by the TDT
+    ///      holder as a refund. The remainder of the signers' bonds are
+    ///      returned to the bonding pool and the signers are released from any
+    ///      further responsibilities. Reverts if the deposit is not awaiting
+    ///      signer setup or if the signing group formation timeout has not
+    ///      elapsed.
     function notifySignerSetupFailed() public {
         self.notifySignerSetupFailed();
     }

--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -82,7 +82,7 @@ contract Deposit is DepositFactoryAuthority {
     /// @dev We implement this because contracts don't handle foreign enums
     ///      well. See `DepositStates` for more info on states.
     /// @return The 0-indexed state from the DepositStates enum.
-    function getCurrentState() public view returns (uint256) {
+    function currentState() public view returns (uint256) {
         return uint256(self.currentState);
     }
 
@@ -96,7 +96,7 @@ contract Deposit is DepositFactoryAuthority {
     ///         this Deposit.
     /// @dev The keep contract address is saved on Deposit initialization.
     /// @return Address of the Keep contract.
-    function getKeepAddress() public view returns (address) {
+    function keepAddress() public view returns (address) {
         return self.keepAddress;
     }
 
@@ -113,15 +113,15 @@ contract Deposit is DepositFactoryAuthority {
     /// @dev This value represents the percentage of the backing BTC value the
     ///      signers currently must hold as bond.
     /// @return The current collateralization level for this deposit.
-    function getCollateralizationPercentage() public view returns (uint256) {
-        return self.getCollateralizationPercentage();
+    function collateralizationPercentage() public view returns (uint256) {
+        return self.collateralizationPercentage();
     }
 
     /// @notice Get the initial collateralization level for this Deposit.
     /// @dev This value represents the percentage of the backing BTC value
     ///      the signers hold initially. It is set at creation time.
     /// @return The initial collateralization level for this deposit.
-    function getInitialCollateralizedPercent() public view returns (uint16) {
+    function initialCollateralizedPercent() public view returns (uint16) {
         return self.initialCollateralizedPercent;
     }
 
@@ -135,7 +135,7 @@ contract Deposit is DepositFactoryAuthority {
     ///      can be changed by governance, but the value for a particular
     ///      deposit is static once the deposit is created.
     /// @return The undercollateralized level for this deposit.
-    function getUndercollateralizedThresholdPercent() public view returns (uint16) {
+    function undercollateralizedThresholdPercent() public view returns (uint16) {
         return self.undercollateralizedThresholdPercent;
     }
 
@@ -149,7 +149,7 @@ contract Deposit is DepositFactoryAuthority {
     ///      but the value for a particular deposit is static once the deposit
     ///      is created.
     /// @return The severely undercollateralized level for this deposit.
-    function getSeverelyUndercollateralizedThresholdPercent() public view returns (uint16) {
+    function severelyUndercollateralizedThresholdPercent() public view returns (uint16) {
         return self.severelyUndercollateralizedThresholdPercent;
     }
 
@@ -206,7 +206,7 @@ contract Deposit is DepositFactoryAuthority {
     ///      can be withdrawn using `withdrawFunds` if the deposit is in an end
     ///      state.
     /// @return The withdraw allowance in wei.
-    function getWithdrawAllowance() public view returns (uint256) {
+    function withdrawableAmount() public view returns (uint256) {
         return self.getWithdrawAllowance();
     }
 
@@ -636,5 +636,4 @@ contract Deposit is DepositFactoryAuthority {
     function withdrawFunds() public {
         self.withdrawFunds();
     }
-
 }

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -86,7 +86,7 @@ library DepositFunding {
 
     /// @notice     Anyone may notify the contract that signing group setup has timed out.
     /// @param  _d  Deposit storage pointer.
-    function notifySignerSetupFailure(DepositUtils.Deposit storage _d) public {
+    function notifySignerSetupFailed(DepositUtils.Deposit storage _d) public {
         require(_d.inAwaitingSignerSetup(), "Not awaiting setup");
         require(
             block.timestamp > _d.signingGroupRequestedAt.add(TBTCConstants.getSigningGroupFormationTimeout()),
@@ -129,11 +129,14 @@ library DepositFunding {
             _d.signingGroupPubkeyY);
     }
 
-    /// @notice     Anyone may notify the contract that the funder has failed to send BTC.
-    /// @dev        This is considered a funder fault, and the funder's payment
-    ///             for opening the deposit is not refunded.
-    /// @param  _d  Deposit storage pointer.
-    function notifyFundingTimeout(DepositUtils.Deposit storage _d) public {
+    /// @notice Anyone may notify the contract that the funder has failed to
+    ///         prove that they have sent BTC in time.
+    /// @dev This is considered a funder fault, and the funder's payment for
+    ///      opening the deposit is not refunded. Reverts if the funding timeout
+    ///      has not yet elapsed, or if the deposit is not currently awaiting
+    ///      funding proof.
+    /// @param _d Deposit storage pointer.
+    function notifyFundingTimedOut(DepositUtils.Deposit storage _d) public {
         require(_d.inAwaitingBTCFundingProof(), "Funding timeout has not started");
         require(
             block.timestamp > _d.fundingProofTimerStart.add(TBTCConstants.getFundingTimeout()),

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -40,15 +40,15 @@ library DepositFunding {
         _d.signingGroupPubkeyY = bytes32(0);
     }
 
-    /// @notice         Internally called function to set up a newly created Deposit instance.
-    ///                 This should not be called by developers, use `DepositFactory.createNewDeposit`
-    ///                 to create a new deposit.
-    /// @dev            If called directly, the transaction will revert since the call will be
-    ///                 executed on an already set-up instance.
-    /// @param _d       Deposit storage pointer.
-    /// @param _m       Signing group honesty threshold.
-    /// @param _n       Signing group size.
-    function createNewDeposit(
+    /// @notice Internally called function to set up a newly created Deposit
+    ///         instance. This should not be called by developers, use
+    ///         `DepositFactory.createDeposit` to create a new deposit.
+    /// @dev If called directly, the transaction will revert since the call will
+    ///      be executed on an already set-up instance.
+    /// @param _d Deposit storage pointer.
+    /// @param _m Signing group honesty threshold.
+    /// @param _n Signing group size.
+    function initialize(
         DepositUtils.Deposit storage _d,
         uint16 _m,
         uint16 _n,

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -47,7 +47,7 @@ library DepositLiquidation {
     /// @dev        Compares the bond value and lot value.
     /// @param _d   Deposit storage pointer.
     /// @return     Collateralization percentage as uint.
-    function getCollateralizationPercentage(DepositUtils.Deposit storage _d) public view returns (uint256) {
+    function collateralizationPercentage(DepositUtils.Deposit storage _d) public view returns (uint256) {
 
         // Determine value of the lot in wei
         uint256 _satoshiPrice = _d.fetchBitcoinPrice();
@@ -192,7 +192,7 @@ library DepositLiquidation {
     /// @param  _d  Deposit storage pointer.
     function notifyCourtesyCall(DepositUtils.Deposit storage _d) public  {
         require(_d.inActive(), "Can only courtesy call from active state");
-        require(getCollateralizationPercentage(_d) < _d.undercollateralizedThresholdPercent, "Signers have sufficient collateral");
+        require(collateralizationPercentage(_d) < _d.undercollateralizedThresholdPercent, "Signers have sufficient collateral");
         _d.courtesyCallInitiated = block.timestamp;
         _d.setCourtesyCall();
         _d.logCourtesyCalled();
@@ -203,7 +203,7 @@ library DepositLiquidation {
     /// @param  _d  Deposit storage pointer.
     function exitCourtesyCall(DepositUtils.Deposit storage _d) public {
         require(_d.inCourtesyCall(), "Not currently in courtesy call");
-        require(getCollateralizationPercentage(_d) >= _d.undercollateralizedThresholdPercent, "Deposit is still undercollateralized");
+        require(collateralizationPercentage(_d) >= _d.undercollateralizedThresholdPercent, "Deposit is still undercollateralized");
         _d.setActive();
         _d.logExitedCourtesyCall();
     }
@@ -213,7 +213,7 @@ library DepositLiquidation {
     /// @param  _d  Deposit storage pointer.
     function notifyUndercollateralizedLiquidation(DepositUtils.Deposit storage _d) public {
         require(_d.inRedeemableState(), "Deposit not in active or courtesy call");
-        require(getCollateralizationPercentage(_d) < _d.severelyUndercollateralizedThresholdPercent, "Deposit has sufficient collateral");
+        require(collateralizationPercentage(_d) < _d.severelyUndercollateralizedThresholdPercent, "Deposit has sufficient collateral");
         startLiquidation(_d, false);
     }
 

--- a/solidity/contracts/deposit/DepositLiquidation.sol
+++ b/solidity/contracts/deposit/DepositLiquidation.sol
@@ -220,7 +220,7 @@ library DepositLiquidation {
     /// @notice     Notifies the contract that the courtesy period has elapsed.
     /// @dev        This is treated as an abort, rather than fraud.
     /// @param  _d  Deposit storage pointer.
-    function notifyCourtesyTimeout(DepositUtils.Deposit storage _d) public {
+    function notifyCourtesyCallExpired(DepositUtils.Deposit storage _d) public {
         require(_d.inCourtesyCall(), "Not in a courtesy call period");
         require(block.timestamp >= _d.courtesyCallInitiated.add(TBTCConstants.getCourtesyCallTimeout()), "Courtesy period has not elapsed");
         startLiquidation(_d, false);

--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -362,7 +362,7 @@ library DepositRedemption {
     /// @notice     Anyone may notify the contract that the signers have failed to produce a signature.
     /// @dev        This is considered fraud, and is punished.
     /// @param  _d  Deposit storage pointer.
-    function notifySignatureTimeout(DepositUtils.Deposit storage _d) public {
+    function notifyRedemptionSignatureTimedOut(DepositUtils.Deposit storage _d) public {
         require(_d.inAwaitingWithdrawalSignature(), "Not currently awaiting a signature");
         require(block.timestamp > _d.withdrawalRequestTime.add(TBTCConstants.getSignatureTimeout()), "Signature timer has not elapsed");
         _d.startLiquidation(false);  // not fraud, just failure
@@ -371,7 +371,7 @@ library DepositRedemption {
     /// @notice     Anyone may notify the contract that the signers have failed to produce a redemption proof.
     /// @dev        This is considered fraud, and is punished.
     /// @param  _d  Deposit storage pointer.
-    function notifyRedemptionProofTimeout(DepositUtils.Deposit storage _d) public {
+    function notifyRedemptionProofTimedOut(DepositUtils.Deposit storage _d) public {
         require(_d.inAwaitingWithdrawalProof(), "Not currently awaiting a redemption proof");
         require(block.timestamp > _d.withdrawalRequestTime.add(TBTCConstants.getRedemptionProofTimeout()), "Proof timer has not elapsed");
         _d.startLiquidation(false);  // not fraud, just failure

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -67,7 +67,7 @@ library DepositUtils {
         bytes utxoOutpoint;  // the 36-byte outpoint of the custodied UTXO
 
         /// @dev Map of ETH balances an address can withdraw after contract reaches ends-state.
-        mapping(address => uint256) withdrawalAllowances;
+        mapping(address => uint256) withdrawableAmounts;
 
         /// @dev Map of timestamps representing when transaction digests were approved for signing
         mapping (bytes32 => uint256) approvedDigests;
@@ -392,33 +392,33 @@ library DepositUtils {
     /// @notice     Adds a given amount to the withdraw allowance for the address.
     /// @dev        Withdrawals can only happen when a contract is in an end-state.
     function enableWithdrawal(DepositUtils.Deposit storage _d, address _withdrawer, uint256 _amount) internal {
-        _d.withdrawalAllowances[_withdrawer] = _d.withdrawalAllowances[_withdrawer].add(_amount);
+        _d.withdrawableAmounts[_withdrawer] = _d.withdrawableAmounts[_withdrawer].add(_amount);
     }
 
     /// @notice     Withdraw caller's allowance.
     /// @dev        Withdrawals can only happen when a contract is in an end-state.
     function withdrawFunds(DepositUtils.Deposit storage _d) internal {
-        uint256 available = _d.withdrawalAllowances[msg.sender];
+        uint256 available = _d.withdrawableAmounts[msg.sender];
 
         require(_d.inEndState(), "Contract not yet terminated");
         require(available > 0, "Nothing to withdraw");
         require(address(this).balance >= available, "Insufficient contract balance");
 
         // zero-out to prevent reentrancy
-        _d.withdrawalAllowances[msg.sender] = 0;
+        _d.withdrawableAmounts[msg.sender] = 0;
 
         /* solium-disable-next-line security/no-call-value */
         (bool ok,) = msg.sender.call.value(available)("");
         require(
             ok,
-            "Failed to send withdrawal allowance to sender"
+            "Failed to send withdraw allowance to sender"
         );
     }
 
     /// @notice     Get the caller's withdraw allowance.
     /// @return     The caller's withdraw allowance in wei.
     function getWithdrawAllowance(DepositUtils.Deposit storage _d) internal view returns (uint256) {
-        return _d.withdrawalAllowances[msg.sender];
+        return _d.withdrawableAmounts[msg.sender];
     }
 
     /// @notice     Distributes the fee rebate to the Fee Rebate Token owner.

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -411,7 +411,7 @@ library DepositUtils {
         (bool ok,) = msg.sender.call.value(available)("");
         require(
             ok,
-            "Failed to send withdraw allowance to sender"
+            "Failed to send withdrawable amount to sender"
         );
     }
 

--- a/solidity/contracts/deposit/DepositUtils.sol
+++ b/solidity/contracts/deposit/DepositUtils.sol
@@ -417,7 +417,7 @@ library DepositUtils {
 
     /// @notice     Get the caller's withdraw allowance.
     /// @return     The caller's withdraw allowance in wei.
-    function getWithdrawAllowance(DepositUtils.Deposit storage _d) internal view returns (uint256) {
+    function getWithdrawableAmount(DepositUtils.Deposit storage _d) internal view returns (uint256) {
         return _d.withdrawableAmounts[msg.sender];
     }
 

--- a/solidity/contracts/proxy/DepositFactory.sol
+++ b/solidity/contracts/proxy/DepositFactory.sol
@@ -67,9 +67,14 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     ///         currently the only way to create a new deposit.
     /// @dev Calls `Deposit.initializeDeposit` to initialize the instance. Mints
     ///      the TDT to the function caller. (See `TBTCDepositToken` for more
-    ///      info on TDTs).
-    /// @return True if successful, otherwise the new deposit's address.
-    function createDeposit (uint64 _lotSizeSatoshis) public payable returns(address) {
+    ///      info on TDTs). Reverts if new deposits are currently paused, if the
+    ///      specified lot size is not currently permitted, or if the selection
+    ///      of the signers fails for any reason. Also reverts if the bonds
+    ///      collateralizing the deposit would not be enough to cover a refund
+    ///      of the deposit creation fee, should the signer group fail to
+    ///      complete its setup process.
+    /// @return The address of the new deposit.
+    function createDeposit(uint64 _lotSizeSatoshis) public payable returns(address) {
         address cloneAddress = createClone(masterDepositAddress);
 
         TBTCDepositToken(tbtcDepositToken).mint(msg.sender, uint256(cloneAddress));

--- a/solidity/contracts/proxy/DepositFactory.sol
+++ b/solidity/contracts/proxy/DepositFactory.sol
@@ -63,12 +63,12 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
 
     event DepositCloneCreated(address depositCloneAddress);
 
-    /// @notice                Creates a new deposit instance and mints a TDT.
-    ///                        This function is currently the only way to create a new deposit.
-    /// @dev                   Calls `Deposit.createNewDeposit` to initialize the instance.
-    ///                        Mints the TDT to the function caller.
-    ///                        (See `TBTCDepositToken` for more info on TDTs).
-    /// @return                True if successful, otherwise revert.
+    /// @notice Creates a new deposit instance and mints a TDT. This function is
+    ///         currently the only way to create a new deposit.
+    /// @dev Calls `Deposit.initializeDeposit` to initialize the instance. Mints
+    ///      the TDT to the function caller. (See `TBTCDepositToken` for more
+    ///      info on TDTs).
+    /// @return True if successful, otherwise the new deposit's address.
     function createDeposit (uint64 _lotSizeSatoshis) public payable returns(address) {
         address cloneAddress = createClone(masterDepositAddress);
 
@@ -76,7 +76,7 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
 
         Deposit deposit = Deposit(address(uint160(cloneAddress)));
         deposit.initialize(address(this));
-        deposit.createNewDeposit.value(msg.value)(
+        deposit.initializeDeposit.value(msg.value)(
                 tbtcSystem,
                 tbtcToken,
                 tbtcDepositToken,

--- a/solidity/contracts/system/FeeRebateToken.sol
+++ b/solidity/contracts/system/FeeRebateToken.sol
@@ -16,7 +16,7 @@ import "./VendingMachineAuthority.sol";
 contract FeeRebateToken is ERC721Metadata, VendingMachineAuthority {
 
     constructor(address _vendingMachine)
-        ERC721Metadata("Fee Rebate Token", "FRT")
+        ERC721Metadata("tBTC Fee Rebate Token", "FRT")
         VendingMachineAuthority(_vendingMachine)
     public {
         // solium-disable-previous-line no-empty-blocks

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -12,7 +12,7 @@ contract TestDeposit is Deposit {
     // solium-disable-previous-line no-empty-blocks
     }
 
-    function createNewDeposit(
+    function initializeDeposit(
         ITBTCSystem _tbtcSystem,
         TBTCToken _tbtcToken,
         IERC721 _tbtcDepositToken,
@@ -27,7 +27,7 @@ contract TestDeposit is Deposit {
         self.tbtcDepositToken = _tbtcDepositToken;
         self.feeRebateToken = _feeRebateToken;
         self.vendingMachineAddress = _vendingMachineAddress;
-        self.createNewDeposit(_m, _n, _lotSizeSatoshis);
+        self.initialize(_m, _n, _lotSizeSatoshis);
     }
 
     function setExteriorAddresses(

--- a/solidity/contracts/test/deposit/TestDepositUtils.sol
+++ b/solidity/contracts/test/deposit/TestDepositUtils.sol
@@ -49,10 +49,6 @@ contract TestDepositUtils is TestDeposit {
         return self.signerPKH();
     }
 
-    function utxoValue() public view returns (uint256) {
-        return self.utxoValue();
-    }
-
     function fetchBitcoinPrice() public view returns (uint256) {
         return self.fetchBitcoinPrice();
     }

--- a/solidity/test/DepositFactoryTest.js
+++ b/solidity/test/DepositFactoryTest.js
@@ -169,8 +169,8 @@ describe("DepositFactory", async function() {
 
       // deposit1 should be AWAITING_BTC_FUNDING_PROOF (2)
       // deposit2 should be ACTIVE (5)
-      const deposit1state = await deposit1.getCurrentState()
-      const deposit2state = await deposit2.getCurrentState()
+      const deposit1state = await deposit1.currentState()
+      const deposit2state = await deposit2.currentState()
 
       expect(
         deposit1state,
@@ -204,7 +204,7 @@ describe("DepositFactory", async function() {
       await testDeposit.retrieveSignerPubkey()
 
       // master deposit should now be in AWAITING_BTC_FUNDING_PROOF
-      const masterState = await testDeposit.getCurrentState()
+      const masterState = await testDeposit.currentState()
 
       const blockNumber = await web3.eth.getBlockNumber()
 
@@ -218,7 +218,7 @@ describe("DepositFactory", async function() {
       const depositNew = await TestDeposit.at(cloneNew)
 
       // should be behind Master, at AWAITING_SIGNER_SETUP
-      const newCloneState = await depositNew.getCurrentState()
+      const newCloneState = await depositNew.currentState()
 
       expect(
         masterState,

--- a/solidity/test/DepositFactoryTest.js
+++ b/solidity/test/DepositFactoryTest.js
@@ -185,7 +185,7 @@ describe("DepositFactory", async function() {
       const keep = await ECDSAKeepStub.new()
 
       await tbtcDepositToken.forceMint(accounts[0], testDeposit.address)
-      await testDeposit.createNewDeposit(
+      await testDeposit.initializeDeposit(
         tbtcSystemStub.address,
         tbtcToken.address,
         tbtcDepositToken.address,

--- a/solidity/test/DepositFraudTest.js
+++ b/solidity/test/DepositFraudTest.js
@@ -72,7 +72,7 @@ describe("DepositFraud", async function() {
       await assertBalance.eth(ecdsaKeepStub.address, new BN(0))
       await assertBalance.eth(testDeposit.address, new BN(bond))
 
-      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+      const withdrawable = await testDeposit.withdrawableAmount.call({
         from: beneficiary,
       })
       expect(withdrawable).to.eq.BN(new BN(bond))
@@ -161,7 +161,7 @@ describe("DepositFraud", async function() {
       const currentBond = await web3.eth.getBalance(ecdsaKeepStub.address)
       const {receipt} = await testDeposit.startLiquidation(true)
 
-      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+      const withdrawable = await testDeposit.withdrawableAmount.call({
         from: owner,
       })
       expect(withdrawable).to.eq.BN(new BN(currentBond))

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -66,7 +66,7 @@ describe("DepositFunding", async function() {
     await restoreSnapshot()
   })
 
-  describe("createNewDeposit", async () => {
+  describe("initializeDeposit", async () => {
     it("runs and updates state and fires a created event", async () => {
       const expectedKeepAddress = ecdsaKeepStub.address
       const depositFee = await tbtcSystemStub.getNewDepositFeeEstimate()
@@ -76,7 +76,7 @@ describe("DepositFunding", async function() {
 
       const blockNumber = await web3.eth.getBlockNumber()
 
-      await testDeposit.createNewDeposit(
+      await testDeposit.initializeDeposit(
         tbtcSystemStub.address,
         tbtcToken.address,
         tbtcDepositToken.address,
@@ -132,7 +132,7 @@ describe("DepositFunding", async function() {
       await ecdsaKeepStub.setBondAmount(depositFee - 1)
 
       await expectRevert(
-        testDeposit.createNewDeposit.call(
+        testDeposit.initializeDeposit.call(
           tbtcSystemStub.address,
           tbtcToken.address,
           tbtcDepositToken.address,
@@ -150,7 +150,7 @@ describe("DepositFunding", async function() {
       await testDeposit.setState(states.REDEEMED)
 
       await expectRevert(
-        testDeposit.createNewDeposit.call(
+        testDeposit.initializeDeposit.call(
           tbtcSystemStub.address,
           tbtcToken.address,
           tbtcDepositToken.address,
@@ -168,7 +168,7 @@ describe("DepositFunding", async function() {
       await tbtcSystemStub.emergencyPauseNewDeposits()
 
       await expectRevert(
-        testDeposit.createNewDeposit.call(
+        testDeposit.initializeDeposit.call(
           tbtcSystemStub.address,
           tbtcToken.address,
           tbtcDepositToken.address,

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -98,7 +98,7 @@ describe("DepositFunding", async function() {
       const signerFeeDivisor = await testDeposit.getSignerFeeDivisor.call()
       expect(signerFeeDivisor).to.eq.BN(systemSignerFeeDivisor)
 
-      const keepAddress = await testDeposit.getKeepAddress.call()
+      const keepAddress = await testDeposit.keepAddress.call()
       expect(keepAddress, "keepAddress not as expected").to.equal(
         expectedKeepAddress,
       )
@@ -234,7 +234,7 @@ describe("DepositFunding", async function() {
 
       const signingGroupRequestedAt = await testDeposit.getSigningGroupRequestedAt.call()
 
-      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+      const withdrawable = await testDeposit.withdrawableAmount.call({
         from: owner,
       })
 

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -182,7 +182,7 @@ describe("DepositFunding", async function() {
       )
     })
   })
-  describe("notifySignerSetupFailure", async () => {
+  describe("notifySignerSetupFailed", async () => {
     let timer
     let owner
     let openKeepFee
@@ -230,7 +230,7 @@ describe("DepositFunding", async function() {
 
     it("updates state to setup failed, deconstes state, logs SetupFailed, and refunds TDT owner", async () => {
       const blockNumber = await web3.eth.getBlockNumber()
-      await testDeposit.notifySignerSetupFailure({from: owner})
+      await testDeposit.notifySignerSetupFailed({from: owner})
 
       const signingGroupRequestedAt = await testDeposit.getSigningGroupRequestedAt.call()
 
@@ -264,7 +264,7 @@ describe("DepositFunding", async function() {
       await testDeposit.setState(states.START)
 
       await expectRevert(
-        testDeposit.notifySignerSetupFailure(),
+        testDeposit.notifySignerSetupFailed(),
         "Not awaiting setup",
       )
     })
@@ -273,7 +273,7 @@ describe("DepositFunding", async function() {
       await testDeposit.setSigningGroupRequestedAt(fundingProofTimerStart * 5)
 
       await expectRevert(
-        testDeposit.notifySignerSetupFailure(),
+        testDeposit.notifySignerSetupFailed(),
         "Signing group formation timeout not yet elapsed",
       )
     })
@@ -349,7 +349,7 @@ describe("DepositFunding", async function() {
     })
   })
 
-  describe("notifyFundingTimeout", async () => {
+  describe("notifyFundingTimedOut", async () => {
     let timer
 
     before(async () => {
@@ -368,7 +368,7 @@ describe("DepositFunding", async function() {
     it("updates the state to failed setup, deconsts funding info, and logs SetupFailed", async () => {
       const blockNumber = await web3.eth.getBlockNumber()
 
-      await testDeposit.notifyFundingTimeout()
+      await testDeposit.notifyFundingTimedOut()
 
       const depositState = await testDeposit.getState.call()
       expect(depositState).to.eq.BN(states.FAILED_SETUP)
@@ -384,7 +384,7 @@ describe("DepositFunding", async function() {
       await testDeposit.setState(states.START)
 
       await expectRevert(
-        testDeposit.notifyFundingTimeout(),
+        testDeposit.notifyFundingTimedOut(),
         "Funding timeout has not started",
       )
     })
@@ -393,7 +393,7 @@ describe("DepositFunding", async function() {
       await testDeposit.setFundingProofTimerStart(fundingProofTimerStart * 5)
 
       await expectRevert(
-        testDeposit.notifyFundingTimeout(),
+        testDeposit.notifyFundingTimedOut(),
         "Funding timeout has not elapsed",
       )
     })
@@ -430,7 +430,7 @@ describe("DepositFunding", async function() {
 
     it("emits a FunderAbortRequested event", async () => {
       const blockNumber = await web3.eth.getBlockNumber()
-      await testDeposit.notifyFundingTimeout()
+      await testDeposit.notifyFundingTimedOut()
 
       const outputScript = "0x012345"
       await testDeposit.requestFunderAbort(outputScript, {from: owner})

--- a/solidity/test/DepositLiquidationTest.js
+++ b/solidity/test/DepositLiquidationTest.js
@@ -225,6 +225,7 @@ describe("DepositLiquidation", async function() {
       await testDeposit.send(value, {from: accounts[8]})
 
       await testDeposit.setLiquidationAndCourtesyInitated(notifiedTime, 0)
+      await testDeposit.setState(states.LIQUIDATION_IN_PROGRESS)
       const auctionValue = await testDeposit.auctionValue.call()
 
       await testDeposit.purchaseSignerBondsAtAuction({from: buyer})

--- a/solidity/test/DepositLiquidationTest.js
+++ b/solidity/test/DepositLiquidationTest.js
@@ -78,7 +78,7 @@ describe("DepositLiquidation", async function() {
     await restoreSnapshot()
   })
 
-  describe("getCollateralizationPercentage", async () => {
+  describe("collateralizationPercentage", async () => {
     const ETHprice = new BN(190)
     const BTCPrice = new BN(7700)
     const satwei = BTCPrice.div(ETHprice).mul(new BN(10000000000))
@@ -90,7 +90,7 @@ describe("DepositLiquidation", async function() {
       // expect 200% collateralization by setting bond = 2 * lotValue
       await ecdsaKeepStub.setBondAmount(satwei.mul(lotSize).mul(new BN(2)))
 
-      const collateralization = await testDeposit.getCollateralizationPercentage()
+      const collateralization = await testDeposit.collateralizationPercentage()
 
       expect(collateralization).to.eq.BN(new BN(200))
     })
@@ -102,7 +102,7 @@ describe("DepositLiquidation", async function() {
       // expect 100% collateralization by setting bond = lotValue.
       await ecdsaKeepStub.setBondAmount(satwei.mul(lotSize))
 
-      const collateralization = await testDeposit.getCollateralizationPercentage()
+      const collateralization = await testDeposit.collateralizationPercentage()
 
       expect(collateralization).to.eq.BN(new BN(100))
     })
@@ -114,7 +114,7 @@ describe("DepositLiquidation", async function() {
       // send 1/5 of value, expect 20% collateralization.
       await ecdsaKeepStub.setBondAmount(satwei.mul(lotSize).div(new BN(5)))
 
-      const collateralization = await testDeposit.getCollateralizationPercentage()
+      const collateralization = await testDeposit.collateralizationPercentage()
 
       expect(collateralization).to.eq.BN(new BN(20))
     })
@@ -126,7 +126,7 @@ describe("DepositLiquidation", async function() {
       // set less than 1% of bond, expect to receive a 0% collateralization (no decimals)
       await ecdsaKeepStub.setBondAmount(satwei.mul(lotSize).div(new BN(101)))
 
-      const collateralization = await testDeposit.getCollateralizationPercentage()
+      const collateralization = await testDeposit.collateralizationPercentage()
 
       expect(collateralization).to.eq.BN(new BN(0))
     })
@@ -233,7 +233,7 @@ describe("DepositLiquidation", async function() {
       // calculate the split of the un-purchased signer bond
       const split = value.sub(auctionValue).div(new BN(2))
 
-      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+      const withdrawable = await testDeposit.withdrawableAmount.call({
         from: buyer,
       })
 
@@ -277,7 +277,7 @@ describe("DepositLiquidation", async function() {
       const totalReward = (value * (100 - basePercentage)) / 100
       const split = totalReward / 2
 
-      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+      const withdrawable = await testDeposit.withdrawableAmount.call({
         from: liquidationInitiator,
       })
       const depositBalance = await web3.eth.getBalance(testDeposit.address)
@@ -314,7 +314,7 @@ describe("DepositLiquidation", async function() {
         new BN(initialSignerBalance),
       )
 
-      const withdrawable = await testDeposit.getWithdrawAllowance.call({
+      const withdrawable = await testDeposit.withdrawableAmount.call({
         from: liquidationInitiator,
       })
 
@@ -340,7 +340,7 @@ describe("DepositLiquidation", async function() {
       lotSize = await testDeposit.lotSizeSatoshis.call()
       lotValue = lotSize.mul(oraclePrice)
 
-      undercollateralizedPercent = await testDeposit.getUndercollateralizedThresholdPercent.call()
+      undercollateralizedPercent = await testDeposit.undercollateralizedThresholdPercent.call()
     })
 
     beforeEach(async () => {

--- a/solidity/test/DepositLiquidationTest.js
+++ b/solidity/test/DepositLiquidationTest.js
@@ -537,7 +537,7 @@ describe("DepositLiquidation", async function() {
     })
   })
 
-  describe("notifyCourtesyTimeout", async () => {
+  describe("notifyCourtesyCallExpired", async () => {
     let courtesyTime
     let timer
     before(async () => {
@@ -554,7 +554,7 @@ describe("DepositLiquidation", async function() {
     })
 
     it("executes and moves state to LIQUIDATION_IN_PROGRESS", async () => {
-      await testDeposit.notifyCourtesyTimeout()
+      await testDeposit.notifyCourtesyCallExpired()
       const depositState = await testDeposit.getState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
@@ -562,7 +562,7 @@ describe("DepositLiquidation", async function() {
     it("reverts if not in a courtesy call period", async () => {
       await testDeposit.setState(states.START)
       await expectRevert(
-        testDeposit.notifyCourtesyTimeout(),
+        testDeposit.notifyCourtesyCallExpired(),
         "Not in a courtesy call period",
       )
     })
@@ -570,14 +570,14 @@ describe("DepositLiquidation", async function() {
     it("reverts if the period has not elapsed", async () => {
       await testDeposit.setLiquidationAndCourtesyInitated(0, courtesyTime * 5)
       await expectRevert(
-        testDeposit.notifyCourtesyTimeout(),
+        testDeposit.notifyCourtesyCallExpired(),
         "Courtesy period has not elapsed",
       )
     })
 
     it("assert starts signer abort liquidation", async () => {
       await ecdsaKeepStub.send(1000000, {from: owner})
-      await testDeposit.notifyCourtesyTimeout()
+      await testDeposit.notifyCourtesyCallExpired()
 
       const bond = await web3.eth.getBalance(ecdsaKeepStub.address)
       expect(new BN(bond), "Bond not seized as expected").to.eq.BN("0")

--- a/solidity/test/DepositRedemptionTest.js
+++ b/solidity/test/DepositRedemptionTest.js
@@ -900,14 +900,14 @@ describe("DepositRedemption", async function() {
       timeoutError: "Signature timer has not elapsed",
       state: states.AWAITING_WITHDRAWAL_SIGNATURE,
       stateError: "Not currently awaiting a signature",
-      notifyFn: deposit => deposit.notifySignatureTimeout,
+      notifyFn: deposit => deposit.notifyRedemptionSignatureTimedOut,
     },
     "proof timeout": {
       timeoutFn: constants => constants.getRedemptionProofTimeout,
       timeoutError: "Proof timer has not elapsed",
       state: states.AWAITING_WITHDRAWAL_PROOF,
       stateError: "Not currently awaiting a redemption proof",
-      notifyFn: deposit => deposit.notifyRedemptionProofTimeout,
+      notifyFn: deposit => deposit.notifyRedemptionProofTimedOut,
     },
   }
 

--- a/solidity/test/DepositUtilsTest.js
+++ b/solidity/test/DepositUtilsTest.js
@@ -450,7 +450,7 @@ describe("DepositUtils", async function() {
     it("returns correct base percentage", async () => {
       const basePercentage = await testDeposit.getAuctionBasePercentage.call()
 
-      const initialCollateralization = await testDeposit.getInitialCollateralizedPercent()
+      const initialCollateralization = await testDeposit.initialCollateralizedPercent()
 
       // 10000 to avoid losing value to truncating in solidity.
       const expected = new BN(10000).div(initialCollateralization)
@@ -742,17 +742,17 @@ describe("DepositUtils", async function() {
       await restoreSnapshot()
     })
 
-    it("correctly adds value to withdrawalAllowances", async () => {
+    it("correctly adds value to withdrawableAmounts", async () => {
       const value = new BN(10000)
       const beneficiary = accounts[1]
 
-      const initialWithdrawable = await testDeposit.getWithdrawAllowance.call({
+      const initialWithdrawable = await testDeposit.withdrawableAmount.call({
         from: beneficiary,
       })
 
       await testDeposit.enableWithdrawal(accounts[1], value)
 
-      const finalWithdrawable = await testDeposit.getWithdrawAllowance.call({
+      const finalWithdrawable = await testDeposit.withdrawableAmount.call({
         from: beneficiary,
       })
 
@@ -790,7 +790,7 @@ describe("DepositUtils", async function() {
         const tx = await testDeposit.withdrawFunds({from: beneficiary})
         const finalBalance = await web3.eth.getBalance(beneficiary)
 
-        const withdrawable = await testDeposit.getWithdrawAllowance.call({
+        const withdrawable = await testDeposit.withdrawableAmount.call({
           from: beneficiary,
         })
         const gasPrice = await web3.eth.getGasPrice()

--- a/solidity/test/DepositUtilsTest.js
+++ b/solidity/test/DepositUtilsTest.js
@@ -56,7 +56,7 @@ describe("DepositUtils", async function() {
     await ecdsaKeepStub.setBondAmount(depositFee)
     await tbtcSystemStub.setKeepAddress(ecdsaKeepStub.address)
 
-    await testDeposit.createNewDeposit(
+    await testDeposit.initializeDeposit(
       tbtcSystemStub.address,
       tbtcToken.address,
       tbtcDepositToken.address,
@@ -344,7 +344,7 @@ describe("DepositUtils", async function() {
       await ecdsaKeepStub.setBondAmount(depositFee)
       await tbtcSystemStub.setKeepAddress(ecdsaKeepStub.address)
 
-      await testDeposit.createNewDeposit(
+      await testDeposit.initializeDeposit(
         tbtcSystemStub.address,
         tbtcToken.address,
         tbtcDepositToken.address,

--- a/solidity/test/DepositUtilsTest.js
+++ b/solidity/test/DepositUtilsTest.js
@@ -582,7 +582,26 @@ describe("DepositUtils", async function() {
   })
 
   describe("utxoValue()", async () => {
+    beforeEach(createSnapshot)
+    afterEach(restoreSnapshot)
+
+    it("reverts if the deposit is in a funding state", async () => {
+      for (const state of [
+        states.AWAITING_SIGNER_SETUP,
+        states.AWAITING_BTC_FUNDING_PROOF,
+      ]) {
+        await testDeposit.setState(state)
+
+        await expectRevert(
+          testDeposit.utxoValue.call(),
+          "Deposit has not yet been funded and has no available funding info",
+        )
+      }
+    })
+
     it("returns the state's utxoValueBytes as an integer", async () => {
+      await testDeposit.setState(states.ACTIVE)
+
       const utxoValue = await testDeposit.utxoValue.call()
       expect(utxoValue).to.eq.BN(0)
 

--- a/solidity/test/liquidation-tests/courtesyCallTest.js
+++ b/solidity/test/liquidation-tests/courtesyCallTest.js
@@ -32,7 +32,7 @@ describe("Integration -- courtesy_call", async function () {
       testDeposit.notifyCourtesyCall(),
       "Signers have sufficient collateral",
     )
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.ACTIVE)
   })
 
@@ -41,7 +41,7 @@ describe("Integration -- courtesy_call", async function () {
     await mockSatWeiPriceFeed.setPrice(satwei.add(new BN(1)))
     await testDeposit.notifyCourtesyCall()
 
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.COURTESY_CALL)
   })
 
@@ -50,7 +50,7 @@ describe("Integration -- courtesy_call", async function () {
       testDeposit.notifyCourtesyCallExpired(),
       "Courtesy period has not elapsed",
     )
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.COURTESY_CALL)
   })
 
@@ -58,7 +58,7 @@ describe("Integration -- courtesy_call", async function () {
     await mockSatWeiPriceFeed.setPrice(satwei)
     await testDeposit.exitCourtesyCall()
 
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.ACTIVE)
   })
 
@@ -68,7 +68,7 @@ describe("Integration -- courtesy_call", async function () {
       "Not currently in courtesy call",
     )
 
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.ACTIVE)
   })
 
@@ -76,7 +76,7 @@ describe("Integration -- courtesy_call", async function () {
     await mockSatWeiPriceFeed.setPrice(satwei.add(new BN(1)))
     await testDeposit.notifyCourtesyCall()
 
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.COURTESY_CALL)
   })
 
@@ -86,7 +86,7 @@ describe("Integration -- courtesy_call", async function () {
 
     await testDeposit.notifyCourtesyCallExpired({ from: liqInitiator })
     // not fraud and we did not come from redemption.
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
   })
 
@@ -97,7 +97,7 @@ describe("Integration -- courtesy_call", async function () {
       "Not currently in courtesy call",
     )
 
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
   })
 
@@ -107,7 +107,7 @@ describe("Integration -- courtesy_call", async function () {
       testDeposit.purchaseSignerBondsAtAuction(),
       "Not enough TBTC to cover outstanding debt",
     )
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
   })
 
@@ -118,10 +118,10 @@ describe("Integration -- courtesy_call", async function () {
     await tbtcToken.approve(testDeposit.address, lotSizeTbtc, { from: auctionBuyer })
     await testDeposit.purchaseSignerBondsAtAuction({ from: auctionBuyer })
 
-    const allowance = await testDeposit.getWithdrawAllowance({ from: auctionBuyer })
+    const allowance = await testDeposit.withdrawableAmount({ from: auctionBuyer })
     await testDeposit.withdrawFunds({ from: auctionBuyer })
 
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     const endingBalance = await web3.eth.getBalance(testDeposit.address)
 
     expect(allowance).to.eq.BN(collateralAmount)
@@ -150,7 +150,7 @@ describe("Integration -- courtesy_call", async function () {
     await increaseTime(timer.toNumber())
     await testDeposit.notifyCourtesyCallExpired({ from: liqInitiator })
     // not fraud and we did not come from redemption.
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
   })
 
@@ -162,10 +162,10 @@ describe("Integration -- courtesy_call", async function () {
     await tbtcToken.approve(testDeposit.address, lotSizeTbtc, { from: auctionBuyer })
     await testDeposit.purchaseSignerBondsAtAuction({ from: auctionBuyer })
 
-    const allowance = await testDeposit.getWithdrawAllowance({ from: auctionBuyer })
+    const allowance = await testDeposit.withdrawableAmount({ from: auctionBuyer })
     await testDeposit.withdrawFunds({ from: auctionBuyer })
 
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     const endingBalance = await web3.eth.getBalance(testDeposit.address)
 
     expect(allowance).to.eq.BN(collateralAmount)

--- a/solidity/test/liquidation-tests/courtesyCallTest.js
+++ b/solidity/test/liquidation-tests/courtesyCallTest.js
@@ -47,7 +47,7 @@ describe("Integration -- courtesy_call", async function () {
 
   it("unabse to liquidate if timer has not elapsed", async () => {
     await expectRevert(
-      testDeposit.notifyCourtesyTimeout(),
+      testDeposit.notifyCourtesyCallExpired(),
       "Courtesy period has not elapsed",
     )
     const depositState = await testDeposit.getCurrentState.call()
@@ -84,7 +84,7 @@ describe("Integration -- courtesy_call", async function () {
     timer = await tbtcConstants.getCourtesyCallTimeout.call()
     await increaseTime(timer.toNumber())
 
-    await testDeposit.notifyCourtesyTimeout({ from: liqInitiator })
+    await testDeposit.notifyCourtesyCallExpired({ from: liqInitiator })
     // not fraud and we did not come from redemption.
     const depositState = await testDeposit.getCurrentState.call()
     expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
@@ -148,7 +148,7 @@ describe("Integration -- courtesy_call", async function () {
 
     timer = await tbtcConstants.getCourtesyCallTimeout.call()
     await increaseTime(timer.toNumber())
-    await testDeposit.notifyCourtesyTimeout({ from: liqInitiator })
+    await testDeposit.notifyCourtesyCallExpired({ from: liqInitiator })
     // not fraud and we did not come from redemption.
     const depositState = await testDeposit.getCurrentState.call()
     expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)

--- a/solidity/test/liquidation-tests/fraudProofTest.js
+++ b/solidity/test/liquidation-tests/fraudProofTest.js
@@ -60,7 +60,7 @@ describe("Integration -- fraud proof", async function () {
       testDeposit.purchaseSignerBondsAtAuction(),
       "Not enough TBTC to cover outstanding debt",
     )
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     expect(depositState).to.eq.BN(states.FRAUD_LIQUIDATION_IN_PROGRESS)
   })
 
@@ -71,10 +71,10 @@ describe("Integration -- fraud proof", async function () {
     await tbtcToken.approve(testDeposit.address, lotSizeTbtc, { from: auctionBuyer })
     await testDeposit.purchaseSignerBondsAtAuction({ from: auctionBuyer })
 
-    const allowance = await testDeposit.getWithdrawAllowance({ from: auctionBuyer })
+    const allowance = await testDeposit.withdrawableAmount({ from: auctionBuyer })
     await testDeposit.withdrawFunds({ from: auctionBuyer })
 
-    const depositState = await testDeposit.getCurrentState.call()
+    const depositState = await testDeposit.currentState.call()
     const endingBalance = await web3.eth.getBalance(testDeposit.address)
 
     expect(allowance).to.eq.BN(collateralAmount)

--- a/solidity/test/liquidation-tests/multiDepositBlackSwan.js
+++ b/solidity/test/liquidation-tests/multiDepositBlackSwan.js
@@ -39,7 +39,7 @@ describe("Integration -- black-swan", async function () {
       await mockSatWeiPriceFeed.setPrice(new BN("4666666666666"))// price down 90%
       await deposits[i].notifyUndercollateralizedLiquidation()
 
-      const depositState = await deposits[i].getCurrentState.call()
+      const depositState = await deposits[i].currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     }
   })

--- a/solidity/test/liquidation-tests/redemptionProofTimeoutTest.js
+++ b/solidity/test/liquidation-tests/redemptionProofTimeoutTest.js
@@ -37,7 +37,7 @@ describe("Integration -- Redemption-proof timeout", async function () {
   describe("Redemption-proof timeout", async () => {
     it("unable to start liquidation if timer not elapsed", async () => {
       await expectRevert(
-        testDeposit.notifyRedemptionProofTimeout(),
+        testDeposit.notifyRedemptionProofTimedOut(),
         "Not currently awaiting a redemption proof",
       )
       const depositState = await testDeposit.getCurrentState.call()
@@ -52,7 +52,7 @@ describe("Integration -- Redemption-proof timeout", async function () {
       const timer = await tbtcConstants.getRedemptionProofTimeout.call()
       await increaseTime(timer.toNumber())
 
-      await testDeposit.notifyRedemptionProofTimeout()
+      await testDeposit.notifyRedemptionProofTimedOut()
 
       const depositState = await testDeposit.getState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)

--- a/solidity/test/liquidation-tests/redemptionProofTimeoutTest.js
+++ b/solidity/test/liquidation-tests/redemptionProofTimeoutTest.js
@@ -40,7 +40,7 @@ describe("Integration -- Redemption-proof timeout", async function () {
         testDeposit.notifyRedemptionProofTimedOut(),
         "Not currently awaiting a redemption proof",
       )
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.AWAITING_WITHDRAWAL_SIGNATURE)
     })
 
@@ -54,7 +54,7 @@ describe("Integration -- Redemption-proof timeout", async function () {
 
       await testDeposit.notifyRedemptionProofTimedOut()
 
-      const depositState = await testDeposit.getState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
@@ -64,7 +64,7 @@ describe("Integration -- Redemption-proof timeout", async function () {
         testDeposit.purchaseSignerBondsAtAuction(),
         "Not enough TBTC to cover outstanding debt",
       )
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
@@ -85,10 +85,10 @@ describe("Integration -- Redemption-proof timeout", async function () {
         }
       )
 
-      const allowance = await testDeposit.getWithdrawAllowance({ from: auctionBuyer })
+      const allowance = await testDeposit.withdrawableAmount({ from: auctionBuyer })
       await testDeposit.withdrawFunds({ from: auctionBuyer })
 
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       const endingBalance = await web3.eth.getBalance(testDeposit.address)
 
       expect(allowance).to.eq.BN(collateralAmount)

--- a/solidity/test/liquidation-tests/signatureTimeoutTest.js
+++ b/solidity/test/liquidation-tests/signatureTimeoutTest.js
@@ -30,7 +30,7 @@ describe("Integration -- Signature-timeout", async function () {
 
     it("unable to start liquidation when timer has not elapsed", async () => {
       await expectRevert(
-        testDeposit.notifySignatureTimeout(),
+        testDeposit.notifyRedemptionSignatureTimedOut(),
         "Signature timer has not elapsed",
       )
       const depositState = await testDeposit.getCurrentState.call()
@@ -43,7 +43,7 @@ describe("Integration -- Signature-timeout", async function () {
       const timer = await tbtcConstants.getSignatureTimeout.call()
       await increaseTime(timer.toNumber() + 1)
 
-      await testDeposit.notifySignatureTimeout()
+      await testDeposit.notifyRedemptionSignatureTimedOut()
 
       const depositState = await testDeposit.getState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
@@ -127,7 +127,7 @@ describe("Integration -- Signature-timeout", async function () {
 
     it("unable to start liquidation when timer has not elapsed", async () => {
       await expectRevert(
-        testDeposit.notifySignatureTimeout(),
+        testDeposit.notifyRedemptionSignatureTimedOut(),
         "Signature timer has not elapsed",
       )
     })
@@ -138,7 +138,7 @@ describe("Integration -- Signature-timeout", async function () {
       const timer = await tbtcConstants.getSignatureTimeout.call()
       await increaseTime(timer.toNumber() + 1)
 
-      await testDeposit.notifySignatureTimeout()
+      await testDeposit.notifyRedemptionSignatureTimedOut()
 
       const depositState = await testDeposit.getState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)

--- a/solidity/test/liquidation-tests/signatureTimeoutTest.js
+++ b/solidity/test/liquidation-tests/signatureTimeoutTest.js
@@ -33,7 +33,7 @@ describe("Integration -- Signature-timeout", async function () {
         testDeposit.notifyRedemptionSignatureTimedOut(),
         "Signature timer has not elapsed",
       )
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.AWAITING_WITHDRAWAL_SIGNATURE)
     })
 
@@ -45,7 +45,7 @@ describe("Integration -- Signature-timeout", async function () {
 
       await testDeposit.notifyRedemptionSignatureTimedOut()
 
-      const depositState = await testDeposit.getState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
@@ -55,7 +55,7 @@ describe("Integration -- Signature-timeout", async function () {
         testDeposit.purchaseSignerBondsAtAuction(),
         "Not enough TBTC to cover outstanding debt",
       )
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
@@ -66,10 +66,10 @@ describe("Integration -- Signature-timeout", async function () {
       await tbtcToken.approve(testDeposit.address, lotSizeTbtc, { from: auctionBuyer })
       await testDeposit.purchaseSignerBondsAtAuction({ from: auctionBuyer })
 
-      const allowance = await testDeposit.getWithdrawAllowance({ from: auctionBuyer })
+      const allowance = await testDeposit.withdrawableAmount({ from: auctionBuyer })
       await testDeposit.withdrawFunds({ from: auctionBuyer })
 
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       const endingBalance = await web3.eth.getBalance(testDeposit.address)
 
       expect(allowance).to.eq.BN(collateralAmount)
@@ -118,7 +118,7 @@ describe("Integration -- Signature-timeout", async function () {
 
       const tdtOwner = await tbtcDepositToken.ownerOf(tdtId)
       await toAwaitingWithdrawalSignature(testDeposit)
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
 
       expect(depositState).to.eq.BN(states.AWAITING_WITHDRAWAL_SIGNATURE)
       expect(tdtOwner).to.equal(depositInitiator)
@@ -140,7 +140,7 @@ describe("Integration -- Signature-timeout", async function () {
 
       await testDeposit.notifyRedemptionSignatureTimedOut()
 
-      const depositState = await testDeposit.getState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
@@ -150,7 +150,7 @@ describe("Integration -- Signature-timeout", async function () {
         testDeposit.purchaseSignerBondsAtAuction(),
         "Not enough TBTC to cover outstanding debt",
       )
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
@@ -161,10 +161,10 @@ describe("Integration -- Signature-timeout", async function () {
       await tbtcToken.approve(testDeposit.address, lotSizeTbtc, { from: auctionBuyer })
       await testDeposit.purchaseSignerBondsAtAuction({ from: auctionBuyer })
 
-      const allowance = await testDeposit.getWithdrawAllowance({ from: auctionBuyer })
+      const allowance = await testDeposit.withdrawableAmount({ from: auctionBuyer })
       await testDeposit.withdrawFunds({ from: auctionBuyer })
 
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       const endingBalance = await web3.eth.getBalance(testDeposit.address)
 
       expect(allowance).to.eq.BN(collateralAmount)

--- a/solidity/test/liquidation-tests/undercollateralizedTest.js
+++ b/solidity/test/liquidation-tests/undercollateralizedTest.js
@@ -34,7 +34,7 @@ describe("Integration -- Undercollateralized", async function () {
         testDeposit.notifyUndercollateralizedLiquidation(),
         "Deposit has sufficient collateral",
       )
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.ACTIVE)
     })
 
@@ -44,7 +44,7 @@ describe("Integration -- Undercollateralized", async function () {
       await mockSatWeiPriceFeed.setPrice(satwei.add(new BN(1)))
       await testDeposit.notifyUndercollateralizedLiquidation()
 
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
@@ -54,7 +54,7 @@ describe("Integration -- Undercollateralized", async function () {
         testDeposit.purchaseSignerBondsAtAuction(),
         "Not enough TBTC to cover outstanding debt",
       )
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       expect(depositState).to.eq.BN(states.LIQUIDATION_IN_PROGRESS)
     })
 
@@ -67,10 +67,10 @@ describe("Integration -- Undercollateralized", async function () {
   
       await testDeposit.purchaseSignerBondsAtAuction({ from: auctionBuyer })
   
-      const allowance = await testDeposit.getWithdrawAllowance({ from: auctionBuyer })
+      const allowance = await testDeposit.withdrawableAmount({ from: auctionBuyer })
       await testDeposit.withdrawFunds({from: auctionBuyer})
   
-      const depositState = await testDeposit.getCurrentState.call()
+      const depositState = await testDeposit.currentState.call()
       const endingBalance = await web3.eth.getBalance(testDeposit.address)
       const tbtcBalance = await tbtcToken.balanceOf(depositInitiator)
 

--- a/solidity/test/states/deposit.js
+++ b/solidity/test/states/deposit.js
@@ -203,7 +203,7 @@ module.exports = {
 
                     return {
                         state: "signerSetupFailure",
-                        tx: deposit.notifySignerSetupFailure(),
+                        tx: deposit.notifySignerSetupFailed(),
                     }
                 },
                 expect: async (_, receipt, { deposit }) => {
@@ -226,7 +226,7 @@ module.exports = {
 
                     return {
                         state: "signerSetupFailure",
-                        tx: deposit.notifySignerSetupFailure(),
+                        tx: deposit.notifySignerSetupFailed(),
                     }
                 },
                 expectError: async (_, error) => {
@@ -245,7 +245,7 @@ module.exports = {
                     await System.drainBond(state)
                     return {
                         state: "signerSetupFailure",
-                        tx: deposit.notifySignerSetupFailure(),
+                        tx: deposit.notifySignerSetupFailed(),
                     }
                 },
                 expectError: async (_, error) => {
@@ -297,7 +297,7 @@ module.exports = {
 
                     return {
                         state: "failedSetup",
-                        tx: deposit.notifyFundingTimeout()
+                        tx: deposit.notifyFundingTimedOut()
                     }
                 },
                 expect: async (_, receipt, { deposit }) => {
@@ -337,7 +337,7 @@ module.exports = {
                 transition: async ({ deposit }) => {
                     return {
                         state: "signerSetupFailure",
-                        tx: deposit.notifySignerSetupFailure(),
+                        tx: deposit.notifySignerSetupFailed(),
                     }
                 },
                 expectError: async (_, error) => {
@@ -505,7 +505,7 @@ module.exports = {
                     await System.setUpBond(state)
                     return {
                         state: "liquidatinInProgress",
-                        tx: deposit.notifySignatureTimeout()
+                        tx: deposit.notifyRedemptionSignatureTimedOut()
                     }
                 },
                 expect: async (_, receipt, { deposit }) => {
@@ -549,7 +549,7 @@ module.exports = {
 
                     return {
                         state: "liquidationInProgress",
-                        tx: deposit.notifyCourtesyTimeout()
+                        tx: deposit.notifyCourtesyCallExpired()
                     }
                 },
                 expect: async (_, receipt, { deposit }) => {

--- a/solidity/test/states/deposit.js
+++ b/solidity/test/states/deposit.js
@@ -82,21 +82,21 @@ const System = {
     setWellCollateralized: async ({ deposit, ECDSAKeepStub, mockSatWeiPriceFeed }) => {
         const bondAmount = await ECDSAKeepStub.checkBondAmount()
         const lotSize = await deposit.lotSizeSatoshis()
-        const initial = await deposit.getInitialCollateralizedPercent()
+        const initial = await deposit.initialCollateralizedPercent()
         const wellCollateralized = bondAmount.div(lotSize.mul(initial).div(new BN(100)))
         await mockSatWeiPriceFeed.setPrice(wellCollateralized)
     },
     setUndercollateralized: async ({ deposit, ECDSAKeepStub, mockSatWeiPriceFeed }) => {
         const bondAmount = await ECDSAKeepStub.checkBondAmount()
         const lotSize = await deposit.lotSizeSatoshis()
-        const under = await deposit.getUndercollateralizedThresholdPercent()
+        const under = await deposit.undercollateralizedThresholdPercent()
         const undercollateralized = bondAmount.div(lotSize.mul(under.sub(new BN(1))).div(new BN(100)))
         await mockSatWeiPriceFeed.setPrice(undercollateralized)
     },
     setSeverelyUndercollateralized: async ({ deposit, ECDSAKeepStub, mockSatWeiPriceFeed }) => {
         const bondAmount = await ECDSAKeepStub.checkBondAmount()
         const lotSize = await deposit.lotSizeSatoshis()
-        const severe = await deposit.getSeverelyUndercollateralizedThresholdPercent()
+        const severe = await deposit.severelyUndercollateralizedThresholdPercent()
         const severelyUndercollateralized = bondAmount.div(lotSize.mul(severe.sub(new BN(1))).div(new BN(100)))
         await mockSatWeiPriceFeed.setPrice(severelyUndercollateralized)
     },
@@ -155,7 +155,7 @@ module.exports = {
                         _depositContractAddress: deposit.address,
                         _keepAddress: ECDSAKeepStub.address,
                     })
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.AWAITING_SIGNER_SETUP
                     )
                     expect(await TBTCDepositToken.ownerOf(deposit.address)).to.equal(
@@ -190,7 +190,7 @@ module.exports = {
                         _signingGroupPubkeyX: depositRoundTrip.signerPubkey.x,
                         _signingGroupPubkeyY: depositRoundTrip.signerPubkey.y,
                     })
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.AWAITING_BTC_FUNDING_PROOF
                     )
                 },
@@ -208,7 +208,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "SetupFailed")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.FAILED_SETUP
                     )
                 }
@@ -284,7 +284,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "Funded")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.ACTIVE
                     )
                 },
@@ -302,7 +302,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "SetupFailed")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.FAILED_SETUP
                     )
                 },
@@ -325,7 +325,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "SetupFailed")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.FAILED_SETUP
                     )
                 },
@@ -368,7 +368,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "RedemptionRequested")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.AWAITING_WITHDRAWAL_SIGNATURE
                     )
                 },
@@ -386,7 +386,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "CourtesyCalled")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.COURTESY_CALL
                     )
                 },
@@ -403,7 +403,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "StartedLiquidation")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.LIQUIDATION_IN_PROGRESS
                     )
                 },
@@ -425,7 +425,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "StartedLiquidation")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.FRAUD_LIQUIDATION_IN_PROGRESS
                     )
                 },
@@ -458,7 +458,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "Redeemed")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.REDEEMED
                     )
                 },
@@ -493,7 +493,7 @@ module.exports = {
                             "_depositContractAddress": deposit.address,
                         },
                     )
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.LIQUIDATED
                     )
                 },
@@ -510,7 +510,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "StartedLiquidation")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.LIQUIDATION_IN_PROGRESS
                     )
                 },
@@ -537,7 +537,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "ExitedCourtesyCall")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.ACTIVE
                     )
                 },
@@ -554,7 +554,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "StartedLiquidation")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.LIQUIDATION_IN_PROGRESS
                     )
                 },
@@ -576,7 +576,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "StartedLiquidation")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.FRAUD_LIQUIDATION_IN_PROGRESS
                     )
                 },
@@ -602,7 +602,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "Liquidated")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.LIQUIDATED
                     )
                 },
@@ -639,7 +639,7 @@ module.exports = {
                 },
                 expect: async (_, receipt, { deposit }) => {
                     expectEvent(receipt, "Liquidated")
-                    expect(await deposit.getCurrentState()).to.eq.BN(
+                    expect(await deposit.currentState()).to.eq.BN(
                         System.States.LIQUIDATED
                     )
                 },


### PR DESCRIPTION
This PR is apparently massive, as it reorganizes the Deposit file significantly.

The major changes here are:
- Reorganizing functions in the Deposit.sol file in a clear order.
- Aligning naming for notification and getter functions.
- Revamping the NatSpec docs across all of the public Deposit contract API.

The commits detail the full changes, and looking at commits individually will
probably be an easier review approach. In particular, commit a4e285d is the
one that makes it hardest to see code changes. Most (though not all) changes
outside of Deposit.sol are simply updating tests to new function names.

Closes #695.