### PR TITLE
Refresh the minimum bondable value

### DIFF
--- a/solidity/contracts/deposit/Deposit.sol
+++ b/solidity/contracts/deposit/Deposit.sol
@@ -125,8 +125,6 @@ contract Deposit is DepositFactoryAuthority {
     /// @param _tbtcDepositToken  `TBTCDepositToken` (TDT) contract. More info in `TBTCDepositToken`.
     /// @param _feeRebateToken    `FeeRebateToken` (FRT) contract. More info in `FeeRebateToken`.
     /// @param _vendingMachineAddress    `VendingMachine` address. More info in `VendingMachine`.
-    /// @param _m           Signing group honesty threshold.
-    /// @param _n           Signing group size.
     /// @param _lotSizeSatoshis The minimum amount of satoshi the funder is required to send.
     ///                         This is also the amount of TBTC the TDT holder will receive:
     ///                         (10**7 satoshi == 0.1 BTC == 0.1 TBTC).
@@ -136,8 +134,6 @@ contract Deposit is DepositFactoryAuthority {
         IERC721 _tbtcDepositToken,
         FeeRebateToken _feeRebateToken,
         address _vendingMachineAddress,
-        uint16 _m,
-        uint16 _n,
         uint64 _lotSizeSatoshis
     ) public onlyFactory payable {
         self.tbtcSystem = _tbtcSystem;
@@ -145,7 +141,7 @@ contract Deposit is DepositFactoryAuthority {
         self.tbtcDepositToken = _tbtcDepositToken;
         self.feeRebateToken = _feeRebateToken;
         self.vendingMachineAddress = _vendingMachineAddress;
-        self.createNewDeposit(_m, _n, _lotSizeSatoshis);
+        self.createNewDeposit(_lotSizeSatoshis);
     }
 
     /// @notice                     Deposit owner (TDT holder) can request redemption.

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -46,12 +46,8 @@ library DepositFunding {
     /// @dev            If called directly, the transaction will revert since the call will be
     ///                 executed on an already set-up instance.
     /// @param _d       Deposit storage pointer.
-    /// @param _m       Signing group honesty threshold.
-    /// @param _n       Signing group size.
     function createNewDeposit(
         DepositUtils.Deposit storage _d,
-        uint16 _m,
-        uint16 _n,
         uint64 _lotSizeSatoshis
     ) public {
         require(_d.tbtcSystem.getAllowNewDeposits(), "New deposits aren't allowed.");
@@ -66,8 +62,6 @@ library DepositFunding {
 
         /* solium-disable-next-line value-in-payable */
         _d.keepAddress = _d.tbtcSystem.requestNewKeep.value(msg.value)(
-            _m,
-            _n,
             _bondRequirementWei,
             TBTCConstants.getDepositTerm()
         );

--- a/solidity/contracts/deposit/DepositFunding.sol
+++ b/solidity/contracts/deposit/DepositFunding.sol
@@ -52,17 +52,14 @@ library DepositFunding {
     ) public {
         require(_d.tbtcSystem.getAllowNewDeposits(), "New deposits aren't allowed.");
         require(_d.inStart(), "Deposit setup already requested");
-        require(_d.tbtcSystem.isAllowedLotSize(_lotSizeSatoshis), "provided lot size not supported");
 
         _d.lotSizeSatoshis = _lotSizeSatoshis;
-        uint256 _bondRequirementSatoshi = _lotSizeSatoshis.mul(_d.tbtcSystem.getInitialCollateralizedPercent()).div(100);
-        uint256 _bondRequirementWei = _d.fetchBitcoinPrice().mul(_bondRequirementSatoshi);
 
         _d.keepSetupFee = _d.tbtcSystem.getNewDepositFeeEstimate();
 
         /* solium-disable-next-line value-in-payable */
         _d.keepAddress = _d.tbtcSystem.requestNewKeep.value(msg.value)(
-            _bondRequirementWei,
+            _lotSizeSatoshis,
             TBTCConstants.getDepositTerm()
         );
 

--- a/solidity/contracts/interfaces/ITBTCSystem.sol
+++ b/solidity/contracts/interfaces/ITBTCSystem.sol
@@ -17,7 +17,7 @@ interface ITBTCSystem {
     function getNewDepositFeeEstimate() external view returns (uint256);
     function getAllowNewDeposits() external view returns (bool);
     function isAllowedLotSize(uint64 _lotSizeSatoshis) external view returns (bool);
-    function requestNewKeep(uint256 _bond, uint256 _maxSecuredLifetime) external payable returns (address);
+    function requestNewKeep(uint64 _lotSizeSatoshis, uint256 _maxSecuredLifetime) external payable returns (address);
     function getSignerFeeDivisor() external view returns (uint16);
     function getInitialCollateralizedPercent() external view returns (uint16);
     function getUndercollateralizedThresholdPercent() external view returns (uint16);

--- a/solidity/contracts/interfaces/ITBTCSystem.sol
+++ b/solidity/contracts/interfaces/ITBTCSystem.sol
@@ -17,7 +17,7 @@ interface ITBTCSystem {
     function getNewDepositFeeEstimate() external view returns (uint256);
     function getAllowNewDeposits() external view returns (bool);
     function isAllowedLotSize(uint64 _lotSizeSatoshis) external view returns (bool);
-    function requestNewKeep(uint256 _m, uint256 _n, uint256 _bond, uint256 _maxSecuredLifetime) external payable returns (address);
+    function requestNewKeep(uint256 _bond, uint256 _maxSecuredLifetime) external payable returns (address);
     function getSignerFeeDivisor() external view returns (uint16);
     function getInitialCollateralizedPercent() external view returns (uint16);
     function getUndercollateralizedThresholdPercent() external view returns (uint16);

--- a/solidity/contracts/proxy/DepositFactory.sol
+++ b/solidity/contracts/proxy/DepositFactory.sol
@@ -25,8 +25,6 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     TBTCToken public tbtcToken;
     FeeRebateToken public feeRebateToken;
     address public vendingMachineAddress;
-    uint16 public keepThreshold;
-    uint16 public keepSize;
 
     constructor(address _systemAddress)
         TBTCSystemAuthority(_systemAddress)
@@ -39,17 +37,13 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
     /// @param _tbtcDepositToken      TBTC Deposit Token contract.
     /// @param _feeRebateToken        AFee Rebate Token contract.
     /// @param _vendingMachineAddress Address of the Vending Machine contract.
-    /// @param _keepThreshold         Minimum number of honest keep members.
-    /// @param _keepSize              Number of all members in a keep.
     function setExternalDependencies(
         address payable _masterDepositAddress,
         TBTCSystem _tbtcSystem,
         TBTCToken _tbtcToken,
         TBTCDepositToken _tbtcDepositToken,
         FeeRebateToken _feeRebateToken,
-        address _vendingMachineAddress,
-        uint16 _keepThreshold,
-        uint16 _keepSize
+        address _vendingMachineAddress
     ) public onlyTbtcSystem {
         masterDepositAddress = _masterDepositAddress;
         tbtcDepositToken = _tbtcDepositToken;
@@ -57,8 +51,6 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
         tbtcToken = _tbtcToken;
         feeRebateToken = _feeRebateToken;
         vendingMachineAddress = _vendingMachineAddress;
-        keepThreshold = _keepThreshold;
-        keepSize = _keepSize;
     }
 
     event DepositCloneCreated(address depositCloneAddress);
@@ -82,8 +74,6 @@ contract DepositFactory is CloneFactory, TBTCSystemAuthority{
                 tbtcDepositToken,
                 feeRebateToken,
                 vendingMachineAddress,
-                keepThreshold,
-                keepSize,
                 _lotSizeSatoshis
             );
 

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -91,20 +91,28 @@ library KeepFactorySelection {
 
     /// @notice Sets the minimum bondable value required from the operator to
     /// join the sortition pool for tBTC.
-    /// @param _minimumBondableValue The minimum unbonded value allowing
-    /// an operator to join and stay in the sortition pool for the application.
+    /// @param _minimumBondableValue The minimum bond value the application
+    /// requires from a single keep.
+    /// @param _groupSize Number of signers in the keep.
+    /// @param _honestThreshold Minimum number of honest keep signers.
     function setMinimumBondableValue(
         Storage storage _self,
-        uint256 _minimumBondableValue
+        uint256 _minimumBondableValue,
+        uint256 _groupSize,
+        uint256 _honestThreshold
     ) public {
         if (address(_self.keepStakeFactory) != address(0)) {
             _self.keepStakeFactory.setMinimumBondableValue(
-                _minimumBondableValue
+                _minimumBondableValue,
+                _groupSize,
+                _honestThreshold
             );
         }
         if (address(_self.ethStakeFactory) != address(0)) {
             _self.ethStakeFactory.setMinimumBondableValue(
-                _minimumBondableValue
+                _minimumBondableValue,
+                _groupSize,
+                _honestThreshold
             );
         }
     }

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -49,7 +49,7 @@ library KeepFactorySelection {
     function initialize(
         Storage storage _self,
         IBondedECDSAKeepFactory _defaultFactory
-    ) internal {
+    ) public {
         require(
             address(_self.keepStakeFactory) == address(0),
             "Already initialized"
@@ -87,6 +87,26 @@ library KeepFactorySelection {
         refreshFactory(_self);
 
         return factory;
+    }
+
+    /// @notice Sets the minimum bondable value required from the operator to
+    /// join the sortition pool for tBTC.
+    /// @param _minimumBondableValue The minimum unbonded value allowing
+    /// an operator to join and stay in the sortition pool for the application.
+    function setMinimumBondableValue(
+        Storage storage _self,
+        uint256 _minimumBondableValue
+    ) public {
+        if (address(_self.keepStakeFactory) != address(0)) {
+            _self.keepStakeFactory.setMinimumBondableValue(
+                _minimumBondableValue
+            );
+        }
+        if (address(_self.ethStakeFactory) != address(0)) {
+            _self.ethStakeFactory.setMinimumBondableValue(
+                _minimumBondableValue
+            );
+        }
     }
 
     /// @notice Refreshes the keep factory choice. If either ETH-stake factory

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -566,7 +566,9 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// after minimum lot size update.
     function refreshMinimumBondableValue() public {
         keepFactorySelection.setMinimumBondableValue(
-            calculateBondRequirementWei(getMinimumLotSize())
+            calculateBondRequirementWei(getMinimumLotSize()),
+            keepSize,
+            keepThreshold
         );
     }
 

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -162,7 +162,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
 
     /// @notice Return the largest lot size currently enabled for deposits.
     /// @return The largest lot size, in satoshis.
-    function getMaxLotSize() public view returns (uint256) {
+    function getMaximumLotSize() public view returns (uint256) {
         return lotSizesSatoshis[lotSizesSatoshis.length - 1];
     }
 

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -626,7 +626,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     }
 
     /// @notice Calculates bond requirement in wei for the given lot size in
-    /// satoshis given the current BTCETH price.
+    /// satoshis based on the current ETHBTC price.
     /// @param _lotSizeSatoshis Lot size in satoshis.
     /// @return Bond requirement in wei.
     function calculateBondRequirementWei(

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -569,14 +569,24 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @dev It is recommended to call this function on tBTC initialization and
     /// after minimum lot size update.
     function refreshMinimumBondableValue() public {
-        uint256 minimimLotSizeSatoshis = lotSizesSatoshis[0];
-        uint256 bondRequirementSatoshis = minimimLotSizeSatoshis.mul(
+        uint256 bondRequirementSatoshis = getMinimumLotSizeSatoshi().mul(
             initialCollateralizedPercent
         ).div(100);
         uint256 bondRequirementWei = _fetchBitcoinPrice().mul(
             bondRequirementSatoshis
         );
         keepFactorySelection.setMinimumBondableValue(bondRequirementWei);
+    }
+
+    /// @notice Returns the minimum lot size in satoshi.
+    function getMinimumLotSizeSatoshi() public view returns (uint256) {
+        uint256 minimum = lotSizesSatoshis[0];
+        for (uint i = 1; i < lotSizesSatoshis.length; i++) {
+            if (lotSizesSatoshis[i] < minimum) {
+                minimum = lotSizesSatoshis[i];
+            }
+        }
+        return minimum;
     }
 
     /// @notice Returns the time delay used for governance actions except for

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -613,19 +613,6 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         return _keepFactory.openKeep.value(msg.value)(keepSize, keepThreshold, msg.sender, bond, _maxSecuredLifetime);
     }
 
-    /// @notice Calculates bond requirement in wei for the given lot size in
-    /// satoshis given the current BTCETH price.
-    /// @param _lotSizeSatoshis Lot size in satoshis.
-    /// @return Bond requirement in wei.
-    function calculateBondRequirementWei(
-        uint256 _lotSizeSatoshis
-    ) public view returns (uint256) {
-        uint256 bondRequirementSatoshis = _lotSizeSatoshis.mul(
-            initialCollateralizedPercent
-        ).div(100);
-        return _fetchBitcoinPrice().mul(bondRequirementSatoshis);
-    }
-
     /// @notice Check if a lot size is allowed.
     /// @param _lotSizeSatoshis Lot size to check.
     /// @return True if lot size is allowed, false otherwise.
@@ -636,6 +623,19 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             }
         }
         return false;
+    }
+
+    /// @notice Calculates bond requirement in wei for the given lot size in
+    /// satoshis given the current BTCETH price.
+    /// @param _lotSizeSatoshis Lot size in satoshis.
+    /// @return Bond requirement in wei.
+    function calculateBondRequirementWei(
+        uint256 _lotSizeSatoshis
+    ) internal view returns (uint256) {
+        uint256 bondRequirementSatoshis = _lotSizeSatoshis.mul(
+            initialCollateralizedPercent
+        ).div(100);
+        return _fetchBitcoinPrice().mul(bondRequirementSatoshis);
     }
 
     function _fetchBitcoinPrice() internal view returns (uint256) {

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -377,6 +377,8 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         emit LotSizesUpdated(newLotSizesSatoshis);
         lotSizesChangeInitiated = 0;
         newLotSizesSatoshis.length = 0;
+
+        refreshMinimumBondableValue();
     }
 
     /// @notice Finish setting the system collateralization levels
@@ -566,7 +568,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// the current BTC price.
     /// @dev It is recommended to call this function on tBTC initialization and
     /// after minimum lot size update.
-    function refreshMinimumBondableValue() external {
+    function refreshMinimumBondableValue() public {
         uint256 minimimLotSizeSatoshis = lotSizesSatoshis[0];
         uint256 bondRequirementSatoshis = minimimLotSizeSatoshis.mul(
             initialCollateralizedPercent
@@ -574,7 +576,6 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         uint256 bondRequirementWei = _fetchBitcoinPrice().mul(
             bondRequirementSatoshis
         );
-
         keepFactorySelection.setMinimumBondableValue(bondRequirementWei);
     }
 

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -156,7 +156,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
 
     /// @notice Return the lowest lot size currently enabled for deposits.
     /// @return The lowest lot size, in satoshis.
-    function getMinLotSize() public view returns (uint256) {
+    function getMinimumLotSize() public view returns (uint256) {
         return lotSizesSatoshis[0];
     }
 
@@ -566,7 +566,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// after minimum lot size update.
     function refreshMinimumBondableValue() public {
         keepFactorySelection.setMinimumBondableValue(
-            calculateBondRequirementWei(getMinLotSize())
+            calculateBondRequirementWei(getMinimumLotSize())
         );
     }
 

--- a/solidity/contracts/test/deposit/TestDeposit.sol
+++ b/solidity/contracts/test/deposit/TestDeposit.sol
@@ -18,8 +18,6 @@ contract TestDeposit is Deposit {
         IERC721 _tbtcDepositToken,
         FeeRebateToken _feeRebateToken,
         address _vendingMachineAddress,
-        uint16 _m,
-        uint16 _n,
         uint64 _lotSizeSatoshis
     ) public payable {
         self.tbtcSystem = _tbtcSystem;
@@ -27,7 +25,7 @@ contract TestDeposit is Deposit {
         self.tbtcDepositToken = _tbtcDepositToken;
         self.feeRebateToken = _feeRebateToken;
         self.vendingMachineAddress = _vendingMachineAddress;
-        self.createNewDeposit(_m, _n, _lotSizeSatoshis);
+        self.createNewDeposit(_lotSizeSatoshis);
     }
 
     function setExteriorAddresses(

--- a/solidity/contracts/test/keep/ECDSAKeepFactoryStub.sol
+++ b/solidity/contracts/test/keep/ECDSAKeepFactoryStub.sol
@@ -40,7 +40,11 @@ contract ECDSAKeepFactoryStub is IBondedECDSAKeepFactory {
         return 100000;
     }
 
-    function setMinimumBondableValue(uint256 _minimumBondableValue) public {
+    function setMinimumBondableValue(
+        uint256 _minimumBondableValue,
+        uint256 _groupSize,
+        uint256 _honestThreshold
+    ) public {
         minimumBondableValue = _minimumBondableValue;
     }
 }

--- a/solidity/contracts/test/keep/ECDSAKeepFactoryStub.sol
+++ b/solidity/contracts/test/keep/ECDSAKeepFactoryStub.sol
@@ -6,6 +6,7 @@ contract ECDSAKeepFactoryStub is IBondedECDSAKeepFactory {
     address public keepOwner;
     address public keepAddress = address(888);
     uint256 public stakeLockDuration;
+    uint256 public minimumBondableValue = 999;
     uint256 feeEstimate = 123456;
 
     function openKeep(
@@ -37,5 +38,9 @@ contract ECDSAKeepFactoryStub is IBondedECDSAKeepFactory {
         address _application
     ) external view returns (uint256 poolWeight) {
         return 100000;
+    }
+
+    function setMinimumBondableValue(uint256 _minimumBondableValue) public {
+        minimumBondableValue = _minimumBondableValue;
     }
 }

--- a/solidity/contracts/test/system/TBTCSystemStub.sol
+++ b/solidity/contracts/test/system/TBTCSystemStub.sol
@@ -27,7 +27,7 @@ contract TBTCSystemStub is TBTCSystem {
         keepAddress = _keepAddress;
     }
 
-    function requestNewKeep(uint256, uint256) external payable returns (address _keepAddress) {
+    function requestNewKeep(uint64, uint256) external payable returns (address _keepAddress) {
         return keepAddress;
     }
 }

--- a/solidity/contracts/test/system/TBTCSystemStub.sol
+++ b/solidity/contracts/test/system/TBTCSystemStub.sol
@@ -27,7 +27,7 @@ contract TBTCSystemStub is TBTCSystem {
         keepAddress = _keepAddress;
     }
 
-    function requestNewKeep(uint256, uint256, uint256, uint256) external payable returns (address _keepAddress) {
+    function requestNewKeep(uint256, uint256) external payable returns (address _keepAddress) {
         return keepAddress;
     }
 }

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -716,9 +716,9 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "1.2.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-pre.1.tgz",
-      "integrity": "sha512-q9FUWYIP49vY91IAbHQDMACx/4dabeSrQ/nopKTwPUDl9FZiZrPOamycSzQy01RHZLF20BJF1hmiOOHr2YoRWA==",
+      "version": "1.2.0-pre.2",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-pre.2.tgz",
+      "integrity": "sha512-GSY2nAh289qDPOKQEl3ezr9fTGAG6p/DKepHtoo5/DwKc1zEL8eIpEQaS+oYEulbB4IgCucaFb4iCb7m3O89Lw==",
       "requires": {
         "@keep-network/keep-core": ">1.3.0-pre <1.3.0-rc",
         "@keep-network/sortition-pools": "1.1.0",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -716,21 +716,21 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "1.2.0-pre",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-pre.tgz",
-      "integrity": "sha512-u7Aqc6RMpQ/UGSfT4JmTrF9IdlUYZpTpELDLIeKZ8B2KneLpRkqbZy9wzRAsZjN3gpho5214zEGqy5avNuPB0g==",
+      "version": "1.2.0-pre.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.2.0-pre.1.tgz",
+      "integrity": "sha512-q9FUWYIP49vY91IAbHQDMACx/4dabeSrQ/nopKTwPUDl9FZiZrPOamycSzQy01RHZLF20BJF1hmiOOHr2YoRWA==",
       "requires": {
         "@keep-network/keep-core": ">1.3.0-pre <1.3.0-rc",
-        "@keep-network/sortition-pools": "1.0.0",
+        "@keep-network/sortition-pools": "1.1.0",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0",
         "solidity-bytes-utils": "0.0.7"
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.0.0.tgz",
-      "integrity": "sha512-wPOjqQphGtIBTGpGmw8gwBDbvMeq/9wf+HCsD6Vhvd7bcY5lPT/oWFFqhiExhuaLyISwr1fl6Jgm4RkN6Cispg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.0.tgz",
+      "integrity": "sha512-4mPp6f6HpfEdjfFM/PHwqabfnWc91gldbcIQEoS6bSfrqfrgFgmmOT6r9WO+Sqw9bR6Ve1tPWp3jpu6ufkPDww==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
@@ -1729,9 +1729,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.50",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.50.tgz",
-          "integrity": "sha512-5ImO01Fb8YsEOYpV+aeyGYztcYcjGsBvN4D7G5r1ef2cuQOpymjWNQi5V0rKHE6PC2ru3HkoUr/Br2/8GUA84w=="
+          "version": "12.12.53",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
+          "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
         },
         "bignumber.js": {
           "version": "7.2.1",
@@ -3336,11 +3336,27 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
       "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
     },
+    "@types/pbkdf2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/qs": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
       "integrity": "sha512-lhbQXx9HKZAPgBkISrBcmAcMpZsmpe/Cd/hY7LGZS5OfkySUBItnPZHgQPssWYUET8elF+yCFBbP1Q0RZPTdaw==",
       "dev": true
+    },
+    "@types/secp256k1": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+      "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/underscore": {
       "version": "1.9.4",
@@ -4763,6 +4779,11 @@
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "blakejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
+      "integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
     },
     "bls12377js": {
       "version": "git+https://github.com/celo-org/bls12377js.git#400bcaeec9e7620b040bfad833268f5289699cac",
@@ -6907,6 +6928,59 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
       "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
+    },
+    "ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "requires": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "keccak": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+          "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        },
+        "scrypt-js": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+          "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
+        },
+        "secp256k1": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
+          "requires": {
+            "elliptic": "^6.5.2",
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+          "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+        }
+      }
     },
     "ethereum-ens": {
       "version": "0.8.0",
@@ -26133,6 +26207,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-addon-api": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
+      "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
+    },
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -26159,6 +26238,11 @@
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
       }
+    },
+    "node-gyp-build": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.3.tgz",
+      "integrity": "sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg=="
     },
     "nofilter": {
       "version": "1.0.3",
@@ -29501,7 +29585,7 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
       "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
       "requires": {
-        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+        "bignumber.js": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",
@@ -29836,28 +29920,17 @@
           "from": "git+https://github.com/debris/bignumber.js.git#master"
         },
         "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
             "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          }
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
+            "safe-buffer": "^5.1.1"
           }
         },
         "solc": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://tbtc.network/",
   "dependencies": {
-    "@keep-network/keep-ecdsa": ">=1.2.0-pre <1.2.0-rc",
+    "@keep-network/keep-ecdsa": "^1.2.0-pre.2",
     "@summa-tx/bitcoin-spv-sol": "^3.1.0",
     "@summa-tx/relay-sol": "^2.0.2",
     "openzeppelin-solidity": "2.3.0"

--- a/solidity/test/DepositFactoryTest.js
+++ b/solidity/test/DepositFactoryTest.js
@@ -191,8 +191,6 @@ describe("DepositFactory", async function() {
         tbtcDepositToken.address,
         ZERO_ADDRESS,
         ZERO_ADDRESS,
-        1,
-        1,
         fullBtc,
         {value: openKeepFee},
       )

--- a/solidity/test/DepositFundingTest.js
+++ b/solidity/test/DepositFundingTest.js
@@ -82,8 +82,6 @@ describe("DepositFunding", async function() {
         tbtcDepositToken.address,
         ZERO_ADDRESS,
         ZERO_ADDRESS,
-        1, // m
-        1,
         fullBtc,
         {value: funderBondAmount},
       )
@@ -138,8 +136,6 @@ describe("DepositFunding", async function() {
           tbtcDepositToken.address,
           ZERO_ADDRESS,
           ZERO_ADDRESS,
-          1, // m
-          1,
           fullBtc,
         ),
         "Insufficient signer bonds to cover setup fee",
@@ -156,8 +152,6 @@ describe("DepositFunding", async function() {
           tbtcDepositToken.address,
           ZERO_ADDRESS,
           ZERO_ADDRESS,
-          1, // m
-          1,
           fullBtc,
         ),
         "Deposit setup already requested",
@@ -174,8 +168,6 @@ describe("DepositFunding", async function() {
           tbtcDepositToken.address,
           ZERO_ADDRESS,
           ZERO_ADDRESS,
-          1, // m
-          1,
           fullBtc,
         ),
         "New deposits aren't allowed.",

--- a/solidity/test/DepositUtilsTest.js
+++ b/solidity/test/DepositUtilsTest.js
@@ -62,8 +62,6 @@ describe("DepositUtils", async function() {
       tbtcDepositToken.address,
       feeRebateToken.address,
       ZERO_ADDRESS,
-      1, // m
-      1, // n
       fullBtc,
       {value: depositFee},
     )
@@ -350,8 +348,6 @@ describe("DepositUtils", async function() {
         tbtcDepositToken.address,
         feeRebateToken.address,
         ZERO_ADDRESS,
-        1, // m
-        1, // n
         fullBtc,
         {value: depositFee},
       )

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -288,13 +288,13 @@ describe("TBTCSystem governance", async function() {
           error: "Lot sizes greater than 100 BTC are not allowed",
         },
         "array is not sorted": {
-          parameters: [[10 ** 6, 10 ** 8, 10 **7]],
+          parameters: [[10 ** 6, 10 ** 8, 10 ** 7]],
           error: "Lot size array must be sorted",
         },
         "array has duplicate lots": {
           parameters: [[10 ** 6, 10 ** 7, 10 ** 7, 10 ** 8]],
           error: "Lot size array must not have duplicates",
-        }
+        },
       },
       verifyFinalizationEvents: (receipt, setLotSizes) => {
         expectEvent(receipt, "LotSizesUpdated", {_lotSizes: setLotSizes})
@@ -307,9 +307,9 @@ describe("TBTCSystem governance", async function() {
 
     describe("when finalizing lot size update", async () => {
       it("updates the minimum bondable value", async () => {
-        const lotSizes = [   
-          new BN(10 ** 5), 
-          new BN(10 ** 8) // required 
+        const lotSizes = [
+          new BN(10 ** 5),
+          new BN(10 ** 8), // required
         ]
 
         await ethBtcMedianizer.setValue(new BN(10 ** 11))
@@ -420,14 +420,14 @@ describe("TBTCSystem governance", async function() {
         keepFactorySelector.setFullyBackedMode()
         // Expect this to work normally, and update to the new factory for the
         // next call.
-        await tbtcSystem.requestNewKeep(5, 10, 0, 123, {
+        await tbtcSystem.requestNewKeep(0, 123, {
           from: mockDeposit,
           value: await ecdsaKeepFactory.openKeepFeeEstimate.call(),
         })
 
         // This should fail as the _ethBackedFactory is not a real contract
         // address, so dereferencing it will go boom.
-        await tbtcSystem.requestNewKeep(5, 10, 0, 123, {
+        await tbtcSystem.requestNewKeep(0, 123, {
           from: mockDeposit,
           value: await newKeepFactory.openKeepFeeEstimate.call(),
         })
@@ -658,11 +658,11 @@ describe("TBTCSystem governance", async function() {
 
   describe("when refreshing minimum bondable value", async () => {
     it("uses the most recent ETHBTC price", async () => {
-      const lotSizes = [  
+      const lotSizes = [
         new BN(10 ** 5),
-        new BN(10 ** 6),         
+        new BN(10 ** 6),
         new BN(10 ** 7),
-        new BN(10 ** 8), // required  
+        new BN(10 ** 8), // required
       ]
 
       await ethBtcMedianizer.setValue(new BN(10 ** 11))

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -420,14 +420,14 @@ describe("TBTCSystem governance", async function() {
         keepFactorySelector.setFullyBackedMode()
         // Expect this to work normally, and update to the new factory for the
         // next call.
-        await tbtcSystem.requestNewKeep(0, 123, {
+        await tbtcSystem.requestNewKeep(10 ** 8, 123, {
           from: mockDeposit,
           value: await ecdsaKeepFactory.openKeepFeeEstimate.call(),
         })
 
         // This should fail as the _ethBackedFactory is not a real contract
         // address, so dereferencing it will go boom.
-        await tbtcSystem.requestNewKeep(0, 123, {
+        await tbtcSystem.requestNewKeep(10 ** 8, 123, {
           from: mockDeposit,
           value: await newKeepFactory.openKeepFeeEstimate.call(),
         })

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -297,6 +297,24 @@ describe("TBTCSystem governance", async function() {
       },
     })
 
+    describe("when finalizing lot size update", async () => {
+      it("updates the minimum bondable value", async () => {
+        const lotSizes = [             
+          new BN(10 ** 8), // required
+          new BN(10 ** 6),
+          new BN(10 ** 9)
+        ]
+
+        await tbtcSystem.beginLotSizesUpdate(lotSizes)
+        const remainingTime = await tbtcSystem.getRemainingLotSizesUpdateTime()
+        await increaseTime(remainingTime.toNumber() + 1)
+        await tbtcSystem.finalizeLotSizesUpdate()
+
+        const minimum = await ecdsaKeepFactory.minimumBondableValue()
+        expect(minimum).to.eq.BN(new BN(10 ** 6))
+      })
+    })
+
     governanceTest({
       property: "collateralization thresholds",
       change: "CollateralizationThresholdsUpdate",

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -95,7 +95,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller does not match a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(1, maxSecuredLifetime, {
+        tbtcSystem.requestNewKeep(10 ** 8, maxSecuredLifetime, {
           value: openKeepFee,
           from: accounts[0],
         }),
@@ -105,7 +105,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller is the owner of a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(1, maxSecuredLifetime, {
+        tbtcSystem.requestNewKeep(10 ** 8, maxSecuredLifetime, {
           value: openKeepFee,
           from: tdtOwner,
         }),

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -51,7 +51,7 @@ describe("TBTCSystem", async function() {
     })
 
     it("sends caller as owner to open new keep", async () => {
-      await tbtcSystem.requestNewKeep(5, 10, 0, maxSecuredLifetime, {
+      await tbtcSystem.requestNewKeep(0, maxSecuredLifetime, {
         from: keepOwner,
         value: openKeepFee,
       })
@@ -66,8 +66,6 @@ describe("TBTCSystem", async function() {
       const expectedKeepAddress = await ecdsaKeepFactory.keepAddress.call()
 
       const result = await tbtcSystem.requestNewKeep.call(
-        5,
-        10,
         0,
         maxSecuredLifetime,
         {
@@ -82,7 +80,7 @@ describe("TBTCSystem", async function() {
     it("forwards value to keep factory", async () => {
       const initialBalance = await web3.eth.getBalance(ecdsaKeepFactory.address)
 
-      await tbtcSystem.requestNewKeep(5, 10, 0, maxSecuredLifetime, {
+      await tbtcSystem.requestNewKeep(0, maxSecuredLifetime, {
         value: openKeepFee,
         from: keepOwner,
       })
@@ -97,7 +95,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller does not match a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(5, 10, 0, maxSecuredLifetime, {
+        tbtcSystem.requestNewKeep(0, maxSecuredLifetime, {
           value: openKeepFee,
           from: accounts[0],
         }),
@@ -107,7 +105,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller is the owner of a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(5, 10, 0, maxSecuredLifetime, {
+        tbtcSystem.requestNewKeep(0, maxSecuredLifetime, {
           value: openKeepFee,
           from: tdtOwner,
         }),

--- a/solidity/test/TBTCSystemTest.js
+++ b/solidity/test/TBTCSystemTest.js
@@ -51,7 +51,7 @@ describe("TBTCSystem", async function() {
     })
 
     it("sends caller as owner to open new keep", async () => {
-      await tbtcSystem.requestNewKeep(0, maxSecuredLifetime, {
+      await tbtcSystem.requestNewKeep(10 ** 8, maxSecuredLifetime, {
         from: keepOwner,
         value: openKeepFee,
       })
@@ -66,7 +66,7 @@ describe("TBTCSystem", async function() {
       const expectedKeepAddress = await ecdsaKeepFactory.keepAddress.call()
 
       const result = await tbtcSystem.requestNewKeep.call(
-        0,
+        10 ** 8,
         maxSecuredLifetime,
         {
           value: openKeepFee,
@@ -80,7 +80,7 @@ describe("TBTCSystem", async function() {
     it("forwards value to keep factory", async () => {
       const initialBalance = await web3.eth.getBalance(ecdsaKeepFactory.address)
 
-      await tbtcSystem.requestNewKeep(0, maxSecuredLifetime, {
+      await tbtcSystem.requestNewKeep(10 ** 8, maxSecuredLifetime, {
         value: openKeepFee,
         from: keepOwner,
       })
@@ -95,7 +95,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller does not match a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(0, maxSecuredLifetime, {
+        tbtcSystem.requestNewKeep(1, maxSecuredLifetime, {
           value: openKeepFee,
           from: accounts[0],
         }),
@@ -105,7 +105,7 @@ describe("TBTCSystem", async function() {
 
     it("reverts if caller is the owner of a valid TDT", async () => {
       await expectRevert(
-        tbtcSystem.requestNewKeep(0, maxSecuredLifetime, {
+        tbtcSystem.requestNewKeep(1, maxSecuredLifetime, {
           value: openKeepFee,
           from: tdtOwner,
         }),


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-ecdsa/issues/506

~~Depends on https://github.com/keep-network/keep-ecdsa/pull/508~~
~~Depends on https://github.com/keep-network/sortition-pools/pull/84~~

Deep inside ECDSA keep factory implementation, `BondedSortitionPool` was updating the minimum bondable value for each new group selection. The idea was to automatically remove from the pool operators that are no longer able to satisfy application needs about the minimum available bondable value and prevent operators with too low value griefing signer selection.

We now have two minimum bond values: one defining the minimum unbonded value the operator needs to have so that it can join and stay in the pool, and another defining the required bond value for the current selection. If the given operator has enough unbonded value to stay in the pool but it does not have enough unbonded value for the current group selection, it is skipped.

In ECDSA keep factory, sortition pool is created with a minimum bond of 20 ETH to avoid small operators joining and griefing future selections before the minimum bond is set to the right value by the application. Anyone can create a sortition pool for an application with the default minimum bond value but the application can change this value later, at any point. 20 ETH per operator should be more than enough to cover 1 BTC deposit in 3-operators group.

The default is fine for most cases <now> but the application is expected to refresh the minimum bondable value, depending on the current situation and needs.

For tBTC, the minimum bond value proposed here is be the minimum lot size expressed in wei given the current BTC price with 150% collateralization. For such a value, operator should be able to participate in at least 3 keeps.

Here we add a function allowing to refresh the minimum bondable value given the current BTC price. The function can be called by anyone at any moment. It is recommended to call this function on tBTC initialization and after the minimum lot size update.