### PR TITLE
Keep factories updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,10 @@ blocks/
 __pycache__/
 node_modules/
 .mypy_cache
+
 # Visual Studio Code
 *.code-workspace
+.vscode/
 
 # infrastructure
 .secrets

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -182,11 +182,6 @@ library KeepFactorySelection {
         Storage storage _self,
         address _fullyBackedFactory
     ) internal {
-        require(
-            address(_fullyBackedFactory) != address(0),
-            "Invalid address"
-        );
-
         _self.fullyBackedFactory = IBondedECDSAKeepFactory(_fullyBackedFactory);
     }
 
@@ -203,11 +198,6 @@ library KeepFactorySelection {
         Storage storage _self,
         address _factorySelector
     ) internal {
-        require(
-            address(_factorySelector) != address(0),
-            "Invalid address"
-        );
-
         _self.factorySelector = KeepFactorySelector(_factorySelector);
     }
 }

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -150,23 +150,38 @@ library KeepFactorySelection {
         );
     }
 
+    /// @notice Sets the address of the KEEP-stake based keep factory. This is
+    /// a default factory used when a ETH-stake based keep factory is not set.
+    /// @dev Can be called multiple times! It's responsibility of a contract
+    /// using this library to limit and protect updates.
+    /// @param _keepStakedFactory Address of the regular, KEEP-stake based keep
+    /// factory.
+    function setKeepStakedKeepFactory(
+        Storage storage _self,
+        address _keepStakedFactory
+    ) internal {
+        require(
+            address(_keepStakedFactory) != address(0),
+            "Invalid address"
+        );
+
+        _self.keepStakeFactory = IBondedECDSAKeepFactory(_keepStakedFactory);
+    }
+
     /// @notice Sets the address of the fully backed, ETH-stake based keep
     /// factory. KeepFactorySelection can work without the fully-backed keep
     /// factory set, always selecting the default KEEP-stake-based factory.
     /// Once both fully-backed keep factory and factory selection strategy are
     /// set, KEEP-stake-based factory is no longer the default choice and it is
     /// up to the selection strategy to decide which factory should be chosen.
