### PR TITLE
The Market Waits for No Man

### DIFF
--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -36,7 +36,7 @@ contract VendingMachine is TBTCSystemAuthority{
     /// @notice Get the maximum TBTC token supply based on the age of the contract
     ///         deployment. The supply cap starts at 2 BTC for the two days, 100 for
     ///         the first week, 250 for the next, then 500, 750, 1000, 1500, 2000,
-    ///         2500, and 300... finally removing the minting restriction after 9
+    ///         2500, and 3000... finally removing the minting restriction after 9
     ///         weeks and returning 21M BTC as a sanity check.
     /// @return The max supply in weitoshis (BTC * 10 ** 18)
     function getMaxSupply() public view returns (uint256) {

--- a/solidity/contracts/system/VendingMachine.sol
+++ b/solidity/contracts/system/VendingMachine.sol
@@ -34,27 +34,52 @@ contract VendingMachine is TBTCSystemAuthority{
     }
 
     /// @notice Get the maximum TBTC token supply based on the age of the contract
-    ///         deployment. The supply cap starts at 2 BTC for the first day, 100 for
-    ///         the first 30 days, 250 for the next 30, 500 for the last 30... then
-    ///         finally removes the restriction, returning 21M BTC as a sanity check.
+    ///         deployment. The supply cap starts at 2 BTC for the two days, 100 for
+    ///         the first week, 250 for the next, then 500, 750, 1000, 1500, 2000,
+    ///         2500, and 300... finally removing the minting restriction after 9
+    ///         weeks and returning 21M BTC as a sanity check.
     /// @return The max supply in weitoshis (BTC * 10 ** 18)
     function getMaxSupply() public view returns (uint256) {
         uint256 age = block.timestamp - createdAt;
 
-        if(age < 1 days) {
+        if(age < 2 days) {
             return 2 * 10 ** 18;
         }
 
-        if (age < 30 days) {
+        if (age < 7 days) {
             return 100 * 10 ** 18;
         }
 
-        if (age < 60 days) {
+        if (age < 14 days) {
             return 250 * 10 ** 18;
         }
 
-        if (age < 90 days) {
+        if (age < 21 days) {
             return 500 * 10 ** 18;
+        }
+
+        if (age < 28 days) {
+            return 750 * 10 ** 18;
+        }
+
+        if (age < 35 days) {
+            return 1000 * 10 ** 18;
+        }
+
+        if (age < 42 days) {
+            return 1500 * 10 ** 18;
+        }
+
+        if (age < 49 days) {
+            return 2000 * 10 ** 18;
+        }
+
+        if (age < 56 days) {
+            return 2500 * 10 ** 18;
+        }
+
+        if (age < 63 days) {
+            return 3000 * 10 ** 18;
         }
 
         return 21000000 * 10 ** 18;

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -26125,6 +26125,12 @@
         }
       }
     },
+    "moment": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ==",
+      "dev": true
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -41,17 +41,19 @@
     "openzeppelin-solidity": "2.3.0"
   },
   "devDependencies": {
+    "@asciidoctor/core": "2.2.0",
     "@openzeppelin/test-environment": "^0.1.2",
     "@openzeppelin/test-helpers": "^0.5.4",
     "@truffle/hdwallet-provider": "^1.0.37",
+    "@types/mocha": "^7.0.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.18.0",
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.26.0",
-    "chai": "^4.2.0",
-    "bn.js": "^4.11.8",
     "bn-chai": "^1.0.1",
+    "bn.js": "^4.11.8",
+    "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "eslint-config-keep": "git+https://github.com/keep-network/eslint-config-keep.git#0.2.0",
     "eslint-config-prettier": "^6.10.0",
@@ -59,13 +61,12 @@
     "ethlint": "^1.2.4",
     "ganache-cli": "^6.4.3",
     "mocha": "^7.0.1",
-    "@types/mocha": "^7.0.2",
+    "moment": "^2.27.0",
     "prettier": "^1.19.1",
     "prettier-plugin-solidity": "^1.0.0-alpha.40",
-    "solium-config-keep": "git+https://github.com/keep-network/solium-config-keep.git#0.1.2",
-    "truffle": "^5.1.13",
     "solc": "0.5.17",
-    "@asciidoctor/core": "2.2.0"
+    "solium-config-keep": "git+https://github.com/keep-network/solium-config-keep.git#0.1.2",
+    "truffle": "^5.1.13"
   },
   "engines": {
     "node": ">= 12.0.0"

--- a/solidity/test/VendingMachineTest.js
+++ b/solidity/test/VendingMachineTest.js
@@ -711,11 +711,11 @@ describe("VendingMachine", async function() {
       await restoreSnapshot()
     })
 
-    it("has a max supply of 2 on the first day", async () => {
+    it("has a max supply of 2 on the second day", async () => {
       let maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(2))
 
-      await increaseTime(23.5 * 60 * 60) // 23.5 hours
+      await increaseTime(47.5 * 60 * 60) // 47.5 hours
 
       maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(2))
@@ -726,12 +726,12 @@ describe("VendingMachine", async function() {
       expect(maxSupply).to.not.eq.BN(btcToTbtc(2))
     })
 
-    it("has a max supply of 100 BTC between the first day and 30th day", async () => {
-      await increaseTime(24 * 60 * 60 + 1) // 1 day and 1 second
+    it("has a max supply of 100 BTC between the second day and 7th day", async () => {
+      await increaseTime(48 * 60 * 60 + 1) // 2 days and 1 second
       let maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(100))
 
-      await increaseTime(29 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
+      await increaseTime(5 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
       maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(100))
 
@@ -740,12 +740,12 @@ describe("VendingMachine", async function() {
       expect(maxSupply).to.not.eq.BN(btcToTbtc(100))
     })
 
-    it("has a max supply of 250 BTC between the 30th day and 60th day", async () => {
-      await increaseTime(30 * 24 * 60 * 60 + 1) // 30 days and 1 second
+    it("has a max supply of 250 BTC between the 7th day and 14th day", async () => {
+      await increaseTime(7 * 24 * 60 * 60 + 1) // 7 days and 1 second
       let maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(250))
 
-      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
+      await increaseTime(7 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
       maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(250))
 
@@ -754,12 +754,12 @@ describe("VendingMachine", async function() {
       expect(maxSupply).to.not.eq.BN(btcToTbtc(250))
     })
 
-    it("has a max supply of 500 BTC between the 60th day and 90th day", async () => {
-      await increaseTime(60 * 24 * 60 * 60 + 1) // 60 days and 1 second
+    it("has a max supply of 500 BTC between the 14th day and the 21st day", async () => {
+      await increaseTime(14 * 24 * 60 * 60 + 1) // 14 days and 1 second
       let maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(500))
 
-      await increaseTime(30 * 24 * 60 * 60 - 10 * 60) // 30 days minus 10 minutes
+      await increaseTime(7 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
       maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(500))
 
@@ -768,8 +768,92 @@ describe("VendingMachine", async function() {
       expect(maxSupply).to.not.eq.BN(btcToTbtc(500))
     })
 
-    it("has a max supply of 21M BTC after the 90th day", async () => {
-      await increaseTime(90 * 24 * 60 * 60 + 1) // 120 days and 1 second
+    it("has a max supply of 750 BTC between the 21st day and the 28th day", async () => {
+      await increaseTime(21 * 24 * 60 * 60 + 1) // 21 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(750))
+
+      await increaseTime(7 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(750))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(750))
+    })
+
+    it("has a max supply of 1000 BTC between the 28th day and the 35th day", async () => {
+      await increaseTime(28 * 24 * 60 * 60 + 1) // 28 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(1000))
+
+      await increaseTime(7 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(1000))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(1000))
+    })
+
+    it("has a max supply of 1500 BTC between the 35th day and the 42nd day", async () => {
+      await increaseTime(35 * 24 * 60 * 60 + 1) // 35 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(1500))
+
+      await increaseTime(7 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(1500))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(1500))
+    })
+
+    it("has a max supply of 2000 BTC between the 42nd day and the 49th day", async () => {
+      await increaseTime(42 * 24 * 60 * 60 + 1) // 42 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(2000))
+
+      await increaseTime(7 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(2000))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(2000))
+    })
+
+    it("has a max supply of 2500 BTC between the 49th day and the 56th day", async () => {
+      await increaseTime(49 * 24 * 60 * 60 + 1) // 42 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(2500))
+
+      await increaseTime(7 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(2500))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(2500))
+    })
+
+    it("has a max supply of 3000 BTC between the 56th day and the 63rd day", async () => {
+      await increaseTime(56 * 24 * 60 * 60 + 1) // 42 days and 1 second
+      let maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(3000))
+
+      await increaseTime(7 * 24 * 60 * 60 - 10 * 60) // 7 days minus 10 minutes
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.eq.BN(btcToTbtc(3000))
+
+      await increaseTime(60 * 60) // one hour
+      maxSupply = await vendingMachine.getMaxSupply()
+      expect(maxSupply).to.not.eq.BN(btcToTbtc(3000))
+    })
+
+    it("has a max supply of 21M BTC after the 63rd day", async () => {
+      await increaseTime(63 * 24 * 60 * 60 + 1) // 63 days and 1 second
       let maxSupply = await vendingMachine.getMaxSupply()
       expect(maxSupply).to.eq.BN(btcToTbtc(21000000))
 

--- a/solidity/test/VendingMachineTest.js
+++ b/solidity/test/VendingMachineTest.js
@@ -737,7 +737,7 @@ describe("VendingMachine", async function() {
         } else if (interval === Infinity) {
           return "the end of time"
         }
-        return moment.duration(interval, 'seconds').humanize({d: 7, w: 40})
+        return moment.duration(interval, "seconds").humanize({d: 7, w: 40})
       }
 
       it(`has a max supply of ${expectedMax} TBTC between ${humanize(start)}
@@ -760,12 +760,11 @@ describe("VendingMachine", async function() {
 
           maxSupply = await vendingMachine.getMaxSupply()
           expect(maxSupply).to.not.eq.BN(btcToTbtc(expectedMax))
-        }
-        else {
+        } else {
           // if we've reached infinity, fast-forward 0-1000 days in advance
           // 10 times and confir
-          for(i = 0; i<10; i++) {
-            let rand = Math.floor(Math.random() * 1000)
+          for (let i = 0; i < 10; i++) {
+            const rand = Math.floor(Math.random() * 1000)
             await increaseTime(rand * DAY)
             maxSupply = await vendingMachine.getMaxSupply()
             expect(maxSupply).to.eq.BN(btcToTbtc(expectedMax))


### PR DESCRIPTION
This PR introduces a more aggressive supply cap schedule. Instead of a monthly cap increase, switch to weekly, removing the cap 9 weeks after the launch.

The market has moved on, and today 250/500/750 BTC per month is a pittance. After discussing with other projects in the space, I believe this curve is more appropriate, balancing security and market demand.