### PR TITLE
Truffle Migrate: Create sortition pool

### DIFF
--- a/solidity/migrations/3_initialize.js
+++ b/solidity/migrations/3_initialize.js
@@ -67,6 +67,7 @@ module.exports = async function(deployer, network) {
   }
 
   // Create sorition pool for new TBTCSystem.
+  console.log(`Creating sortition pool for TBTCSystem: [${TBTCSystem.address}]`)
   const BondedECDSAKeepFactoryContract = truffleContract(
     BondedECDSAKeepFactoryJson,
   )


### PR DESCRIPTION
### Intro 

After a fresh migration of tbtc contracts we need to create a sortition pool for the `TBTCSystem` application.  This is a one time endeavor, and doesn't need to be done again until we do another tbtc contract migration.

We currently handle sortition pool creation via the automated init process on keep-ecdsa client deployment.  Specifically, it's handled [here](https://github.com/keep-network/keep-ecdsa/blob/master/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js#L210).  

While this works the configuration is a bit out of place.  It's true that keep-ecdsa requires there to be a sortition pool present for the given `TBTCSystem` to run, but a sortition pool not a product of keep-ecdsa configuration.  Rather, it's a product of environment initialization after a fresh migration.

Application deployment InitContainers should operate within the context of provisioning the application.

### What We Did

To try and correct the ^ scenario we're moving sortition pool creation to the `truffle migrate` initialization script.

### Testing

Much headbanging against a local setup but we got there.  Below is a paste of the output after creation

Script Output
```
3_initialize.js
===============
sortition pool address: [0x0e7150Bf9950BeCe1F61b91685732b9294f61098]
```

### Dependencies

Needs to be merged before or with https://github.com/keep-network/keep-ecdsa/pull/507