### PR TITLE
Holders gonna hold: Clean up VM-owned redemption requests

### DIFF
--- a/solidity/contracts/deposit/DepositRedemption.sol
+++ b/solidity/contracts/deposit/DepositRedemption.sol
@@ -64,15 +64,14 @@ library DepositRedemption {
         ) = _d.calculateRedemptionTbtcAmounts(_d.redeemerAddress, false);
 
         if(tbtcOwedToDeposit > 0){
-            if(tdtHolder == vendingMachineAddress){
-                _d.tbtcToken.burnFrom(msg.sender, tbtcOwedToDeposit);
-            }
-            else{
-                _d.tbtcToken.transferFrom(msg.sender, address(this), tbtcOwedToDeposit);
-            }
+            _d.tbtcToken.transferFrom(msg.sender, address(this), tbtcOwedToDeposit);
         }
         if(tbtcOwedToTdtHolder > 0){
-            _d.tbtcToken.transfer(tdtHolder, tbtcOwedToTdtHolder);
+            if(tdtHolder == vendingMachineAddress){
+                _d.tbtcToken.burn(tbtcOwedToTdtHolder);
+            } else {
+                _d.tbtcToken.transfer(tdtHolder, tbtcOwedToTdtHolder);
+            }
         }
         if(tbtcOwedToFrtHolder > 0){
             _d.tbtcToken.transfer(frtHolder, tbtcOwedToFrtHolder);

--- a/solidity/test/DepositRedemptionTest.js
+++ b/solidity/test/DepositRedemptionTest.js
@@ -212,11 +212,14 @@ describe("DepositRedemption", async function() {
     })
 
     it("does not revert if the fee is just under the max threshold", async () => {
-      await testDeposit.requestRedemption(
-        "0x8a88888888888808",
-        "0x1976a914" + "33".repeat(20) + "88ac",
-        {from: owner},
-      )
+      expect(
+        async () =>
+          await testDeposit.requestRedemption(
+            "0x8a88888888888808",
+            "0x1976a914" + "33".repeat(20) + "88ac",
+            {from: owner},
+          ),
+      ).does.not.throw()
     })
 
     it("reverts if the output script is non-standard", async () => {

--- a/solidity/test/StateTests.js
+++ b/solidity/test/StateTests.js
@@ -3,7 +3,7 @@ const {deployAndLinkAll} = require("./helpers/fullDeployer.js")
 const {runStatePath} = require("./states/run.js")
 
 describe("tBTC states", () => {
-  describe("simple redeem", () => {
+  describe("when running a redemption", () => {
     runStatePath(
       states,
       deployAndLinkAll(),
@@ -14,7 +14,7 @@ describe("tBTC states", () => {
       "awaitingWithdrawalSignature",
     )
   })
-  describe("Courtesy -> Active & liquidation", () => {
+  describe("when liquidating from a courtesy call", () => {
     runStatePath(
       states,
       deployAndLinkAll(),
@@ -26,7 +26,7 @@ describe("tBTC states", () => {
       "liquidationInProgress",
     )
   })
-  describe("Courtesy -> Active & liquidation_fraud", () => {
+  describe("when fraud liquidating from a courtesy call", () => {
     runStatePath(
       states,
       deployAndLinkAll(),
@@ -38,7 +38,7 @@ describe("tBTC states", () => {
       "liquidationInProgress_fraud",
     )
   })
-  describe("Undercollateralized Liquidation", () => {
+  describe("when liquidating from severe undercollateralization", () => {
     runStatePath(
       states,
       deployAndLinkAll(),
@@ -49,7 +49,7 @@ describe("tBTC states", () => {
       "liquidationInProgress",
     )
   })
-  describe("aborted redemption", () => {
+  describe("when liquidiating during a redemption", () => {
     runStatePath(
       states,
       deployAndLinkAll(),
@@ -57,6 +57,82 @@ describe("tBTC states", () => {
       "awaitingSignerSetup",
       "awaitingFundingProof",
       "active",
+      "awaitingWithdrawalSignature",
+      "liquidationInProgress",
+    )
+  })
+  describe("when minting TBTC then running a redemption", () => {
+    runStatePath(
+      states,
+      deployAndLinkAll(),
+      "start",
+      "awaitingSignerSetup",
+      "awaitingFundingProof",
+      "active",
+      "minted",
+      "awaitingWithdrawalSignature",
+    )
+  })
+  describe("when minting TBTC then redeeming from a courtesy call", () => {
+    runStatePath(
+      states,
+      deployAndLinkAll(),
+      "start",
+      "awaitingSignerSetup",
+      "awaitingFundingProof",
+      "active",
+      "minted",
+      "courtesyCall",
+      "awaitingWithdrawalSignature",
+    )
+  })
+  describe("when minting TBTC then liquidating from a courtesy call", () => {
+    runStatePath(
+      states,
+      deployAndLinkAll(),
+      "start",
+      "awaitingSignerSetup",
+      "awaitingFundingProof",
+      "active",
+      "minted",
+      "courtesyCall",
+      "liquidationInProgress",
+    )
+  })
+  describe("when minting TBTC then fraud liquidating from a courtesy call", () => {
+    runStatePath(
+      states,
+      deployAndLinkAll(),
+      "start",
+      "awaitingSignerSetup",
+      "awaitingFundingProof",
+      "active",
+      "minted",
+      "courtesyCall",
+      "liquidationInProgress_fraud",
+    )
+  })
+  describe("when minting TBTC then liquidating from severe undercollateralization", () => {
+    runStatePath(
+      states,
+      deployAndLinkAll(),
+      "start",
+      "awaitingSignerSetup",
+      "awaitingFundingProof",
+      "active",
+      "minted",
+      "liquidationInProgress",
+    )
+  })
+  describe("when minting TBTC then liquidiating during a redemption", () => {
+    runStatePath(
+      states,
+      deployAndLinkAll(),
+      "start",
+      "awaitingSignerSetup",
+      "awaitingFundingProof",
+      "active",
+      "minted",
       "awaitingWithdrawalSignature",
       "liquidationInProgress",
     )

--- a/solidity/test/states/deposit.js
+++ b/solidity/test/states/deposit.js
@@ -18,7 +18,7 @@ const liquidator = accounts[2]
 
 const System = {
     lotSizes: async ({ TBTCSystem }) => {
-        return (await TBTCSystem.getAllowedLotSizes())[0]
+        return await TBTCSystem.getAllowedLotSizes()
     },
     feeEstimate: async ({ TBTCSystem }) => TBTCSystem.getNewDepositFeeEstimate(),
     setEcdsaKey: async ({ ECDSAKeepStub }) => {
@@ -122,16 +122,16 @@ module.exports = {
     start: {
         name: "start",
         dependencies: {
-            lotSize: System.lotSizes,
+            availableLotSizes: System.lotSizes,
             feeEstimate: System.feeEstimate,
         },
         next: {
             awaitingSignerSetup: {
-                transition: async ({ DepositFactory, lotSize, feeEstimate }) => {
+                transition: async ({ DepositFactory, availableLotSizes, feeEstimate }) => {
                     return {
                         state: "awaitingSignerSetup",
                         tx: DepositFactory.createDeposit(
-                            lotSize,
+                            availableLotSizes[0],
                             {
                                 value: feeEstimate,
                                 from: opener,

--- a/solidity/test/states/deposit.js
+++ b/solidity/test/states/deposit.js
@@ -59,9 +59,10 @@ const System = {
     setDifficulty: async ({ MockRelay, difficulty }) => {
         await MockRelay.setCurrentEpochDifficulty(difficulty)
     },
-    setAndApproveRedemptionBalance: async ({ TestTBTCToken, deposit }) => {
-        const redemptionRequirement =
-            await deposit.getRedemptionTbtcRequirement(opener)
+    depositRedemptionRequirement: async ({ deposit }) => {
+        return await deposit.getRedemptionTbtcRequirement(opener)
+    },
+    setAndApproveRedemptionBalance: async ({ TestTBTCToken, deposit, redemptionRequirement }) => {
         await TestTBTCToken.forceMint(
             opener,
             // Let's just play it safe.
@@ -350,6 +351,7 @@ module.exports = {
         name: "active",
         dependencies: {
             bondAmount: System.expectedBond,
+            redemptionRequirement: System.depositRedemptionRequirement,
         },
         next: {
             awaitingWithdrawalSignature: {
@@ -523,6 +525,7 @@ module.exports = {
         name: "courtesyCall",
         dependencies: {
             bondAmount: System.expectedBond,
+            redemptionRequirement: System.depositRedemptionRequirement,
         },
         next: {
             active: {

--- a/solidity/test/states/deposit.js
+++ b/solidity/test/states/deposit.js
@@ -59,6 +59,12 @@ const System = {
     setDifficulty: async ({ MockRelay, difficulty }) => {
         await MockRelay.setCurrentEpochDifficulty(difficulty)
     },
+    depositLotSize: async ({ deposit }) => {
+        return await deposit.lotSizeTbtc();
+    },
+    depositSignerFee: async ({ deposit }) => {
+        return await deposit.signerFeeTbtc();
+    },
     depositRedemptionRequirement: async ({ deposit }) => {
         return await deposit.getRedemptionTbtcRequirement(opener)
     },

--- a/solidity/test/states/deposit.js
+++ b/solidity/test/states/deposit.js
@@ -712,6 +712,27 @@ module.exports = {
                     )
                 },
             },
+            awaitingWithdrawalSignature: {
+                transition: async (state) => {
+                    const { deposit } = state
+                    await System.setAndApproveRedemptionBalance(state)
+
+                    return {
+                        state: "active",
+                        tx: deposit.requestRedemption(
+                            depositRoundTrip.redemptionTx.outputValueBytes,
+                            depositRoundTrip.redemptionTx.outputScript,
+                            { from: opener },
+                        )
+                    }
+                },
+                expect: async (_, receipt, { deposit }) => {
+                    expectEvent(receipt, "RedemptionRequested")
+                    expect(await deposit.currentState()).to.eq.BN(
+                        System.States.AWAITING_WITHDRAWAL_SIGNATURE
+                    )
+                },
+            },
             liquidationInProgress: {
                 after: System.courtesyTimeout,
                 transition: async (state) => {


### PR DESCRIPTION
The original issue reported by @Certora regarded a deposit's TDT being
transferred to the vending machine contract without going through the
vending machine's minting flow. Originally this would allow a TDT holder
to bypass the signer fees for the deposit.

The fee refactor removed this capability, but a mistake in that refactor meant
that, were the TDT holder still willing to *pay* the signer fee, they could
withhold it from the *signers* by doing some gymnastics (in particular by
transferring the TDT to the vending machine, waiting for courtesy call or
term to arrive, transferring the redemption amount to the deposit, and then
requesting redemption). In this code path, the vending machine would receive
the TBTC, but the signer fee would fail to be escrowed on the deposit for
disbursal once redemption completed.

Digging into this revealed a few things:

- Evidently I never committed the test I used to confirm the original issue. That
  test would have caught this issue as well, but went MIA. Unclear how this
  happened. That test is now in the repo.
- Our state tests were not exercising all code paths related to TBTC minting
  comprehensively. This is now addressed.
- In cases where a deposit's TDT was held by the vending machine, the TBTC
  transfers triggered during redemption requests were burning the amount owed
  to the deposit, rather than the amount owed to the TDT holder, leading to the
  bug described above. This is now fixed.

H/t to the @Certora team for catching this while reviewing the fix.