### PR TITLE
Use vendors for Keep factories and lock them

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ jobs:
             echo $GCLOUD_SERVICE_KEY > ~/gcloud-service-key.json
             gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
             export UNISWAP_CONTRACT_DATA="uniswap-contract-data.txt"
-            export BONDED_ECDSA_KEEP_FACTORY_CONTRACT_DATA="BondedECDSAKeepFactory.json"
+            export BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA="BondedECDSAKeepVendor.json"
             solidity/scripts/circleci-provision-external-contracts.sh
       - run:
           name: Migrate Contracts

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -122,19 +122,33 @@ library KeepFactorySelection {
         uint256 _groupSize,
         uint256 _honestThreshold
     ) public {
-        if (address(_self.keepStakeFactory) != address(0)) {
-            _self.keepStakeFactory.setMinimumBondableValue(
+        require(
+            address(_self.keepStakeVendor) != address(0),
+            "KEEP backed vendor not set"
+        );
+
+        IBondedECDSAKeepFactory keepStakeFactory = getKeepStakedFactory(_self);
+
+        if (address(keepStakeFactory) != address(0)) {
+            keepStakeFactory.setMinimumBondableValue(
                 _minimumBondableValue,
                 _groupSize,
                 _honestThreshold
             );
         }
-        if (address(_self.fullyBackedFactory) != address(0)) {
-            _self.fullyBackedFactory.setMinimumBondableValue(
-                _minimumBondableValue,
-                _groupSize,
-                _honestThreshold
+
+        if (address(_self.fullyBackedVendor) != address(0)) {
+            IBondedECDSAKeepFactory fullyBackedFactory = getFullyBackedFactory(
+                _self
             );
+
+            if (address(fullyBackedFactory) != address(0)) {
+                fullyBackedFactory.setMinimumBondableValue(
+                    _minimumBondableValue,
+                    _groupSize,
+                    _honestThreshold
+                );
+            }
         }
     }
 
@@ -257,10 +271,7 @@ library KeepFactorySelection {
             address(_self.factorySelector) == address(0),
             "Factory selector already set"
         );
-        require(
-            address(_factorySelector) != address(0),
-            "Invalid address"
-        );
+        require(address(_factorySelector) != address(0), "Invalid address");
 
         _self.factorySelector = KeepFactorySelector(_factorySelector);
     }

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -49,7 +49,7 @@ library KeepFactorySelection {
 
         // Lock for factories versions freeze. When set to true vendor won't be
         // called to obtain a new factory address but a version of a factory
-        // from the moment of freezing will be used. Once locked the factory
+        // from the moment of freezing will be used, once locked the factory
         // address won't be able to update anymore.
         bool factoriesVersionsLocked;
     }
@@ -213,7 +213,7 @@ library KeepFactorySelection {
     }
 
     /// @notice Returns ETH-bond-only based factory address. If factories lock is not set
-    /// it calls the ETH staked vendor to obtain the latest versions of the factory.
+    /// it calls the fully-backed vendor to obtain the latest versions of the factory.
     function getFullyBackedFactory(Storage storage _self)
         internal
         view
@@ -285,7 +285,8 @@ library KeepFactorySelection {
     /// @notice Locks versions of factories. When lock is set vendor contracts
     /// won't be called anymore to obtain the latest factories versions.
     /// It requires expected factories addresses to be provided to protect from
-    /// locking on unexpected addresses.
+    /// locking on unexpected addresses. The function can be called only once and
+    /// the lock cannot be disabled.
     /// @param _expectedKeepStakedFactory Expected KEEP-staked factory address
     /// @param _expectedFullyBackedFactory Expected ETH-bond-only factory address
     function lockFactoriesVersions(

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -51,7 +51,7 @@ library KeepFactorySelection {
         // called to obtain a new factory address but a version of a factory
         // from the moment of freezing will be used. Once locked the factory
         // address won't be able to update anymore.
-        bool factoriesVersionsLock;
+        bool factoriesVersionsLocked;
     }
 
     /// @notice Initializes the library with the default KEEP-stake-based
@@ -204,7 +204,7 @@ library KeepFactorySelection {
         view
         returns (IBondedECDSAKeepFactory)
     {
-        if (_self.factoriesVersionsLock) {
+        if (_self.factoriesVersionsLocked) {
             return _self.keepStakeFactory;
         } else {
             return
@@ -219,7 +219,7 @@ library KeepFactorySelection {
         view
         returns (IBondedECDSAKeepFactory)
     {
-        if (_self.factoriesVersionsLock) {
+        if (_self.factoriesVersionsLocked) {
             return _self.fullyBackedFactory;
         } else {
             return
@@ -293,7 +293,7 @@ library KeepFactorySelection {
         address _expectedKeepStakeFactory,
         address _expectedFullyBackedFactory
     ) internal {
-        require(!_self.factoriesVersionsLock, "Already locked");
+        require(!_self.factoriesVersionsLocked, "Already locked");
 
         require(
             address(_self.keepStakeVendor) != address(0),
@@ -304,7 +304,7 @@ library KeepFactorySelection {
             "Fully backed vendor not set"
         );
 
-        _self.factoriesVersionsLock = true;
+        _self.factoriesVersionsLocked = true;
 
         address latestKeepStakeFactory = _self
             .keepStakeVendor

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -298,6 +298,8 @@ library KeepFactorySelection {
             "Fully backed vendor not set"
         );
 
+        _self.factoriesVersionsLock = true;
+
         address latestKeepStakeFactory = _self
             .keepStakeVendor
             .selectFactory();
@@ -316,7 +318,5 @@ library KeepFactorySelection {
 
         _self.keepStakeFactory = IBondedECDSAKeepFactory(latestKeepStakeFactory);
         _self.fullyBackedFactory = IBondedECDSAKeepFactory(latestFullyBackedFactory);
-
-        _self.factoriesVersionsLock = true;
     }
 }

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -139,7 +139,7 @@ library KeepFactorySelection {
     /// Unless lock is set, it calls vendors to obtain the latests factories
     /// versions.
     function refreshFactory(Storage storage _self) internal {
-        _self.keepStakeFactory = getKeepStakedFactory(_self);
+        IBondedECDSAKeepFactory keepStakeFactory = getKeepStakedFactory(_self);
 
         if (
             address(_self.ethStakeFactory) == address(0) ||
@@ -147,11 +147,11 @@ library KeepFactorySelection {
         ) {
             // KEEP-stake factory is guaranteed to be there. If the selection
             // can not be performed, this is the default choice.
-            _self.selectedFactory = _self.keepStakeFactory;
+            _self.selectedFactory = keepStakeFactory;
             return;
         }
 
-        _self.ethStakeFactory = getFullyBackedFactory(_self);
+        IBondedECDSAKeepFactory ethStakeFactory = getFullyBackedFactory(_self);
 
         _self.requestCounter++;
         uint256 seed = uint256(
@@ -159,13 +159,13 @@ library KeepFactorySelection {
         );
         _self.selectedFactory = _self.factorySelector.selectFactory(
             seed,
-            _self.keepStakeFactory,
-            _self.ethStakeFactory
+            keepStakeFactory,
+            ethStakeFactory
         );
 
         require(
-            _self.selectedFactory == _self.keepStakeFactory ||
-                _self.selectedFactory == _self.ethStakeFactory,
+            _self.selectedFactory == keepStakeFactory ||
+                _self.selectedFactory == ethStakeFactory,
             "Factory selector returned unknown factory"
         );
     }

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -69,9 +69,7 @@ library KeepFactorySelection {
         );
 
         _self.keepStakeVendor = IBondedECDSAKeepVendor(_defaultVendor);
-        _self.keepStakeFactory = getKeepStakedFactory(_self);
-
-        _self.selectedFactory = _self.keepStakeFactory;
+        _self.selectedFactory = getKeepStakedFactory(_self);
     }
 
     /// @notice Returns the selected keep factory.

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -143,7 +143,7 @@ library KeepFactorySelection {
         IBondedECDSAKeepFactory keepStakeFactory = getKeepStakedFactory(_self);
 
         if (
-            address(_self.fullyBackedFactory) == address(0) ||
+            address(_self.fullyBackedVendor) == address(0) ||
             address(_self.factorySelector) == address(0)
         ) {
             // KEEP-stake factory is guaranteed to be there. If the selection
@@ -223,7 +223,8 @@ library KeepFactorySelection {
     /// Once both fully-backed keep factory and factory selection strategy are
     /// set, KEEP-stake-based factory is no longer the default choice and it is
     /// up to the selection strategy to decide which factory should be chosen.
-    /// @dev Can be called only one time!
+    /// @dev Can be called only one time! The function calls the vendor to confirm
+    /// it correctly returns a factory address.
     /// @param _fullyBackedVendor Address of the fully-backed, ETH-bond-only based
     /// keep vendor.
     function setFullyBackedKeepVendor(
@@ -239,12 +240,13 @@ library KeepFactorySelection {
         IBondedECDSAKeepVendor fullyBackedVendor = IBondedECDSAKeepVendor(
             _fullyBackedVendor
         );
-        address fullyBackedFactory = fullyBackedVendor.selectFactory();
 
-        require(fullyBackedFactory != address(0), "Vendor returned invalid factory address");
+        require(
+            fullyBackedVendor.selectFactory() != address(0),
+            "Vendor returned invalid factory address"
+        );
 
         _self.fullyBackedVendor = fullyBackedVendor;
-        _self.fullyBackedFactory = IBondedECDSAKeepFactory(fullyBackedFactory);
     }
 
     /// @notice Sets the address of the keep factory selection strategy contract.

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -49,7 +49,7 @@ library KeepFactorySelection {
 
         // Lock for factories versions freeze. When set to true vendor won't be
         // called to obtain a new factory address but a version of a factory
-        // from the moment of freezing will be used, once locked the factory
+        // from the moment of freezing will be used. Once locked, the factory
         // address won't be able to update anymore.
         bool factoriesVersionsLocked;
     }

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -124,7 +124,7 @@ library KeepFactorySelection {
     ) public {
         require(
             address(_self.keepStakeVendor) != address(0),
-            "KEEP backed vendor not set"
+            "KEEP-staked vendor not set"
         );
 
         IBondedECDSAKeepFactory keepStakeFactory = getKeepStakedFactory(_self);
@@ -291,7 +291,7 @@ library KeepFactorySelection {
 
         require(
             address(_self.keepStakeVendor) != address(0),
-            "KEEP backed vendor not set"
+            "KEEP-staked vendor not set"
         );
         require(
             address(_self.fullyBackedVendor) != address(0),
@@ -309,7 +309,7 @@ library KeepFactorySelection {
 
         require(
             address(latestKeepStakeFactory) == _expectedKeepStakeFactory,
-            "Unexpected KEEP backed factory"
+            "Unexpected KEEP-staked factory"
         );
         require(
             address(latestFullyBackedFactory) == _expectedFullyBackedFactory,

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -69,7 +69,15 @@ library KeepFactorySelection {
         );
 
         _self.keepStakeVendor = IBondedECDSAKeepVendor(_defaultVendor);
-        _self.selectedFactory = getKeepStakedFactory(_self);
+
+        address keepStakeFactory = _self.keepStakeVendor.selectFactory();
+
+        require(
+            keepStakeFactory != address(0),
+            "Vendor returned invalid factory address"
+        );
+
+        _self.selectedFactory = IBondedECDSAKeepFactory(keepStakeFactory);
     }
 
     /// @notice Returns the selected keep factory.
@@ -179,16 +187,8 @@ library KeepFactorySelection {
         if (_self.factoriesVersionsLock) {
             return _self.keepStakeFactory;
         } else {
-            IBondedECDSAKeepFactory keepStakeFactory = IBondedECDSAKeepFactory(
-                _self.keepStakeVendor.selectFactory()
-            );
-
-            require(
-                address(keepStakeFactory) != address(0),
-                "Vendor returned invalid factory address"
-            );
-
-            return keepStakeFactory;
+            return
+                IBondedECDSAKeepFactory(_self.keepStakeVendor.selectFactory());
         }
     }
 
@@ -202,16 +202,10 @@ library KeepFactorySelection {
         if (_self.factoriesVersionsLock) {
             return _self.fullyBackedFactory;
         } else {
-            IBondedECDSAKeepFactory fullyBackedFactory = IBondedECDSAKeepFactory(
-                _self.fullyBackedVendor.selectFactory()
-            );
-
-            require(
-                address(fullyBackedFactory) != address(0),
-                "Vendor returned invalid factory address"
-            );
-
-            return fullyBackedFactory;
+            return
+                IBondedECDSAKeepFactory(
+                    _self.fullyBackedVendor.selectFactory()
+                );
         }
     }
 
@@ -293,12 +287,12 @@ library KeepFactorySelection {
             "Fully backed vendor not set"
         );
 
-        IBondedECDSAKeepFactory latestKeepStakeFactory = getKeepStakedFactory(
-            _self
-        );
-        IBondedECDSAKeepFactory latestFullyBackedFactory = getFullyBackedFactory(
-            _self
-        );
+        address latestKeepStakeFactory = _self
+            .keepStakeVendor
+            .selectFactory();
+        address latestFullyBackedFactory = _self
+            .fullyBackedVendor
+            .selectFactory();
 
         require(
             address(latestKeepStakeFactory) == _expectedKeepStakeFactory,
@@ -309,8 +303,8 @@ library KeepFactorySelection {
             "Unexpected fully backed factory"
         );
 
-        _self.keepStakeFactory = latestKeepStakeFactory;
-        _self.fullyBackedFactory = latestFullyBackedFactory;
+        _self.keepStakeFactory = IBondedECDSAKeepFactory(latestKeepStakeFactory);
+        _self.fullyBackedFactory = IBondedECDSAKeepFactory(latestFullyBackedFactory);
 
         _self.factoriesVersionsLock = true;
     }

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -303,7 +303,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     ///      called more than once until finalized to reset the values and
     ///      timer, but it can only be finalized once!
     /// @param _factorySelector Address of the keep factory selection strategy.
-    /// @param _fullyBackedVendor Address of the ETH-stake-based vendor.
+    /// @param _fullyBackedVendor Address of the ETH-only-backed vendor.
     function beginKeepVendorSingleShotUpdate(
         address _factorySelector,
         address _fullyBackedVendor
@@ -478,7 +478,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// It requires expected factories addresses to be provided to protect from
     /// locking on unexpected addresses.
     /// @param _expectedKeepStakedFactory Expected KEEP-staked factory address
-    /// @param _expectedFullyBackedFactory Expected ETH-staked factory address
+    /// @param _expectedFullyBackedFactory Expected ETH-only-backed factory address
     function lockKeepFactoriesVersionsUpdates(
         address _expectedKeepStakedFactory,
         address _expectedFullyBackedFactory

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -58,6 +58,11 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         address _ethBackedVendor
     );
 
+    event KeepFactoriesVersionsLocked(
+        address _keepStakeFactory,
+        address _fullyBackedFactory
+    );
+
     uint256 initializedTimestamp = 0;
     uint256 pausedTimestamp;
     uint256 constant pausedDuration = 10 days;
@@ -466,6 +471,27 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         priceFeed.addEthBtcFeed(_nextEthBtcPriceFeed);
 
         emit EthBtcPriceFeedAdded(address(_nextEthBtcPriceFeed));
+    }
+
+    /// @notice Locks versions of Keep factories. When lock is set vendor contracts
+    /// won't be called anymore to obtain the latest Keep factories versions.
+    /// It requires expected factories addresses to be provided to protect from
+    /// locking on unexpected addresses.
+    /// @param _expectedKeepStakeFactory Expected KEEP-staked factory address
+    /// @param _expectedFullyBackedFactory Expected ETH-staked factory address
+    function lockKeepFactoriesVersionsUpdates(
+        address _expectedKeepStakeFactory,
+        address _expectedFullyBackedFactory
+    ) external onlyOwner {
+        keepFactorySelection.lockFactoriesVersions(
+            _expectedKeepStakeFactory,
+            _expectedFullyBackedFactory
+        );
+
+        emit KeepFactoriesVersionsLocked(
+            _expectedKeepStakeFactory,
+            _expectedFullyBackedFactory
+        );
     }
 
     /// @notice Gets the system signer fee divisor.

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -40,7 +40,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     );
     event KeepVendorSingleShotUpdateStarted(
         address _factorySelector,
-        address _ethBackedVendor,
+        address _fullyBackedVendor,
         uint256 _timestamp
     );
 
@@ -55,7 +55,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     );
     event KeepVendorSingleShotUpdated(
         address _factorySelector,
-        address _ethBackedVendor
+        address _fullyBackedVendor
     );
 
     event KeepFactoriesVersionsLocked(
@@ -96,7 +96,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     uint16 private newUndercollateralizedThresholdPercent;
     uint16 private newSeverelyUndercollateralizedThresholdPercent;
     address private newFactorySelector;
-    address private newEthBackedVendor;
+    address private newFullyBackedVendor;
 
     // price feed
     uint256 priceFeedGovernanceTimeDelay = 90 days;
@@ -303,10 +303,10 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     ///      called more than once until finalized to reset the values and
     ///      timer, but it can only be finalized once!
     /// @param _factorySelector Address of the keep factory selection strategy.
-    /// @param _ethBackedVendor Address of the ETH-stake-based vendor.
+    /// @param _fullyBackedVendor Address of the ETH-stake-based vendor.
     function beginKeepVendorSingleShotUpdate(
         address _factorySelector,
-        address _ethBackedVendor
+        address _fullyBackedVendor
     )
         external onlyOwner
     {
@@ -314,9 +314,9 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             // Either an update is in progress,
             keepVendorSingleShotUpdateInitiated != 0 ||
             // or we're trying to start a fresh one, in which case we must not
-            // have an already-finalized one (indicated by newEthBackedVendor
+            // have an already-finalized one (indicated by newFullyBackedVendor
             // being set).
-            newEthBackedVendor == address(0),
+            newFullyBackedVendor == address(0),
             "Keep vendor data can only be updated once"
         );
         require(
@@ -324,16 +324,16 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             "Factory selector must be a nonzero address"
         );
         require(
-            _ethBackedVendor != address(0),
+            _fullyBackedVendor != address(0),
             "ETH-backed vendor must be a nonzero address"
         );
 
         newFactorySelector = _factorySelector;
-        newEthBackedVendor = _ethBackedVendor;
+        newFullyBackedVendor = _fullyBackedVendor;
         keepVendorSingleShotUpdateInitiated = block.timestamp;
         emit KeepVendorSingleShotUpdateStarted(
             _factorySelector,
-            _ethBackedVendor,
+            _fullyBackedVendor,
             block.timestamp
         );
     }
@@ -438,16 +438,16 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         ) {
 
         keepFactorySelection.setKeepFactorySelector(newFactorySelector);
-        keepFactorySelection.setFullyBackedKeepVendor(newEthBackedVendor);
+        keepFactorySelection.setFullyBackedKeepVendor(newFullyBackedVendor);
 
         emit KeepVendorSingleShotUpdated(
             newFactorySelector,
-            newEthBackedVendor
+            newFullyBackedVendor
         );
 
         keepVendorSingleShotUpdateInitiated = 0;
         newFactorySelector = address(0);
-        // Keep newEthBackedVendor set as a marker that the update has already
+        // Keep newFullyBackedVendor set as a marker that the update has already
         // occurred.
     }
 

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -59,7 +59,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     );
 
     event KeepFactoriesVersionsLocked(
-        address _keepStakeFactory,
+        address _keepStakedFactory,
         address _fullyBackedFactory
     );
 
@@ -477,19 +477,19 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// won't be called anymore to obtain the latest Keep factories versions.
     /// It requires expected factories addresses to be provided to protect from
     /// locking on unexpected addresses.
-    /// @param _expectedKeepStakeFactory Expected KEEP-staked factory address
+    /// @param _expectedKeepStakedFactory Expected KEEP-staked factory address
     /// @param _expectedFullyBackedFactory Expected ETH-staked factory address
     function lockKeepFactoriesVersionsUpdates(
-        address _expectedKeepStakeFactory,
+        address _expectedKeepStakedFactory,
         address _expectedFullyBackedFactory
     ) external onlyOwner {
         keepFactorySelection.lockFactoriesVersions(
-            _expectedKeepStakeFactory,
+            _expectedKeepStakedFactory,
             _expectedFullyBackedFactory
         );
 
         emit KeepFactoriesVersionsLocked(
-            _expectedKeepStakeFactory,
+            _expectedKeepStakedFactory,
             _expectedFullyBackedFactory
         );
     }

--- a/solidity/contracts/test/keep/ECDSAKeepVendorStub.sol
+++ b/solidity/contracts/test/keep/ECDSAKeepVendorStub.sol
@@ -1,0 +1,21 @@
+pragma solidity 0.5.17;
+
+import {
+    IBondedECDSAKeepVendor
+} from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeepVendor.sol";
+
+contract ECDSAKeepVendorStub is IBondedECDSAKeepVendor {
+    address payable factory;
+
+    constructor(address payable _factory) public {
+        factory = _factory;
+    }
+
+    function setFactory(address payable _factory) public {
+        factory = _factory;
+    }
+
+    function selectFactory() public view returns (address payable) {
+        return factory;
+    }
+}

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -45,8 +45,8 @@ contract KeepFactorySelectionStub {
         keepFactorySelection.setKeepFactorySelector(_factorySelector);
     }
 
-    function keepStakeFactory() public view returns (address) {
-        return address(keepFactorySelection.keepStakeFactory);
+    function keepStakedFactory() public view returns (address) {
+        return address(keepFactorySelection.keepStakedFactory);
     }
 
     function fullyBackedFactory() public view returns (address) {
@@ -58,11 +58,11 @@ contract KeepFactorySelectionStub {
     }
 
     function lockFactoriesVersions(
-        address _expectedKeepStakeFactory,
+        address _expectedKeepStakedFactory,
         address _expectedFullyBackedFactory
     ) public {
         keepFactorySelection.lockFactoriesVersions(
-            _expectedKeepStakeFactory,
+            _expectedKeepStakedFactory,
             _expectedFullyBackedFactory
         );
     }

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -8,8 +8,8 @@ contract KeepFactorySelectionStub {
     using KeepFactorySelection for KeepFactorySelection.Storage;
     KeepFactorySelection.Storage keepFactorySelection;
 
-    function initialize(IBondedECDSAKeepFactory _defaultFactory) public {
-        keepFactorySelection.initialize(_defaultFactory);
+    function initialize(IBondedECDSAKeepVendor _defaultVendor) public {
+        keepFactorySelection.initialize(_defaultVendor);
     }
 
     function selectFactory() public view returns (IBondedECDSAKeepFactory) {
@@ -20,8 +20,8 @@ contract KeepFactorySelectionStub {
         return keepFactorySelection.selectFactoryAndRefresh();
     }
 
-    function setFullyBackedKeepFactory(address _fullyBackedFactory) public {
-        keepFactorySelection.setFullyBackedKeepFactory(_fullyBackedFactory);
+    function setFullyBackedKeepVendor(address _fullyBackedVendor) public {
+        keepFactorySelection.setFullyBackedKeepVendor(_fullyBackedVendor);
     }
 
     function setKeepFactorySelector(address _factorySelector) public {

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -37,8 +37,8 @@ contract KeepFactorySelectionStub {
         return address(keepFactorySelection.keepStakeFactory);
     }
 
-    function ethStakeFactory() public view returns (address) {
-        return address(keepFactorySelection.ethStakeFactory);
+    function fullyBackedFactory() public view returns (address) {
+        return address(keepFactorySelection.fullyBackedFactory);
     }
 
     function factoriesVersionsLock() public view returns (bool) {

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -1,6 +1,11 @@
 pragma solidity 0.5.17;
 
-import {IBondedECDSAKeepFactory} from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeepFactory.sol";
+import {
+    IBondedECDSAKeepVendor
+} from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeepVendor.sol";
+import {
+    IBondedECDSAKeepFactory
+} from "@keep-network/keep-ecdsa/contracts/api/IBondedECDSAKeepFactory.sol";
 
 import "../../system/KeepFactorySelection.sol";
 
@@ -26,6 +31,28 @@ contract KeepFactorySelectionStub {
 
     function setKeepFactorySelector(address _factorySelector) public {
         keepFactorySelection.setKeepFactorySelector(_factorySelector);
+    }
+
+    function keepStakeFactory() public view returns (address) {
+        return address(keepFactorySelection.keepStakeFactory);
+    }
+
+    function ethStakeFactory() public view returns (address) {
+        return address(keepFactorySelection.ethStakeFactory);
+    }
+
+    function factoriesVersionsLock() public view returns (bool) {
+        return keepFactorySelection.factoriesVersionsLock;
+    }
+
+    function lockFactoriesVersions(
+        address _expectedKeepStakeFactory,
+        address _expectedFullyBackedFactory
+    ) public {
+        keepFactorySelection.lockFactoriesVersions(
+            _expectedKeepStakeFactory,
+            _expectedFullyBackedFactory
+        );
     }
 }
 

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -25,6 +25,18 @@ contract KeepFactorySelectionStub {
         return keepFactorySelection.selectFactoryAndRefresh();
     }
 
+    function setMinimumBondableValue(
+        uint256 _minimumBondableValue,
+        uint256 _groupSize,
+        uint256 _honestThreshold
+    ) public {
+        keepFactorySelection.setMinimumBondableValue(
+            _minimumBondableValue,
+            _groupSize,
+            _honestThreshold
+        );
+    }
+
     function setFullyBackedKeepVendor(address _fullyBackedVendor) public {
         keepFactorySelection.setFullyBackedKeepVendor(_fullyBackedVendor);
     }

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -53,8 +53,8 @@ contract KeepFactorySelectionStub {
         return address(keepFactorySelection.fullyBackedFactory);
     }
 
-    function factoriesVersionsLock() public view returns (bool) {
-        return keepFactorySelection.factoriesVersionsLock;
+    function factoriesVersionsLocked() public view returns (bool) {
+        return keepFactorySelection.factoriesVersionsLocked;
     }
 
     function lockFactoriesVersions(

--- a/solidity/migrations/3_initialize.js
+++ b/solidity/migrations/3_initialize.js
@@ -14,7 +14,7 @@ const VendingMachine = artifacts.require("VendingMachine")
 // Used for creating sortition pool.
 const BondedECDSAKeepFactoryJson = require("@keep-network/keep-ecdsa/artifacts/BondedECDSAKeepFactory.json")
 
-const {BondedECDSAKeepFactoryAddress, ETHBTCMedianizer} = require("./externals")
+const {BondedECDSAKeepVendorAddress, ETHBTCMedianizer} = require("./externals")
 
 module.exports = async function(deployer, network, accounts) {
   // Don't enact this setup during unit testing.
@@ -25,7 +25,7 @@ module.exports = async function(deployer, network, accounts) {
 
   console.debug(
     `Initializing TBTCSystem [${TBTCSystem.address}] with:\n` +
-      `  keepFactory: ${BondedECDSAKeepFactoryAddress}\n` +
+      `  keepVendor: ${BondedECDSAKeepVendorAddress}\n` +
       `  depositFactory: ${DepositFactory.address}\n` +
       `  masterDepositAddress: ${Deposit.address}\n` +
       `  tbtcToken: ${TBTCToken.address}\n` +
@@ -39,7 +39,7 @@ module.exports = async function(deployer, network, accounts) {
   // System.
   const tbtcSystem = await TBTCSystem.deployed()
   await tbtcSystem.initialize(
-    BondedECDSAKeepFactoryAddress,
+    BondedECDSAKeepVendorAddress,
     DepositFactory.address,
     Deposit.address,
     TBTCToken.address,

--- a/solidity/migrations/externals.js
+++ b/solidity/migrations/externals.js
@@ -1,6 +1,6 @@
 // Configuration for addresses of externally deployed smart contracts
 // prettier-ignore
-const BondedECDSAKeepFactoryAddress = "0xZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"
+const BondedECDSAKeepVendorAddress = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 
 // Medianized price feeds.
 // These are deployed and maintained by Maker.
@@ -10,7 +10,7 @@ const ETHBTCMedianizer = "0xABCDEABCDEABCDEABCDEABCDEABCDEABCDEABCDE"
 const RopstenETHBTCPriceFeed = "0xe9046e086137d2c0ffe60035391f6d7b4ec16733"
 
 module.exports = {
-  BondedECDSAKeepFactoryAddress,
+  BondedECDSAKeepVendorAddress,
   ETHBTCMedianizer,
   RopstenETHBTCPriceFeed,
 }

--- a/solidity/scripts/circleci-provision-external-contracts.sh
+++ b/solidity/scripts/circleci-provision-external-contracts.sh
@@ -1,20 +1,20 @@
 #!/bin/bash
 set -ex
 
-# BondedECDSAKeepFactoryAddress: Migration from keep-network/keep-ecdsa
+# BondedECDSAKeepVendorAddress: Migration from keep-network/keep-ecdsa
 # BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA is set in the CircleCI job config
 # ETH_NETWORK_ID is set in the CircleCI context for each deployed environment
-BONDED_ECDSA_KEEP_FACTORY_ADDRESS=""
+BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA=""
 
-function fetch_bonded_keep_factory_address() {
+function fetch_bonded_keep_vendor_address() {
   gsutil -q cp gs://${CONTRACT_DATA_BUCKET}/keep-ecdsa/${BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA} ./
-  BONDED_ECDSA_KEEP_FACTORY_ADDRESS=$(cat ./${BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA} | jq ".networks[\"${ETH_NETWORK_ID}\"].address" | tr -d '"')
+  BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA=$(cat ./${BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA} | jq ".networks[\"${ETH_NETWORK_ID}\"].address" | tr -d '"')
 }
 
-function set_bonded_keep_factory_address() {
+function set_bonded_keep_vendor_address() {
   # TODO: Replace file we store external addresses by a `json` file and use `jq` to update it.
-  sed -i -e "/BondedECDSAKeepFactoryAddress/s/0x[a-zA-Z0-9]\{0,40\}/${BONDED_ECDSA_KEEP_FACTORY_ADDRESS}/" ./solidity/migrations/externals.js
+  sed -i -e "/BondedECDSAKeepVendorAddress/s/0x[a-zA-Z0-9]\{0,40\}/${BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA}/" ./solidity/migrations/externals.js
 }
 
-fetch_bonded_keep_factory_address
-set_bonded_keep_factory_address
+fetch_bonded_keep_vendor_address
+set_bonded_keep_vendor_address

--- a/solidity/scripts/circleci-provision-external-contracts.sh
+++ b/solidity/scripts/circleci-provision-external-contracts.sh
@@ -2,13 +2,13 @@
 set -ex
 
 # BondedECDSAKeepFactoryAddress: Migration from keep-network/keep-ecdsa
-# BONDED_ECDSA_KEEP_FACTORY_CONTRACT_DATA is set in the CircleCI job config
+# BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA is set in the CircleCI job config
 # ETH_NETWORK_ID is set in the CircleCI context for each deployed environment
 BONDED_ECDSA_KEEP_FACTORY_ADDRESS=""
 
 function fetch_bonded_keep_factory_address() {
-  gsutil -q cp gs://${CONTRACT_DATA_BUCKET}/keep-ecdsa/${BONDED_ECDSA_KEEP_FACTORY_CONTRACT_DATA} ./
-  BONDED_ECDSA_KEEP_FACTORY_ADDRESS=$(cat ./${BONDED_ECDSA_KEEP_FACTORY_CONTRACT_DATA} | jq ".networks[\"${ETH_NETWORK_ID}\"].address" | tr -d '"')
+  gsutil -q cp gs://${CONTRACT_DATA_BUCKET}/keep-ecdsa/${BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA} ./
+  BONDED_ECDSA_KEEP_FACTORY_ADDRESS=$(cat ./${BONDED_ECDSA_KEEP_VENDOR_CONTRACT_DATA} | jq ".networks[\"${ETH_NETWORK_ID}\"].address" | tr -d '"')
 }
 
 function set_bonded_keep_factory_address() {

--- a/solidity/scripts/lcl-provision-external-contracts.sh
+++ b/solidity/scripts/lcl-provision-external-contracts.sh
@@ -12,8 +12,8 @@ set -e
 # NETWORK_ID=1801 \
 #   ./lcl-provision-external-contracts.sh
 
-FACTORY_CONTRACT_DATA="BondedECDSAKeepFactory.json"
-FACTORY_PROPERTY="BondedECDSAKeepFactory"
+VENDOR_CONTRACT_DATA="BondedECDSAKeepVendor.json"
+VENDOR_PROPERTY="BondedECDSAKeepVendor"
 
 DESTINATION_FILE=$(realpath $(dirname $0)/../migrations/externals.js)
 
@@ -26,21 +26,21 @@ SED_SUBSTITUTION_REGEXP="['\"][a-zA-Z0-9]*['\"]"
 
 FAILED=false
 
-function fetch_bonded_ecdsa_keep_factory_contract_address() {
-  echo "Fetching value for ${FACTORY_PROPERTY}..."
-  local contractDataPath=$(realpath $KEEP_ECDSA_SOL_ARTIFACTS_PATH/$FACTORY_CONTRACT_DATA)
+function fetch_bonded_ecdsa_keep_vendor_contract_address() {
+  echo "Fetching value for ${VENDOR_PROPERTY}..."
+  local contractDataPath=$(realpath $KEEP_ECDSA_SOL_ARTIFACTS_PATH/$VENDOR_CONTRACT_DATA)
   local ADDRESS=$(cat ${contractDataPath} | jq "${JSON_QUERY}" | tr -d '"')
 
   if [[ !($ADDRESS =~ $ADDRESS_REGEXP) ]]; then
     echo "Invalid address: ${ADDRESS}"
     FAILED=true
   else
-    echo "Found value for ${FACTORY_PROPERTY} = ${ADDRESS}"
-    sed -i -e "/${FACTORY_PROPERTY}/s/${SED_SUBSTITUTION_REGEXP}/\"${ADDRESS}\"/" $DESTINATION_FILE
+    echo "Found value for ${VENDOR_PROPERTY} = ${ADDRESS}"
+    sed -i -e "/${VENDOR_PROPERTY}/s/${SED_SUBSTITUTION_REGEXP}/\"${ADDRESS}\"/" $DESTINATION_FILE
   fi
 }
 
-fetch_bonded_ecdsa_keep_factory_contract_address
+fetch_bonded_ecdsa_keep_vendor_contract_address
 
 if $FAILED; then
 echo "Failed to fetch external contract addresses!"

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -267,7 +267,7 @@ describe("TBTCSystem governance", async function() {
       })
     })
 
-    it("reverts when lockKeepFactoriesVersionsUpdates is called twice", async () => {
+    it("reverts when called twice", async () => {
       const ethStakedFactory = newKeepFactory
       const ethStakedVendor = newKeepVendor
 
@@ -294,7 +294,7 @@ describe("TBTCSystem governance", async function() {
       )
     })
 
-    it("reverts when lockKeepFactoriesVersionsUpdates is by non-owner", async () => {
+    it("reverts when not performed by owner", async () => {
       const ethStakedFactory = newKeepFactory
       const ethStakedVendor = newKeepVendor
 

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -478,7 +478,7 @@ describe("TBTCSystem governance", async function() {
           value: keepFactorySelector.address,
         },
         {
-          name: "_ethBackedVendor",
+          name: "_fullyBackedVendor",
           value: newKeepVendor.address,
         },
       ],
@@ -494,11 +494,11 @@ describe("TBTCSystem governance", async function() {
       verifyFinalizationEvents: async (
         receipt,
         setFactorySelector,
-        setEthBackedVendor,
+        setFullyBackedVendor,
       ) => {
         expectEvent(receipt, "KeepVendorSingleShotUpdated", {
           _factorySelector: setFactorySelector,
-          _ethBackedVendor: setEthBackedVendor,
+          _fullyBackedVendor: setFullyBackedVendor,
         })
       },
       verifyFinalState: async () => {
@@ -514,7 +514,7 @@ describe("TBTCSystem governance", async function() {
           value: await ecdsaKeepFactory.openKeepFeeEstimate.call(),
         })
 
-        // This should fail as the _ethBackedVendor is not a real contract
+        // This should fail as the _fullyBackedVendor is not a real contract
         // address, so dereferencing it will go boom.
         await tbtcSystem.requestNewKeep(10 ** 8, 123, {
           from: mockDeposit,

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -201,7 +201,7 @@ describe("TBTCSystem governance", async function() {
     it("reverts if finalizeKeepVendorSingleShotUpdate has already been called", async () => {
       await tbtcSystem.beginKeepVendorSingleShotUpdate(
         "0x0000000000000000000000000000000000000001",
-        "0x0000000000000000000000000000000000000002",
+        newKeepVendor.address,
       )
 
       const finalizationTime = await tbtcSystem.getRemainingKeepVendorSingleShotUpdateTime()
@@ -220,7 +220,7 @@ describe("TBTCSystem governance", async function() {
     it("reverts if finalizeKeepVendorSingleShotUpdate is called twice", async () => {
       await tbtcSystem.beginKeepVendorSingleShotUpdate(
         "0x0000000000000000000000000000000000000001",
-        "0x0000000000000000000000000000000000000002",
+        newKeepVendor.address,
       )
 
       const finalizationTime = await tbtcSystem.getRemainingKeepVendorSingleShotUpdateTime()

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -262,7 +262,7 @@ describe("TBTCSystem governance", async function() {
       )
 
       expectEvent(receipt, "KeepFactoriesVersionsLocked", {
-        _keepStakeFactory: ecdsaKeepFactory.address,
+        _keepStakedFactory: ecdsaKeepFactory.address,
         _fullyBackedFactory: ethStakedFactory.address,
       })
     })

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -495,11 +495,11 @@ describe("KeepFactorySelection", async () => {
       await keepFactorySelection.selectFactoryAndRefresh()
 
       expect(await keepFactorySelection.keepStakeFactory()).to.equal(
-        keepStakeFactory.address,
+        constants.ZERO_ADDRESS,
       )
 
       expect(await keepFactorySelection.fullyBackedFactory()).to.equal(
-        fullyBackedFactory.address,
+        constants.ZERO_ADDRESS,
       )
 
       const newKeepFactory = await ECDSAKeepFactoryStub.new()

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -583,7 +583,7 @@ describe("KeepFactorySelection", async () => {
         fullyBackedFactory.address,
       )
 
-      expect(await keepFactorySelection.factoriesVersionsLock()).to.be.true
+      expect(await keepFactorySelection.factoriesVersionsLocked()).to.be.true
     })
 
     it("gets latest factories from vendor", async () => {

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -50,15 +50,6 @@ describe("KeepFactorySelection", async () => {
   })
 
   describe("initialize", async () => {
-    it("gets KEEP stake factory from vendor", async () => {
-      const keepFactorySelection = await KeepFactorySelectionStub.new()
-      await keepFactorySelection.initialize(keepStakeVendor.address)
-
-      expect(await keepFactorySelection.keepStakeFactory()).to.equal(
-        keepStakeFactory.address,
-      )
-    })
-
     it("can be called only one time", async () => {
       // already initialized in before
       await expectRevert(

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -15,7 +15,7 @@ describe("KeepFactorySelection", async () => {
   let keepFactorySelection
 
   let keepStakeFactory
-  let ethStakeFactory
+  let fullyBackedFactory
   let keepFactorySelector
 
   const thirdParty = accounts[3]
@@ -31,8 +31,10 @@ describe("KeepFactorySelection", async () => {
     keepStakeFactory = await ECDSAKeepFactoryStub.new()
     keepStakeVendor = await ECDSAKeepVendorStub.new(keepStakeFactory.address)
 
-    ethStakeFactory = await ECDSAKeepFactoryStub.new()
-    ethStakeVendor = await ECDSAKeepVendorStub.new(ethStakeFactory.address)
+    fullyBackedFactory = await ECDSAKeepFactoryStub.new()
+    fullyBackedVendor = await ECDSAKeepVendorStub.new(
+      fullyBackedFactory.address,
+    )
 
     keepFactorySelector = await KeepFactorySelectorStub.new()
 
@@ -91,7 +93,7 @@ describe("KeepFactorySelection", async () => {
     // Selection strategy set.
     it("returns the same factory until refreshed", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       await keepFactorySelection.setKeepFactorySelector(
         keepFactorySelector.address,
@@ -122,7 +124,7 @@ describe("KeepFactorySelection", async () => {
       selected = await keepFactorySelection.selectFactory()
 
       expect(selected, "unexpected factory selected").to.equal(
-        ethStakeFactory.address,
+        fullyBackedFactory.address,
       )
     })
   })
@@ -142,7 +144,7 @@ describe("KeepFactorySelection", async () => {
     // No selection strategy set.
     it("returns KEEP stake factory if strategy is not set", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
@@ -168,7 +170,7 @@ describe("KeepFactorySelection", async () => {
     // Selection strategy set.
     it("returns fully-backed factory if selected by the strategy", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       await keepFactorySelection.setKeepFactorySelector(
         keepFactorySelector.address,
@@ -183,7 +185,7 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        ethStakeFactory.address,
+        fullyBackedFactory.address,
       )
     })
 
@@ -191,7 +193,7 @@ describe("KeepFactorySelection", async () => {
     // Selection strategy set.
     it("returns default factory if selected by the strategy", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       await keepFactorySelection.setKeepFactorySelector(
         keepFactorySelector.address,
@@ -214,7 +216,7 @@ describe("KeepFactorySelection", async () => {
     // Selection strategy set.
     it("returns the factory selected before refreshing", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       await keepFactorySelection.setKeepFactorySelector(
         keepFactorySelector.address,
@@ -262,7 +264,7 @@ describe("KeepFactorySelection", async () => {
     // Selection strategy set.
     it("gets new ETH stake factory after update in vendor", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       await keepFactorySelection.setKeepFactorySelector(
         keepFactorySelector.address,
@@ -277,11 +279,11 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        ethStakeFactory.address,
+        fullyBackedFactory.address,
       )
 
       const newEthFactory = await ECDSAKeepFactoryStub.new()
-      await ethStakeVendor.setFactory(newEthFactory.address)
+      await fullyBackedVendor.setFactory(newEthFactory.address)
 
       // refresh the choice; it should be the old factory now
       await keepFactorySelection.selectFactoryAndRefresh()
@@ -298,12 +300,12 @@ describe("KeepFactorySelection", async () => {
     // No selection strategy set.
     it("returns locked KEEP stake factory", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
 
       await keepFactorySelection.lockFactoriesVersions(
         keepStakeFactory.address,
-        ethStakeFactory.address,
+        fullyBackedFactory.address,
       )
 
       const newKeepFactory = await ECDSAKeepFactoryStub.new()
@@ -324,7 +326,7 @@ describe("KeepFactorySelection", async () => {
     // Selection strategy set.
     it("returns locked ETH stake factory", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       await keepFactorySelection.setKeepFactorySelector(
         keepFactorySelector.address,
@@ -334,11 +336,11 @@ describe("KeepFactorySelection", async () => {
 
       await keepFactorySelection.lockFactoriesVersions(
         keepStakeFactory.address,
-        ethStakeFactory.address,
+        fullyBackedFactory.address,
       )
 
       const newEthFactory = await ECDSAKeepFactoryStub.new()
-      await ethStakeVendor.setFactory(newEthFactory.address)
+      await fullyBackedVendor.setFactory(newEthFactory.address)
 
       // refresh the choice
       await keepFactorySelection.selectFactoryAndRefresh()
@@ -347,13 +349,13 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        ethStakeFactory.address,
+        fullyBackedFactory.address,
       )
     })
 
     it("reverts if the returned factory is not one of the set factories", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       await keepFactorySelection.setKeepFactorySelector(
         keepFactorySelector.address,
@@ -379,13 +381,13 @@ describe("KeepFactorySelection", async () => {
 
     it("reverts when ETH stake vendor returns factory with zero address", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       await keepFactorySelection.setKeepFactorySelector(
         keepFactorySelector.address,
       )
 
-      await ethStakeVendor.setFactory(constants.ZERO_ADDRESS)
+      await fullyBackedVendor.setFactory(constants.ZERO_ADDRESS)
 
       await expectRevert(
         keepFactorySelection.selectFactoryAndRefresh(),
@@ -397,12 +399,14 @@ describe("KeepFactorySelection", async () => {
   describe("setFullyBackedKeepVendor", async () => {
     it("can be called only one time", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
       // ok, this was the first time
 
       await expectRevert(
-        keepFactorySelection.setFullyBackedKeepVendor(ethStakeVendor.address),
+        keepFactorySelection.setFullyBackedKeepVendor(
+          fullyBackedVendor.address,
+        ),
         "Fully backed vendor already set",
       )
     })
@@ -416,7 +420,7 @@ describe("KeepFactorySelection", async () => {
 
     it("obtains factory from vendor", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
 
       await keepFactorySelection.setKeepFactorySelector(
@@ -431,14 +435,16 @@ describe("KeepFactorySelection", async () => {
       expect(
         await keepFactorySelection.selectFactory(),
         "unexpected factory selected",
-      ).to.equal(ethStakeFactory.address)
+      ).to.equal(fullyBackedFactory.address)
     })
 
     it("reverts when vendor returns factory with zero address", async () => {
-      await ethStakeVendor.setFactory(constants.ZERO_ADDRESS)
+      await fullyBackedVendor.setFactory(constants.ZERO_ADDRESS)
 
       await expectRevert(
-        keepFactorySelection.setFullyBackedKeepVendor(ethStakeVendor.address),
+        keepFactorySelection.setFullyBackedKeepVendor(
+          fullyBackedVendor.address,
+        ),
         "Vendor returned invalid factory address",
       )
     })
@@ -470,12 +476,12 @@ describe("KeepFactorySelection", async () => {
   describe("lockFactoriesVersions", async () => {
     it("sets factories version lock", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
 
       await keepFactorySelection.lockFactoriesVersions(
         keepStakeFactory.address,
-        ethStakeFactory.address,
+        fullyBackedFactory.address,
       )
 
       expect(await keepFactorySelection.factoriesVersionsLock()).to.be.true
@@ -483,7 +489,7 @@ describe("KeepFactorySelection", async () => {
 
     it("gets latest factories from vendor", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
 
       await keepFactorySelection.selectFactoryAndRefresh()
@@ -492,15 +498,15 @@ describe("KeepFactorySelection", async () => {
         keepStakeFactory.address,
       )
 
-      expect(await keepFactorySelection.ethStakeFactory()).to.equal(
-        ethStakeFactory.address,
+      expect(await keepFactorySelection.fullyBackedFactory()).to.equal(
+        fullyBackedFactory.address,
       )
 
       const newKeepFactory = await ECDSAKeepFactoryStub.new()
       await keepStakeVendor.setFactory(newKeepFactory.address)
 
       const newEthFactory = await ECDSAKeepFactoryStub.new()
-      await ethStakeVendor.setFactory(newEthFactory.address)
+      await fullyBackedVendor.setFactory(newEthFactory.address)
 
       await keepFactorySelection.lockFactoriesVersions(
         newKeepFactory.address,
@@ -511,26 +517,26 @@ describe("KeepFactorySelection", async () => {
         newKeepFactory.address,
       )
 
-      expect(await keepFactorySelection.ethStakeFactory()).to.equal(
+      expect(await keepFactorySelection.fullyBackedFactory()).to.equal(
         newEthFactory.address,
       )
     })
 
     it("can be called only one time", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
 
       await keepFactorySelection.lockFactoriesVersions(
         keepStakeFactory.address,
-        ethStakeFactory.address,
+        fullyBackedFactory.address,
       )
       // ok, this was the first time
 
       await expectRevert(
         keepFactorySelection.lockFactoriesVersions(
           keepStakeFactory.address,
-          ethStakeFactory.address,
+          fullyBackedFactory.address,
         ),
         "Already locked",
       )
@@ -540,7 +546,7 @@ describe("KeepFactorySelection", async () => {
       await expectRevert(
         keepFactorySelection.lockFactoriesVersions(
           constants.ZERO_ADDRESS,
-          ethStakeFactory.address,
+          fullyBackedFactory.address,
         ),
         "Fully backed vendor not set",
       )
@@ -548,13 +554,13 @@ describe("KeepFactorySelection", async () => {
 
     it("reverts for unexpected KEEP stake factory address", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
 
       await expectRevert(
         keepFactorySelection.lockFactoriesVersions(
           thirdParty,
-          ethStakeFactory.address,
+          fullyBackedFactory.address,
         ),
         "Unexpected KEEP backed factory",
       )
@@ -562,7 +568,7 @@ describe("KeepFactorySelection", async () => {
 
     it("reverts for unexpected ETH stake factory address", async () => {
       await keepFactorySelection.setFullyBackedKeepVendor(
-        ethStakeVendor.address,
+        fullyBackedVendor.address,
       )
 
       await expectRevert(

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -409,7 +409,7 @@ describe("KeepFactorySelection", async () => {
 
       await expectRevert(
         newKeepFactorySelection.setMinimumBondableValue(newValue, 5, 3),
-        "KEEP backed vendor not set",
+        "KEEP-staked vendor not set",
       )
     })
 
@@ -649,7 +649,7 @@ describe("KeepFactorySelection", async () => {
           constants.ZERO_ADDRESS,
           fullyBackedFactory.address,
         ),
-        "KEEP backed vendor not set",
+        "KEEP-staked vendor not set",
       )
     })
 
@@ -673,7 +673,7 @@ describe("KeepFactorySelection", async () => {
           thirdParty,
           fullyBackedFactory.address,
         ),
-        "Unexpected KEEP backed factory",
+        "Unexpected KEEP-staked factory",
       )
     })
 

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -14,7 +14,7 @@ const ECDSAKeepVendorStub = contract.fromArtifact("ECDSAKeepVendorStub")
 describe("KeepFactorySelection", async () => {
   let keepFactorySelection
 
-  let keepStakeFactory
+  let keepStakedFactory
   let fullyBackedFactory
   let keepFactorySelector
 
@@ -28,8 +28,8 @@ describe("KeepFactorySelection", async () => {
     await KeepFactorySelectionStub.link("KeepFactorySelection", library.address)
     keepFactorySelection = await KeepFactorySelectionStub.new()
 
-    keepStakeFactory = await ECDSAKeepFactoryStub.new()
-    keepStakeVendor = await ECDSAKeepVendorStub.new(keepStakeFactory.address)
+    keepStakedFactory = await ECDSAKeepFactoryStub.new()
+    keepStakedVendor = await ECDSAKeepVendorStub.new(keepStakedFactory.address)
 
     fullyBackedFactory = await ECDSAKeepFactoryStub.new()
     fullyBackedVendor = await ECDSAKeepVendorStub.new(
@@ -38,7 +38,7 @@ describe("KeepFactorySelection", async () => {
 
     keepFactorySelector = await KeepFactorySelectorStub.new()
 
-    await keepFactorySelection.initialize(keepStakeVendor.address)
+    await keepFactorySelection.initialize(keepStakedVendor.address)
   })
 
   beforeEach(async () => {
@@ -53,7 +53,7 @@ describe("KeepFactorySelection", async () => {
     it("can be called only one time", async () => {
       // already initialized in before
       await expectRevert(
-        keepFactorySelection.initialize(keepStakeVendor.address),
+        keepFactorySelection.initialize(keepStakedVendor.address),
         "Already initialized",
       )
     })
@@ -61,10 +61,10 @@ describe("KeepFactorySelection", async () => {
     it("reverts when vendor returns factory with zero address", async () => {
       const keepFactorySelection = await KeepFactorySelectionStub.new()
 
-      await keepStakeVendor.setFactory(constants.ZERO_ADDRESS)
+      await keepStakedVendor.setFactory(constants.ZERO_ADDRESS)
 
       await expectRevert(
-        keepFactorySelection.initialize(keepStakeVendor.address),
+        keepFactorySelection.initialize(keepStakedVendor.address),
         "Vendor returned invalid factory address",
       )
     })
@@ -76,7 +76,7 @@ describe("KeepFactorySelection", async () => {
     it("returns KEEP stake factory by default", async () => {
       const selected = await keepFactorySelection.selectFactory()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
     })
 
@@ -94,7 +94,7 @@ describe("KeepFactorySelection", async () => {
 
       let selected = await keepFactorySelection.selectFactory()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
 
       await keepFactorySelector.setFullyBackedMode()
@@ -104,7 +104,7 @@ describe("KeepFactorySelection", async () => {
       // the selection will be refreshed
       selected = await keepFactorySelection.selectFactory()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
 
       // refresh the choice
@@ -127,7 +127,7 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
     })
 
@@ -140,7 +140,7 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
     })
 
@@ -153,7 +153,7 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
     })
 
@@ -199,7 +199,7 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
     })
 
@@ -226,7 +226,7 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
     })
 
@@ -234,13 +234,13 @@ describe("KeepFactorySelection", async () => {
     // No selection strategy set.
     it("gets new KEEP stake factory after update in vendor", async () => {
       const newKeepFactory = await ECDSAKeepFactoryStub.new()
-      await keepStakeVendor.setFactory(newKeepFactory.address)
+      await keepStakedVendor.setFactory(newKeepFactory.address)
 
       // refresh the choice; it should be the old factory now
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
 
       // refresh the choice; it should be the new factory now
@@ -295,12 +295,12 @@ describe("KeepFactorySelection", async () => {
       )
 
       await keepFactorySelection.lockFactoriesVersions(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
         fullyBackedFactory.address,
       )
 
       const newKeepFactory = await ECDSAKeepFactoryStub.new()
-      await keepStakeVendor.setFactory(newKeepFactory.address)
+      await keepStakedVendor.setFactory(newKeepFactory.address)
 
       // refresh the choice
       await keepFactorySelection.selectFactoryAndRefresh()
@@ -309,7 +309,7 @@ describe("KeepFactorySelection", async () => {
       const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
       await keepFactorySelection.selectFactoryAndRefresh()
       expect(selected, "unexpected factory selected").to.equal(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
       )
     })
 
@@ -326,7 +326,7 @@ describe("KeepFactorySelection", async () => {
       await keepFactorySelector.setFullyBackedMode()
 
       await keepFactorySelection.lockFactoriesVersions(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
         fullyBackedFactory.address,
       )
 
@@ -362,7 +362,7 @@ describe("KeepFactorySelection", async () => {
     })
 
     it("returns zero address when KEEP stake vendor returns factory with zero address", async () => {
-      await keepStakeVendor.setFactory(constants.ZERO_ADDRESS)
+      await keepStakedVendor.setFactory(constants.ZERO_ADDRESS)
 
       // refresh the choice
       await keepFactorySelection.selectFactoryAndRefresh()
@@ -415,11 +415,11 @@ describe("KeepFactorySelection", async () => {
 
     // KEEP stake vendor set, factory zero.
     it("completes when KEEP stake factory address is zero", async () => {
-      await keepStakeVendor.setFactory(constants.ZERO_ADDRESS)
+      await keepStakedVendor.setFactory(constants.ZERO_ADDRESS)
 
       await keepFactorySelection.setMinimumBondableValue(newValue, 5, 3)
 
-      expect(await keepStakeFactory.minimumBondableValue()).to.eq.BN(
+      expect(await keepStakedFactory.minimumBondableValue()).to.eq.BN(
         defaultValue,
       )
       expect(await fullyBackedFactory.minimumBondableValue()).to.eq.BN(
@@ -431,7 +431,7 @@ describe("KeepFactorySelection", async () => {
     it("updates value in KEEP stake factory", async () => {
       await keepFactorySelection.setMinimumBondableValue(newValue, 5, 3)
 
-      expect(await keepStakeFactory.minimumBondableValue()).to.eq.BN(newValue)
+      expect(await keepStakedFactory.minimumBondableValue()).to.eq.BN(newValue)
       expect(await fullyBackedFactory.minimumBondableValue()).to.eq.BN(
         defaultValue,
       )
@@ -446,7 +446,7 @@ describe("KeepFactorySelection", async () => {
 
       await keepFactorySelection.setMinimumBondableValue(newValue, 5, 3)
 
-      expect(await keepStakeFactory.minimumBondableValue()).to.eq.BN(newValue)
+      expect(await keepStakedFactory.minimumBondableValue()).to.eq.BN(newValue)
       expect(await fullyBackedFactory.minimumBondableValue()).to.eq.BN(
         defaultValue,
       )
@@ -460,7 +460,7 @@ describe("KeepFactorySelection", async () => {
 
       await keepFactorySelection.setMinimumBondableValue(newValue, 5, 3)
 
-      expect(await keepStakeFactory.minimumBondableValue()).to.eq.BN(newValue)
+      expect(await keepStakedFactory.minimumBondableValue()).to.eq.BN(newValue)
       expect(await fullyBackedFactory.minimumBondableValue()).to.eq.BN(newValue)
     })
 
@@ -473,13 +473,13 @@ describe("KeepFactorySelection", async () => {
 
       // Lock factories
       await keepFactorySelection.lockFactoriesVersions(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
         fullyBackedFactory.address,
       )
 
       // Upgrade factories in vendors
       const newKeepFactory = await ECDSAKeepFactoryStub.new()
-      await keepStakeVendor.setFactory(newKeepFactory.address)
+      await keepStakedVendor.setFactory(newKeepFactory.address)
 
       const newEthFactory = await ECDSAKeepFactoryStub.new()
       await fullyBackedVendor.setFactory(newEthFactory.address)
@@ -487,7 +487,7 @@ describe("KeepFactorySelection", async () => {
       // Set minimum bondable value
       await keepFactorySelection.setMinimumBondableValue(newValue, 5, 3)
 
-      expect(await keepStakeFactory.minimumBondableValue()).to.eq.BN(newValue)
+      expect(await keepStakedFactory.minimumBondableValue()).to.eq.BN(newValue)
       expect(await fullyBackedFactory.minimumBondableValue()).to.eq.BN(newValue)
 
       expect(await newKeepFactory.minimumBondableValue()).to.eq.BN(defaultValue)
@@ -579,7 +579,7 @@ describe("KeepFactorySelection", async () => {
       )
 
       await keepFactorySelection.lockFactoriesVersions(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
         fullyBackedFactory.address,
       )
 
@@ -593,7 +593,7 @@ describe("KeepFactorySelection", async () => {
 
       await keepFactorySelection.selectFactoryAndRefresh()
 
-      expect(await keepFactorySelection.keepStakeFactory()).to.equal(
+      expect(await keepFactorySelection.keepStakedFactory()).to.equal(
         constants.ZERO_ADDRESS,
       )
 
@@ -602,7 +602,7 @@ describe("KeepFactorySelection", async () => {
       )
 
       const newKeepFactory = await ECDSAKeepFactoryStub.new()
-      await keepStakeVendor.setFactory(newKeepFactory.address)
+      await keepStakedVendor.setFactory(newKeepFactory.address)
 
       const newEthFactory = await ECDSAKeepFactoryStub.new()
       await fullyBackedVendor.setFactory(newEthFactory.address)
@@ -612,7 +612,7 @@ describe("KeepFactorySelection", async () => {
         newEthFactory.address,
       )
 
-      expect(await keepFactorySelection.keepStakeFactory()).to.equal(
+      expect(await keepFactorySelection.keepStakedFactory()).to.equal(
         newKeepFactory.address,
       )
 
@@ -627,14 +627,14 @@ describe("KeepFactorySelection", async () => {
       )
 
       await keepFactorySelection.lockFactoriesVersions(
-        keepStakeFactory.address,
+        keepStakedFactory.address,
         fullyBackedFactory.address,
       )
       // ok, this was the first time
 
       await expectRevert(
         keepFactorySelection.lockFactoriesVersions(
-          keepStakeFactory.address,
+          keepStakedFactory.address,
           fullyBackedFactory.address,
         ),
         "Already locked",
@@ -684,7 +684,7 @@ describe("KeepFactorySelection", async () => {
 
       await expectRevert(
         keepFactorySelection.lockFactoriesVersions(
-          keepStakeFactory.address,
+          keepStakedFactory.address,
           thirdParty,
         ),
         "Unexpected fully backed factory",

--- a/solidity/test/helpers/fullDeployer.js
+++ b/solidity/test/helpers/fullDeployer.js
@@ -14,6 +14,7 @@ const DepositFunding = contract.fromArtifact("DepositFunding")
 const DepositRedemption = contract.fromArtifact("DepositRedemption")
 const DepositLiquidation = contract.fromArtifact("DepositLiquidation")
 const ECDSAKeepStub = contract.fromArtifact("ECDSAKeepStub")
+const ECDSAKeepVendorStub = contract.fromArtifact("ECDSAKeepVendorStub")
 const ECDSAKeepFactoryStub = contract.fromArtifact("ECDSAKeepFactoryStub")
 const TestTBTCToken = contract.fromArtifact("TestTBTCToken")
 const MockRelay = contract.fromArtifact("MockRelay")
@@ -130,6 +131,7 @@ async function deployAndLinkAll(additions = [], substitutions = {}) {
   const tbtcSystem = deployed.TBTCSystem
   const ecdsaKeepFactoryStub = await ECDSAKeepFactoryStub.new()
   await ecdsaKeepFactoryStub.setKeepAddress(deployed.ECDSAKeepStub.address)
+  const ecdsaKeepVendorStub = await ECDSAKeepVendorStub.new(ecdsaKeepFactoryStub.address)
 
   const TestTBTCTokenInstance = await TestTBTCToken.new(vendingMachine.address)
   const testDeposit = deployed.TestDeposit
@@ -142,7 +144,7 @@ async function deployAndLinkAll(additions = [], substitutions = {}) {
   await mockSatWeiPriceFeed.setPrice(100000000)
 
   await tbtcSystem.initialize(
-    ecdsaKeepFactoryStub.address,
+    ecdsaKeepVendorStub.address,
     depositFactory.address,
     testDeposit.address,
     TestTBTCTokenInstance.address,

--- a/solidity/test/helpers/testDeployer.js
+++ b/solidity/test/helpers/testDeployer.js
@@ -13,6 +13,7 @@ const DepositFunding = contract.fromArtifact("DepositFunding")
 const DepositRedemption = contract.fromArtifact("DepositRedemption")
 const DepositLiquidation = contract.fromArtifact("DepositLiquidation")
 const ECDSAKeepStub = contract.fromArtifact("ECDSAKeepStub")
+const ECDSAKeepVendorStub = contract.fromArtifact("ECDSAKeepVendorStub")
 const ECDSAKeepFactoryStub = contract.fromArtifact("ECDSAKeepFactoryStub")
 const TestTBTCToken = contract.fromArtifact("TestTBTCToken")
 const MockRelay = contract.fromArtifact("MockRelay")
@@ -75,6 +76,11 @@ const TEST_DEPOSIT_DEPLOY = [
     name: "ECDSAKeepStub",
     contract: ECDSAKeepStub,
     constructorParams: ["VendingMachine", ""],
+  },
+  {
+    name: "ECDSAKeepVendorStub",
+    contract: ECDSAKeepVendorStub,
+    constructorParams: ["ECDSAKeepFactoryStub"],
   },
   {
     name: "KeepFactorySelectorStub",
@@ -140,6 +146,7 @@ async function deployAndLinkAll(additions = [], substitutions = {}) {
   const tbtcSystemStub = deployed.TBTCSystemStub
   const keepFactorySelectorStub = deployed.KeepFactorySelectorStub
   const ecdsaKeepFactoryStub = deployed.ECDSAKeepFactoryStub
+  const ecdsaKeepVendorStub = deployed.ECDSAKeepVendorStub
 
   const tbtcToken = await TestTBTCToken.new(vendingMachine.address)
   const testDeposit = deployed.TestDeposit
@@ -177,7 +184,7 @@ async function deployAndLinkAll(additions = [], substitutions = {}) {
   }
 
   await tbtcSystemStub.initialize(
-    ecdsaKeepFactoryStub.address,
+    ecdsaKeepVendorStub.address,
     depositFactory.address,
     testDeposit.address,
     tbtcToken.address,

--- a/solidity/test/liquidation-tests/liquidation-test-utils/setup.js
+++ b/solidity/test/liquidation-tests/liquidation-test-utils/setup.js
@@ -25,6 +25,7 @@ const TestTBTCToken = contract.fromArtifact("TestTBTCToken")
 
 // mocks/stubs
 const ECDSAKeepStub = contract.fromArtifact("ECDSAKeepStub")
+const ECDSAKeepVendorStub = contract.fromArtifact("ECDSAKeepVendorStub")
 const ECDSAKeepFactoryStub = contract.fromArtifact("ECDSAKeepFactoryStub")
 const KeepFactorySelection = contract.fromArtifact("KeepFactorySelection")
 const MockRelay = contract.fromArtifact("MockRelay")
@@ -133,7 +134,9 @@ async function deployAndLinkAll(additions = [], substitutions = {}) {
   await mockRelay.setPrevEpochDifficulty(1)
 
   const tbtcSystem = deployed.TBTCSystem
+
   const ecdsaKeepFactoryStub = await ECDSAKeepFactoryStub.new()
+  const ecdsaKeepVendorStub = await ECDSAKeepVendorStub.new(ecdsaKeepFactoryStub.address)
 
   const tbtcToken = await TestTBTCToken.new(vendingMachine.address)
   const testDeposit = deployed.TestDeposit
@@ -171,7 +174,7 @@ async function deployAndLinkAll(additions = [], substitutions = {}) {
   }
 
   await tbtcSystem.initialize(
-    ecdsaKeepFactoryStub.address,
+    ecdsaKeepVendorStub.address,
     depositFactory.address,
     testDeposit.address,
     tbtcToken.address,
@@ -192,6 +195,7 @@ async function deployAndLinkAll(additions = [], substitutions = {}) {
     feeRebateToken,
     testDeposit,
     depositUtils,
+    ecdsaKeepVendorStub,
     ecdsaKeepFactoryStub,
     ecdsaKeepStub,
     depositFactory,


### PR DESCRIPTION
Keep ECDSA defines a vendor contract that is used to register factories and upgrade them. It folds a reference to the latest version of a factory. We were using the vendor contract previously but decided to use a fixed factory address in https://github.com/keep-network/tbtc/pull/610.
In this PR we are adding back usage of the vendor contract. The contract will be called to obtain the latest version of a Keep factory for each type: KEEP staked and ETH only backed keeps.

We are adding also a locking mechanism for Keep factories version updates. We have a possibility to update the factory address via keep vendor contract to the latest one. We want to have a way to lock the versions at some point in the future when keep-ecdsa is considered to be in a state that won't require any updates. When the lock is set we will use only the versions of the factories that were current ones in the moment of locking.

Open questions:
- Do we want to have two separate locks for KEEP backed and ETH only keeps factories?
- Do we want to have a two-step update process with a standard governance period for the locking the factories? 