-    /// @dev Can be called only one time!
+    /// @dev Can be called multiple times! It's responsibility of a contract
+    /// using this library to limit and protect updates.
     /// @param _fullyBackedFactory Address of the fully-backed, ETH-stake based
     /// keep factory.
     function setFullyBackedKeepFactory(
         Storage storage _self,
         address _fullyBackedFactory
     ) internal {
-        require(
-            address(_self.ethStakeFactory) == address(0),
-            "Fully backed factory already set"
-        );
         require(
             address(_fullyBackedFactory) != address(0),
             "Invalid address"
@@ -181,16 +196,13 @@ library KeepFactorySelection {
     /// Once both fully-backed keep factory and factory selection strategy are
     /// set, KEEP-stake-based factory is no longer the default choice and it is
     /// up to the selection strategy to decide which factory should be chosen.
-    /// @dev Can be called only one time!
+    /// @dev Can be called multiple times! It's responsibility of a contract
+    /// using this library to limit and protect updates.
     /// @param _factorySelector Address of the keep factory selection strategy.
     function setKeepFactorySelector(
         Storage storage _self,
         address _factorySelector
     ) internal {
-        require(
-            address(_self.factorySelector) == address(0),
-            "Factory selector already set"
-        );
         require(
             address(_factorySelector) != address(0),
             "Invalid address"

--- a/solidity/contracts/system/KeepFactorySelection.sol
+++ b/solidity/contracts/system/KeepFactorySelection.sol
@@ -150,42 +150,8 @@ library KeepFactorySelection {
         );
     }
 
-    /// @notice Sets the address of the KEEP-stake based keep factory. This is
-    /// a default factory used when a ETH-bond-only based keep factory is not set.
-    /// @dev Can be called multiple times! It's responsibility of a contract
-    /// using this library to limit and protect updates.
-    /// @param _keepStakedFactory Address of the regular, KEEP-stake based keep
-    /// factory.
-    function setKeepStakedKeepFactory(
-        Storage storage _self,
-        address _keepStakedFactory
-    ) internal {
-        require(
-            address(_keepStakedFactory) != address(0),
-            "Invalid address"
-        );
-
-        _self.keepStakedFactory = IBondedECDSAKeepFactory(_keepStakedFactory);
-    }
-
-    /// @notice Sets the address of the fully backed, ETH-bond-only based keep
-    /// factory. KeepFactorySelection can work without the fully-backed keep
-    /// factory set, always selecting the default KEEP-stake-based factory.
-    /// Once both fully-backed keep factory and factory selection strategy are
-    /// set, KEEP-stake-based factory is no longer the default choice and it is
-    /// up to the selection strategy to decide which factory should be chosen.
-    /// @dev Can be called multiple times! It's responsibility of a contract
-    /// using this library to limit and protect updates.
-    /// @param _fullyBackedFactory Address of the fully-backed, ETH-bond-only based
-    /// keep factory.
-    function setFullyBackedKeepFactory(
-        Storage storage _self,
-        address _fullyBackedFactory
-    ) internal {
-        _self.fullyBackedFactory = IBondedECDSAKeepFactory(_fullyBackedFactory);
-    }
-
-    /// @notice Sets the address of the keep factory selection strategy contract.
+    /// @notice Sets addresses of the keep factories and the selection strategy
+    /// contracts.
     /// KeepFactorySelection can work without the keep factory selection
     /// strategy set, always selecting the default KEEP-stake-based factory.
     /// Once both fully-backed keep factory and factory selection strategy are
@@ -193,11 +159,24 @@ library KeepFactorySelection {
     /// up to the selection strategy to decide which factory should be chosen.
     /// @dev Can be called multiple times! It's responsibility of a contract
     /// using this library to limit and protect updates.
+    /// @param _keepStakedFactory Address of the regular, KEEP-stake based keep
+    /// factory.
+    /// @param _fullyBackedFactory Address of the fully-backed, ETH-bond-only based
+    /// keep factory.
     /// @param _factorySelector Address of the keep factory selection strategy.
-    function setKeepFactorySelector(
+    function setFactories(
         Storage storage _self,
+        address _keepStakedFactory,
+        address _fullyBackedFactory,
         address _factorySelector
     ) internal {
+        require(
+            address(_keepStakedFactory) != address(0),
+            "Invalid KEEP-staked factory address"
+        );
+
+        _self.keepStakedFactory = IBondedECDSAKeepFactory(_keepStakedFactory);
+        _self.fullyBackedFactory = IBondedECDSAKeepFactory(_fullyBackedFactory);
         _self.factorySelector = KeepFactorySelector(_factorySelector);
     }
 }

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -38,7 +38,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         uint16 _severelyUndercollateralizedThresholdPercent,
         uint256 _timestamp
     );
-    event KeepFactoryUpdateStarted(
+    event KeepFactoriesUpdateStarted(
         address _keepStakedFactory,
         address _fullyBackedFactory,
         address _factorySelector,
@@ -54,7 +54,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         uint16 _undercollateralizedThresholdPercent,
         uint16 _severelyUndercollateralizedThresholdPercent
     );
-    event KeepFactoryUpdated(
+    event KeepFactoriesUpdated(
         address _keepStakedFactory,
         address _fullyBackedFactory,
         address _factorySelector
@@ -86,7 +86,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     uint256 private signerFeeDivisorChangeInitiated;
     uint256 private lotSizesChangeInitiated;
     uint256 private collateralizationThresholdsChangeInitiated;
-    uint256 private keepFactoryUpdateInitiated;
+    uint256 private keepFactoriesUpdateInitiated;
 
     uint16 private newSignerFeeDivisor;
     uint64[] newLotSizesSatoshis;
@@ -297,7 +297,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     ///         default KEEP-backed factory for new deposits. When the
     ///         ETH-only-backed factory and strategy are set, TBTCSystem load
     ///         balances between two factories based on the selection strategy.
-    /// @dev It can be finalized by calling `finalizeKeepFactoryUpdate`
+    /// @dev It can be finalized by calling `finalizeKeepFactoriesUpdate`
     ///      any time after `governanceTimeDelay` has elapsed. This can be
     ///      called more than once until finalized to reset the values and
     ///      timer. Upgrade can be performed more than once if initialized
@@ -306,7 +306,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @param _keepStakedFactory Address of the KEEP staked based factory.
     /// @param _fullyBackedFactory Address of the ETH-bond-only-based factory.
     /// @param _factorySelector Address of the keep factory selection strategy.
-    function beginKeepFactoryUpdate(
+    function beginKeepFactoriesUpdate(
         address _keepStakedFactory,
         address _fullyBackedFactory,
         address _factorySelector
@@ -316,7 +316,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         uint256 sinceInit = block.timestamp - initializedTimestamp;
         require(
             sinceInit < keepFactoriesUpgradeabilityPeriod,
-            "beginKeepFactoryUpdate can only be called within upgradeability period"
+            "beginKeepFactoriesUpdate can only be called within upgradeability period"
         );
 
         // It is required that KEEP staked factory address is configured as this is
@@ -330,9 +330,9 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         newKeepStakedFactory = _keepStakedFactory;
         newFullyBackedFactory = _fullyBackedFactory;
         newFactorySelector = _factorySelector;
-        keepFactoryUpdateInitiated = block.timestamp;
+        keepFactoriesUpdateInitiated = block.timestamp;
 
-        emit KeepFactoryUpdateStarted(
+        emit KeepFactoriesUpdateStarted(
             _keepStakedFactory,
             _fullyBackedFactory,
             _factorySelector,
@@ -427,15 +427,15 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @notice Finish setting the address of the ETH-only-backed ECDSA keep
     ///         factory and the selection strategy that will choose between it
     ///         and the default KEEP-backed factory for new deposits.
-    /// @dev `beginKeepFactoryUpdate` must be called first; once
+    /// @dev `beginKeepFactoriesUpdate` must be called first; once
     ///      `governanceTimeDelay` has passed, this function can be called to
     ///      set the collateralization thresholds to the value set in
-    ///      `beginKeepFactoryUpdate`.
-    function finalizeKeepFactoryUpdate()
+    ///      `beginKeepFactoriesUpdate`.
+    function finalizeKeepFactoriesUpdate()
         external
         onlyOwner
         onlyAfterGovernanceDelay(
-            keepFactoryUpdateInitiated,
+            keepFactoriesUpdateInitiated,
             governanceTimeDelay
         ) {
 
@@ -443,13 +443,13 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         keepFactorySelection.setFullyBackedKeepFactory(newFullyBackedFactory);
         keepFactorySelection.setKeepFactorySelector(newFactorySelector);
 
-        emit KeepFactoryUpdated(
+        emit KeepFactoriesUpdated(
             newKeepStakedFactory,
             newFullyBackedFactory,
             newFactorySelector
         );
 
-        keepFactoryUpdateInitiated = 0;
+        keepFactoriesUpdateInitiated = 0;
         newKeepStakedFactory = address(0);
         newFullyBackedFactory = address(0);
         newFactorySelector = address(0);
@@ -552,9 +552,9 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @notice Get the time remaining until the Keep ETH-only-backed ECDSA keep
     ///         factory and the selection strategy that will choose between it
     ///         and the KEEP-backed factory can be updated.
-    function getRemainingKeepFactoryUpdateTime() external view returns (uint256) {
+    function getRemainingKeepFactoriesUpdateTime() external view returns (uint256) {
         return getRemainingChangeTime(
-            keepFactoryUpdateInitiated,
+            keepFactoriesUpdateInitiated,
             governanceTimeDelay
         );
     }

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -40,7 +40,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     );
     event KeepFactorySingleShotUpdateStarted(
         address _factorySelector,
-        address _ethBackedFactory,
+        address _fullyBackedFactory,
         uint256 _timestamp
     );
 
@@ -55,7 +55,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     );
     event KeepFactorySingleShotUpdated(
         address _factorySelector,
-        address _ethBackedFactory
+        address _fullyBackedFactory
     );
 
     uint256 initializedTimestamp = 0;
@@ -91,7 +91,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     uint16 private newUndercollateralizedThresholdPercent;
     uint16 private newSeverelyUndercollateralizedThresholdPercent;
     address private newFactorySelector;
-    address private newEthBackedFactory;
+    address private newFullyBackedFactory;
 
     // price feed
     uint256 priceFeedGovernanceTimeDelay = 90 days;
@@ -298,10 +298,10 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     ///      called more than once until finalized to reset the values and
     ///      timer, but it can only be finalized once!
     /// @param _factorySelector Address of the keep factory selection strategy.
-    /// @param _ethBackedFactory Address of the ETH-stake-based factory.
+    /// @param _fullyBackedFactory Address of the ETH-bond-only-based factory.
     function beginKeepFactorySingleShotUpdate(
         address _factorySelector,
-        address _ethBackedFactory
+        address _fullyBackedFactory
     )
         external onlyOwner
     {
@@ -309,9 +309,9 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             // Either an update is in progress,
             keepFactorySingleShotUpdateInitiated != 0 ||
             // or we're trying to start a fresh one, in which case we must not
-            // have an already-finalized one (indicated by newEthBackedFactory
+            // have an already-finalized one (indicated by newFullyBackedFactory
             // being set).
-            newEthBackedFactory == address(0),
+            newFullyBackedFactory == address(0),
             "Keep factory data can only be updated once"
         );
         require(
@@ -319,16 +319,16 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             "Factory selector must be a nonzero address"
         );
         require(
-            _ethBackedFactory != address(0),
+            _fullyBackedFactory != address(0),
             "ETH-backed factory must be a nonzero address"
         );
 
         newFactorySelector = _factorySelector;
-        newEthBackedFactory = _ethBackedFactory;
+        newFullyBackedFactory = _fullyBackedFactory;
         keepFactorySingleShotUpdateInitiated = block.timestamp;
         emit KeepFactorySingleShotUpdateStarted(
             _factorySelector,
-            _ethBackedFactory,
+            _fullyBackedFactory,
             block.timestamp
         );
     }
@@ -433,16 +433,16 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         ) {
 
         keepFactorySelection.setKeepFactorySelector(newFactorySelector);
-        keepFactorySelection.setFullyBackedKeepFactory(newEthBackedFactory);
+        keepFactorySelection.setFullyBackedKeepFactory(newFullyBackedFactory);
 
         emit KeepFactorySingleShotUpdated(
             newFactorySelector,
-            newEthBackedFactory
+            newFullyBackedFactory
         );
 
         keepFactorySingleShotUpdateInitiated = 0;
         newFactorySelector = address(0);
-        // Keep newEthBackedFactory set as a marker that the update has already
+        // Keep newFullyBackedFactory set as a marker that the update has already
         // occurred.
     }
 

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -292,17 +292,24 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         );
     }
 
-    /// @notice Sets the address of the ETH-only-backed ECDSA keep factory and
-    ///         the selection strategy that will choose between it and the
-    ///         default KEEP-backed factory for new deposits. When the
-    ///         ETH-only-backed factory and strategy are set, TBTCSystem load
-    ///         balances between two factories based on the selection strategy.
+    /// @notice Sets the addresses of the KEEP-staked ECDSA keep factory,
+    ///         ETH-only-backed ECDSA keep factory and the selection strategy
+    ///         that will choose between the two factories for new deposits.
+    ///         When the ETH-only-backed factory and strategy are not set TBTCSystem
+    ///         will use KEEP-staked factory. When both factories and strategy
+    ///         are set, TBTCSystem load balances between two factories based on
+    ///         the selection strategy.
     /// @dev It can be finalized by calling `finalizeKeepFactoriesUpdate`
     ///      any time after `governanceTimeDelay` has elapsed. This can be
     ///      called more than once until finalized to reset the values and
     ///      timer. Upgrade can be performed more than once if initialized
     ///      before `keepFactoriesUpgradeabilityPeriod` since system initialization
-    ///      is reached.
+    ///      is reached. This mechanism overwrites the previous values with a set
+    ///      provided in the request. If a parameter is not intended to be updated
+    ///      its' value should be provided as well. KEEP-staked factory address
+    ///      cannot be zero as this is a default factory required for the system
+    ///      to work. ETH-bond-only factory or the strategy are allowed to be
+    ///      set as zero addresses.
     /// @param _keepStakedFactory Address of the KEEP staked based factory.
     /// @param _fullyBackedFactory Address of the ETH-bond-only-based factory.
     /// @param _factorySelector Address of the keep factory selection strategy.
@@ -424,13 +431,12 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         collateralizationThresholdsChangeInitiated = 0;
     }
 
-    /// @notice Finish setting the address of the ETH-only-backed ECDSA keep
-    ///         factory and the selection strategy that will choose between it
-    ///         and the default KEEP-backed factory for new deposits.
+    /// @notice Finish setting addresses of the KEEP-staked ECDSA keep factory
+    ///         ETH-only-backed ECDSA keep factory and the selection strategy
+    ///         that will choose between the two factories for new deposits.
     /// @dev `beginKeepFactoriesUpdate` must be called first; once
     ///      `governanceTimeDelay` has passed, this function can be called to
-    ///      set the collateralization thresholds to the value set in
-    ///      `beginKeepFactoriesUpdate`.
+    ///      set factories addresses to the values set in `beginKeepFactoriesUpdate`.
     function finalizeKeepFactoriesUpdate()
         external
         onlyOwner

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -318,17 +318,13 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             sinceInit < keepFactoriesUpgradeabilityPeriod,
             "beginKeepFactoryUpdate can only be called within upgradeability period"
         );
+
+        // It is required that KEEP staked factory address is configured as this is
+        // a default choice factory. Fully backed factory and factory selector
+        // are optional for the system to work, hence they don't have to be provided.
         require(
             _keepStakedFactory != address(0),
             "KEEP staked factory must be a nonzero address"
-        );
-        require(
-            _fullyBackedFactory != address(0),
-            "Fully backed factory must be a nonzero address"
-        );
-        require(
-            _factorySelector != address(0),
-            "Factory selector must be a nonzero address"
         );
 
         newKeepStakedFactory = _keepStakedFactory;

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -316,7 +316,7 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         uint256 sinceInit = block.timestamp - initializedTimestamp;
         require(
             sinceInit < keepFactoriesUpgradeabilityPeriod,
-            "beginKeepFactoriesUpdate can only be called within upgradeability period"
+            "beginKeepFactoriesUpdate can only be called within 180 days of initialization"
         );
 
         // It is required that KEEP staked factory address is configured as this is

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -302,14 +302,13 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
     /// @dev It can be finalized by calling `finalizeKeepFactoriesUpdate`
     ///      any time after `governanceTimeDelay` has elapsed. This can be
     ///      called more than once until finalized to reset the values and
-    ///      timer. Upgrade can be performed more than once if initialized
-    ///      before `keepFactoriesUpgradeabilityPeriod` since system initialization
-    ///      is reached. This mechanism overwrites the previous values with a set
-    ///      provided in the request. If a parameter is not intended to be updated
-    ///      its' value should be provided as well. KEEP-staked factory address
-    ///      cannot be zero as this is a default factory required for the system
-    ///      to work. ETH-bond-only factory or the strategy are allowed to be
-    ///      set as zero addresses.
+    ///      timer. An update can only be initialized before
+    ///      `keepFactoriesUpgradeabilityPeriod` elapses after system initialization;
+    ///      after that, no further updates can be initialized, though any pending
+    ///      update can be finalized. All calls must set all three properties to
+    ///      their desired value; leaving a value as 0, even if it was previously
+    ///      set, will update that value to be 0. ETH-bond-only factory or the
+    ///      strategy are allowed to be set as zero addresses.
     /// @param _keepStakedFactory Address of the KEEP staked based factory.
     /// @param _fullyBackedFactory Address of the ETH-bond-only-based factory.
     /// @param _factorySelector Address of the keep factory selection strategy.
@@ -431,8 +430,8 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
         collateralizationThresholdsChangeInitiated = 0;
     }
 
-    /// @notice Finish setting addresses of the KEEP-staked ECDSA keep factory
-    ///         ETH-only-backed ECDSA keep factory and the selection strategy
+    /// @notice Finish setting addresses of the KEEP-staked ECDSA keep factory,
+    ///         ETH-only-backed ECDSA keep factory, and the selection strategy
     ///         that will choose between the two factories for new deposits.
     /// @dev `beginKeepFactoriesUpdate` must be called first; once
     ///      `governanceTimeDelay` has passed, this function can be called to

--- a/solidity/contracts/system/TBTCSystem.sol
+++ b/solidity/contracts/system/TBTCSystem.sol
@@ -439,9 +439,11 @@ contract TBTCSystem is Ownable, ITBTCSystem, DepositLog {
             governanceTimeDelay
         ) {
 
-        keepFactorySelection.setKeepStakedKeepFactory(newKeepStakedFactory);
-        keepFactorySelection.setFullyBackedKeepFactory(newFullyBackedFactory);
-        keepFactorySelection.setKeepFactorySelector(newFactorySelector);
+        keepFactorySelection.setFactories(
+            newKeepStakedFactory,
+            newFullyBackedFactory,
+            newFactorySelector
+        );
 
         emit KeepFactoriesUpdated(
             newKeepStakedFactory,

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -25,7 +25,7 @@ contract KeepFactorySelectionStub {
     }
 
     function keepStakedFactory() public view returns (address) {
-        return address(keepFactorySelection.keepStakeFactory);
+        return address(keepFactorySelection.keepStakedFactory);
     }
 
     function setFullyBackedKeepFactory(address _fullyBackedFactory) public {
@@ -33,7 +33,7 @@ contract KeepFactorySelectionStub {
     }
 
     function fullyBackedFactory() public view returns (address) {
-        return address(keepFactorySelection.ethStakeFactory);
+        return address(keepFactorySelection.fullyBackedFactory);
     }
 
     function setKeepFactorySelector(address _factorySelector) public {

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -16,6 +16,18 @@ contract KeepFactorySelectionStub {
         return keepFactorySelection.selectFactory();
     }
 
+    function setMinimumBondableValue(
+        uint256 _minimumBondableValue,
+        uint256 _groupSize,
+        uint256 _honestThreshold
+    ) public {
+        keepFactorySelection.setMinimumBondableValue(
+            _minimumBondableValue,
+            _groupSize,
+            _honestThreshold
+        );
+    }
+
     function selectFactoryAndRefresh() public returns (IBondedECDSAKeepFactory) {
         return keepFactorySelection.selectFactoryAndRefresh();
     }

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -32,28 +32,30 @@ contract KeepFactorySelectionStub {
         return keepFactorySelection.selectFactoryAndRefresh();
     }
 
-    function setKeepStakedKeepFactory(address _keepStakedFactory) public {
-        keepFactorySelection.setKeepStakedKeepFactory(_keepStakedFactory);
+    function setFactories(
+        address _keepStakedFactory,
+        address _fullyBackedFactory,
+        address _factorySelector
+    ) public {
+        keepFactorySelection.setFactories(
+            _keepStakedFactory,
+            _fullyBackedFactory,
+            _factorySelector
+        );
     }
 
-    function keepStakedFactory() public view returns (address) {
-        return address(keepFactorySelection.keepStakedFactory);
-    }
-
-    function setFullyBackedKeepFactory(address _fullyBackedFactory) public {
-        keepFactorySelection.setFullyBackedKeepFactory(_fullyBackedFactory);
-    }
-
-    function fullyBackedFactory() public view returns (address) {
-        return address(keepFactorySelection.fullyBackedFactory);
-    }
-
-    function setKeepFactorySelector(address _factorySelector) public {
-        keepFactorySelection.setKeepFactorySelector(_factorySelector);
-    }
-
-    function factorySelector() public view returns (address) {
-        return address(keepFactorySelection.factorySelector);
+    function factories()
+        public
+        view
+        returns (
+            address _keepStakedFactory,
+            address _fullyBackedFactory,
+            address _factorySelector
+        )
+    {
+        _keepStakedFactory = address(keepFactorySelection.keepStakedFactory);
+        _fullyBackedFactory = address(keepFactorySelection.fullyBackedFactory);
+        _factorySelector = address(keepFactorySelection.factorySelector);
     }
 }
 

--- a/solidity/contracts/test/system/KeepFactorySelectionStub.sol
+++ b/solidity/contracts/test/system/KeepFactorySelectionStub.sol
@@ -20,12 +20,28 @@ contract KeepFactorySelectionStub {
         return keepFactorySelection.selectFactoryAndRefresh();
     }
 
+    function setKeepStakedKeepFactory(address _keepStakedFactory) public {
+        keepFactorySelection.setKeepStakedKeepFactory(_keepStakedFactory);
+    }
+
+    function keepStakedFactory() public view returns (address) {
+        return address(keepFactorySelection.keepStakeFactory);
+    }
+
     function setFullyBackedKeepFactory(address _fullyBackedFactory) public {
         keepFactorySelection.setFullyBackedKeepFactory(_fullyBackedFactory);
     }
 
+    function fullyBackedFactory() public view returns (address) {
+        return address(keepFactorySelection.ethStakeFactory);
+    }
+
     function setKeepFactorySelector(address _factorySelector) public {
         keepFactorySelection.setKeepFactorySelector(_factorySelector);
+    }
+
+    function factorySelector() public view returns (address) {
+        return address(keepFactorySelection.factorySelector);
     }
 }
 

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -252,17 +252,6 @@ describe("TBTCSystem governance", async function() {
     })
 
     it("reverts for beginKeepFactoriesUpdate if upgradeability period has passed", async () => {
-      await tbtcSystem.beginKeepFactoriesUpdate(
-        "0x0000000000000000000000000000000000000001",
-        "0x0000000000000000000000000000000000000002",
-        "0x0000000000000000000000000000000000000003",
-      )
-
-      const finalizationTime = await tbtcSystem.getRemainingKeepFactoriesUpdateTime()
-      await increaseTime(finalizationTime.addn(1))
-
-      await tbtcSystem.finalizeKeepFactoriesUpdate()
-
       const upgradeabilityTime = await tbtcSystem.getRemainingKeepFactoriesUpgradeabilityTime()
       await increaseTime(upgradeabilityTime.addn(1))
 

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -389,7 +389,7 @@ describe("TBTCSystem governance", async function() {
           value: keepFactorySelector.address,
         },
         {
-          name: "_ethBackedFactory",
+          name: "_fullyBackedFactory",
           value: newKeepFactory.address,
         },
       ],
@@ -405,11 +405,11 @@ describe("TBTCSystem governance", async function() {
       verifyFinalizationEvents: async (
         receipt,
         setFactorySelector,
-        setEthBackedFactory,
+        setFullyBackedFactory,
       ) => {
         expectEvent(receipt, "KeepFactorySingleShotUpdated", {
           _factorySelector: setFactorySelector,
-          _ethBackedFactory: setEthBackedFactory,
+          _fullyBackedFactory: setFullyBackedFactory,
         })
       },
       verifyFinalState: async () => {
@@ -425,7 +425,7 @@ describe("TBTCSystem governance", async function() {
           value: await ecdsaKeepFactory.openKeepFeeEstimate.call(),
         })
 
-        // This should fail as the _ethBackedFactory is not a real contract
+        // This should fail as the _fullyBackedFactory is not a real contract
         // address, so dereferencing it will go boom.
         await tbtcSystem.requestNewKeep(10 ** 8, 123, {
           from: mockDeposit,

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -272,7 +272,7 @@ describe("TBTCSystem governance", async function() {
           "0x0000000000000000000000000000000000000002",
           "0x0000000000000000000000000000000000000003",
         ),
-        "beginKeepFactoriesUpdate can only be called within upgradeability period",
+        "beginKeepFactoriesUpdate can only be called within 180 days of initialization",
       )
     })
 

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -193,29 +193,6 @@ describe("TBTCSystem governance", async function() {
       await restoreSnapshot()
     })
 
-    it("does not revert if beginKeepFactoriesUpdate has already been called", async () => {
-      await tbtcSystem.beginKeepFactoriesUpdate(
-        "0x0000000000000000000000000000000000000001",
-        "0x0000000000000000000000000000000000000002",
-        "0x0000000000000000000000000000000000000003",
-      )
-
-      const finalizationTime = await tbtcSystem.getRemainingKeepFactoriesUpdateTime()
-      await increaseTime(finalizationTime.subn(1))
-
-      // Should not revert.
-      await tbtcSystem.beginKeepFactoriesUpdate(
-        "0x0000000000000000000000000000000000000005",
-        "0x0000000000000000000000000000000000000006",
-        "0x0000000000000000000000000000000000000007",
-      )
-
-      // Check if timer has been updated.
-      expect(await tbtcSystem.getRemainingKeepFactoriesUpdateTime()).to.eq.BN(
-        await tbtcSystem.getGovernanceTimeDelay(),
-      )
-    })
-
     it("does not revert if finalizeKeepFactoriesUpdate has already been called", async () => {
       await tbtcSystem.beginKeepFactoriesUpdate(
         "0x0000000000000000000000000000000000000001",

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -196,50 +196,50 @@ describe("TBTCSystem governance", async function() {
       await restoreSnapshot()
     })
 
-    it("does not revert if beginKeepFactoryUpdate has already been called", async () => {
-      await tbtcSystem.beginKeepFactoryUpdate(
+    it("does not revert if beginKeepFactoriesUpdate has already been called", async () => {
+      await tbtcSystem.beginKeepFactoriesUpdate(
         "0x0000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000002",
         "0x0000000000000000000000000000000000000003",
       )
 
-      const finalizationTime = await tbtcSystem.getRemainingKeepFactoryUpdateTime()
+      const finalizationTime = await tbtcSystem.getRemainingKeepFactoriesUpdateTime()
       await increaseTime(finalizationTime.subn(1))
 
       // Should not revert.
-      await tbtcSystem.beginKeepFactoryUpdate(
+      await tbtcSystem.beginKeepFactoriesUpdate(
         "0x0000000000000000000000000000000000000005",
         "0x0000000000000000000000000000000000000006",
         "0x0000000000000000000000000000000000000007",
       )
 
-      expect(await tbtcSystem.getRemainingKeepFactoryUpdateTime()).to.eq.BN(
+      expect(await tbtcSystem.getRemainingKeepFactoriesUpdateTime()).to.eq.BN(
         await tbtcSystem.getGovernanceTimeDelay(),
       )
     })
 
-    it("does not revert if finalizeKeepFactoryUpdate has already been called", async () => {
-      await tbtcSystem.beginKeepFactoryUpdate(
+    it("does not revert if finalizeKeepFactoriesUpdate has already been called", async () => {
+      await tbtcSystem.beginKeepFactoriesUpdate(
         "0x0000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000002",
         "0x0000000000000000000000000000000000000003",
       )
 
-      const finalizationTime = await tbtcSystem.getRemainingKeepFactoryUpdateTime()
+      const finalizationTime = await tbtcSystem.getRemainingKeepFactoriesUpdateTime()
       await increaseTime(finalizationTime.addn(1))
 
-      await tbtcSystem.finalizeKeepFactoryUpdate()
+      await tbtcSystem.finalizeKeepFactoriesUpdate()
 
       // Should not revert.
-      await tbtcSystem.beginKeepFactoryUpdate(
+      await tbtcSystem.beginKeepFactoriesUpdate(
         "0x0000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000002",
         "0x0000000000000000000000000000000000000003",
       )
     })
 
-    it("does not revert finalizeKeepFactoryUpdate if upgradeability period has passed", async () => {
-      await tbtcSystem.beginKeepFactoryUpdate(
+    it("does not revert finalizeKeepFactoriesUpdate if upgradeability period has passed", async () => {
+      await tbtcSystem.beginKeepFactoriesUpdate(
         "0x0000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000002",
         "0x0000000000000000000000000000000000000003",
@@ -248,47 +248,47 @@ describe("TBTCSystem governance", async function() {
       const upgradeabilityTime = await tbtcSystem.getRemainingKeepFactoriesUpgradeabilityTime()
       await increaseTime(upgradeabilityTime.addn(1))
 
-      await tbtcSystem.finalizeKeepFactoryUpdate()
+      await tbtcSystem.finalizeKeepFactoriesUpdate()
     })
 
-    it("reverts for beginKeepFactoryUpdate if upgradeability period has passed", async () => {
-      await tbtcSystem.beginKeepFactoryUpdate(
+    it("reverts for beginKeepFactoriesUpdate if upgradeability period has passed", async () => {
+      await tbtcSystem.beginKeepFactoriesUpdate(
         "0x0000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000002",
         "0x0000000000000000000000000000000000000003",
       )
 
-      const finalizationTime = await tbtcSystem.getRemainingKeepFactoryUpdateTime()
+      const finalizationTime = await tbtcSystem.getRemainingKeepFactoriesUpdateTime()
       await increaseTime(finalizationTime.addn(1))
 
-      await tbtcSystem.finalizeKeepFactoryUpdate()
+      await tbtcSystem.finalizeKeepFactoriesUpdate()
 
       const upgradeabilityTime = await tbtcSystem.getRemainingKeepFactoriesUpgradeabilityTime()
       await increaseTime(upgradeabilityTime.addn(1))
 
       await expectRevert(
-        tbtcSystem.beginKeepFactoryUpdate(
+        tbtcSystem.beginKeepFactoriesUpdate(
           "0x0000000000000000000000000000000000000001",
           "0x0000000000000000000000000000000000000002",
           "0x0000000000000000000000000000000000000003",
         ),
-        "beginKeepFactoryUpdate can only be called within upgradeability period",
+        "beginKeepFactoriesUpdate can only be called within upgradeability period",
       )
     })
 
-    it("reverts if finalizeKeepFactoryUpdate is called twice", async () => {
-      await tbtcSystem.beginKeepFactoryUpdate(
+    it("reverts if finalizeKeepFactoriesUpdate is called twice", async () => {
+      await tbtcSystem.beginKeepFactoriesUpdate(
         "0x0000000000000000000000000000000000000001",
         "0x0000000000000000000000000000000000000002",
         "0x0000000000000000000000000000000000000003",
       )
 
-      const finalizationTime = await tbtcSystem.getRemainingKeepFactoryUpdateTime()
+      const finalizationTime = await tbtcSystem.getRemainingKeepFactoriesUpdateTime()
       await increaseTime(finalizationTime.toNumber() + 1) // 10 days
-      await tbtcSystem.finalizeKeepFactoryUpdate()
+      await tbtcSystem.finalizeKeepFactoriesUpdate()
 
       await expectRevert(
-        tbtcSystem.finalizeKeepFactoryUpdate(),
+        tbtcSystem.finalizeKeepFactoriesUpdate(),
         "Change not initiated",
       )
     })
@@ -447,7 +447,7 @@ describe("TBTCSystem governance", async function() {
 
     governanceTest({
       property: "keep factory update",
-      change: "KeepFactoryUpdate",
+      change: "KeepFactoriesUpdate",
       goodParametersWithName: [
         {
           name: "_keepStakedFactory",
@@ -478,7 +478,7 @@ describe("TBTCSystem governance", async function() {
         setFullyBackedFactory,
         setFactorySelector,
       ) => {
-        expectEvent(receipt, "KeepFactoryUpdated", {
+        expectEvent(receipt, "KeepFactoriesUpdated", {
           _keepStakedFactory: setKeepStakedFactory,
           _fullyBackedFactory: setFullyBackedFactory,
           _factorySelector: setFactorySelector,
@@ -530,7 +530,7 @@ describe("TBTCSystem governance", async function() {
     governanceTest({
       property:
         "keep factory update with zeroed fully backed factory and factory selector",
-      change: "KeepFactoryUpdate",
+      change: "KeepFactoriesUpdate",
       goodParametersWithName: [
         {
           name: "_keepStakedFactory",
@@ -546,7 +546,7 @@ describe("TBTCSystem governance", async function() {
         },
       ],
       verifyFinalizationEvents: async (receipt, setKeepStakedFactory) => {
-        expectEvent(receipt, "KeepFactoryUpdated", {
+        expectEvent(receipt, "KeepFactoriesUpdated", {
           _keepStakedFactory: setKeepStakedFactory,
           _fullyBackedFactory: constants.ZERO_ADDRESS,
           _factorySelector: constants.ZERO_ADDRESS,

--- a/solidity/test/GovernanceTest.js
+++ b/solidity/test/GovernanceTest.js
@@ -26,9 +26,6 @@ describe("TBTCSystem governance", async function() {
 
   const nonSystemOwner = accounts[3]
 
-  // We increased the value for new factories compared to the default ones
-  // as this is a way of validating that factory has been updated when using
-  // old (insufficient) value to request a new keep.
   const defaultOpenKeepFee = 13
   const newKeepStakedOpenKeepFee = 672
   const newFullyBackedOpenKeepFee = 834
@@ -213,6 +210,7 @@ describe("TBTCSystem governance", async function() {
         "0x0000000000000000000000000000000000000007",
       )
 
+      // Check if timer has been updated.
       expect(await tbtcSystem.getRemainingKeepFactoriesUpdateTime()).to.eq.BN(
         await tbtcSystem.getGovernanceTimeDelay(),
       )

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -1,7 +1,7 @@
 const {contract} = require("@openzeppelin/test-environment")
 const {BN, expectRevert, constants} = require("@openzeppelin/test-helpers")
 const {createSnapshot, restoreSnapshot} = require("./helpers/snapshot.js")
-const {expect, assert} = require("chai")
+const {expect} = require("chai")
 
 const KeepFactorySelection = contract.fromArtifact("KeepFactorySelection")
 const KeepFactorySelectionStub = contract.fromArtifact(
@@ -403,15 +403,14 @@ describe("KeepFactorySelection", async () => {
         keepFactorySelector.address,
       )
 
-      assert.include(
+      expect(
         await keepFactorySelection.factories(),
-        {
-          _keepStakedFactory: keepStakedFactory.address,
-          _fullyBackedFactory: fullyBackedFactory.address,
-          _factorySelector: keepFactorySelector.address,
-        },
         "invalid factories after first update",
-      )
+      ).to.include({
+        _keepStakedFactory: keepStakedFactory.address,
+        _fullyBackedFactory: fullyBackedFactory.address,
+        _factorySelector: keepFactorySelector.address,
+      })
 
       await keepFactorySelection.setFactories(
         newKeepStakedFactory.address,
@@ -419,15 +418,14 @@ describe("KeepFactorySelection", async () => {
         newSelector.address,
       )
 
-      assert.include(
+      expect(
         await keepFactorySelection.factories(),
-        {
-          _keepStakedFactory: newKeepStakedFactory.address,
-          _fullyBackedFactory: newFullyBackedFactory.address,
-          _factorySelector: newSelector.address,
-        },
         "invalid factories after second update",
-      )
+      ).to.include({
+        _keepStakedFactory: newKeepStakedFactory.address,
+        _fullyBackedFactory: newFullyBackedFactory.address,
+        _factorySelector: newSelector.address,
+      })
     })
 
     it("can be called for fully backed and factory selector zero addresses", async () => {
@@ -437,15 +435,14 @@ describe("KeepFactorySelection", async () => {
         constants.ZERO_ADDRESS,
       )
 
-      assert.include(
+      expect(
         await keepFactorySelection.factories(),
-        {
-          _keepStakedFactory: keepStakedFactory.address,
-          _fullyBackedFactory: constants.ZERO_ADDRESS,
-          _factorySelector: constants.ZERO_ADDRESS,
-        },
         "invalid factories",
-      )
+      ).to.include({
+        _keepStakedFactory: keepStakedFactory.address,
+        _fullyBackedFactory: constants.ZERO_ADDRESS,
+        _factorySelector: constants.ZERO_ADDRESS,
+      })
     })
 
     it("reverts when KEEP-staked factory address is zero", async () => {

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -164,6 +164,19 @@ describe("KeepFactorySelection", async () => {
       )
     })
 
+    // No ETH-only vendor set.
+    // Selection strategy set.
+    it("returns KEEP stake factory if ETH-only factory is not set", async () => {
+      await keepFactorySelection.setKeepFactorySelector(
+        keepFactorySelector.address,
+      )
+      const selected = await keepFactorySelection.selectFactoryAndRefresh.call()
+      await keepFactorySelection.selectFactoryAndRefresh()
+      expect(selected, "unexpected factory selected").to.equal(
+        keepStakeFactory.address,
+      )
+    })
+
     // ETH stake factory set.
     // Selection strategy set.
     it("returns fully-backed factory if selected by the strategy", async () => {

--- a/solidity/test/KeepFactorySelectionTest.js
+++ b/solidity/test/KeepFactorySelectionTest.js
@@ -449,10 +449,13 @@ describe("KeepFactorySelection", async () => {
       )
     })
 
-    it("can not be called for 0 address", async () => {
-      await expectRevert(
-        keepFactorySelection.setFullyBackedKeepFactory(constants.ZERO_ADDRESS),
-        "Invalid address",
+    it("can be called for 0 address", async () => {
+      await keepFactorySelection.setFullyBackedKeepFactory(
+        constants.ZERO_ADDRESS,
+      )
+
+      expect(await keepFactorySelection.fullyBackedFactory()).to.equal(
+        constants.ZERO_ADDRESS,
       )
     })
   })
@@ -475,10 +478,11 @@ describe("KeepFactorySelection", async () => {
       )
     })
 
-    it("can not be called for 0 address", async () => {
-      await expectRevert(
-        keepFactorySelection.setKeepFactorySelector(constants.ZERO_ADDRESS),
-        "Invalid address",
+    it("can be called for 0 address", async () => {
+      await keepFactorySelection.setKeepFactorySelector(constants.ZERO_ADDRESS)
+
+      expect(await keepFactorySelection.factorySelector()).to.equal(
+        constants.ZERO_ADDRESS,
       )
     })
   })


### PR DESCRIPTION
Currently, the system allows a single-shot update of fully backed keep factory and keep factory selector addresses. KEEP staked factory address is not upgradeable.

In this PR we added a possibility to upgrade all three addresses within a certain time period (180 days) from the system initialization.

This is a two-step upgrade that can be finalized after 48 hours of governance delay.

To begin the upgrade owner has to provide three addresses:
- KEEP-stake backed keep factory,
- ETH-only-bonded keep factory,
- Keep factory selector.

It is required that KEEP-stake backed factory address is always provided to a valid value different than 0. Remaining two addresses are optional for the system to work, so zero addresses are allowed. This is also a safety switch that lets us disable fully backed keep factory and operate only on KEEP-staked factory.