### PR TITLE
Slick Moves: Use npx truffle in install scripts

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,11 +27,11 @@ npm install
 
 printf "${LOG_START}Unlocking ethereum accounts...${LOG_END}"
 KEEP_ETHEREUM_PASSWORD=$KEEP_ETHEREUM_PASSWORD \
-    truffle exec scripts/unlock-eth-accounts.js --network development
+    npx truffle exec scripts/unlock-eth-accounts.js --network development
 
 printf "${LOG_START}Finding current ethereum network ID...${LOG_END}"
 
-output=$(truffle exec ./scripts/get-network-id.js --network development)
+output=$(npx truffle exec ./scripts/get-network-id.js --network development)
 NETWORKID=$(echo "$output" | tail -1)
 printf "Current network ID: ${NETWORKID}\n"
 
@@ -42,6 +42,6 @@ NETWORKID=$NETWORKID \
 
 printf "${LOG_START}Migrating contracts...${LOG_END}"
 npm run clean
-truffle migrate --reset --network development
+npx truffle migrate --reset --network development
 
 printf "${DONE_START}Installation completed!${DONE_END}"


### PR DESCRIPTION
This removes the global Truffle requirement.

Upstream of keep-network/local-setup#40.