### PR TITLE
Remove `bignumber.js@` prefix from package-lock

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -29585,7 +29585,7 @@
       "resolved": "https://registry.npmjs.org/web3/-/web3-0.18.4.tgz",
       "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
       "requires": {
-        "bignumber.js": "bignumber.js@git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+        "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",


### PR DESCRIPTION
Closes: #718 

Here we fix the failing `npm install` command by removing the `bignumber.js@` prefix from the `package-lock.json` file.