### PR TITLE
Add TBTCSystem event log

### DIFF
--- a/pkg/chain/ethereum/gen/eventlog/TBTCSystemEventLog.go
+++ b/pkg/chain/ethereum/gen/eventlog/TBTCSystemEventLog.go
@@ -1,4 +1,4 @@
-package filterer
+package eventlog
 
 import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -8,24 +8,24 @@ import (
 )
 
 // FIXME: This is a temporary structure allowing to access past events
-//  emitted by the `TBTCSystemFilterer` contract. This structure is
-//  here because the generated contract wrappers from `gen/contract`
-//  don't support `Filter*` methods yet. When the contract generator
-//  will support those methods, the below structure can be removed.
-type TBTCSystemFilterer struct {
+//  emitted by the `TBTCSystem` contract. This structure is here because
+//  the generated contract wrappers from `gen/contract` don't support
+//  `Filter*` methods yet. When the contract generator will support
+//  those methods, the below structure can be removed.
+type TBTCSystemEventLog struct {
 	contract *abi.TBTCSystem
 }
 
-func NewTBTCSystemFilterer(
+func NewTBTCSystemEventLog(
 	contractAddress common.Address,
 	backend bind.ContractBackend,
-) (*TBTCSystemFilterer, error) {
+) (*TBTCSystemEventLog, error) {
 	contract, err := abi.NewTBTCSystem(contractAddress, backend)
 	if err != nil {
 		return nil, err
 	}
 
-	return &TBTCSystemFilterer{contract}, nil
+	return &TBTCSystemEventLog{contract}, nil
 }
 
 type TBTCSystemRedemptionRequested struct {
@@ -39,12 +39,12 @@ type TBTCSystemRedemptionRequested struct {
 	BlockNumber            uint64
 }
 
-func (tsf *TBTCSystemFilterer) FilterRedemptionRequested(
+func (tsel *TBTCSystemEventLog) PastRedemptionRequestedEvents(
 	depositsAddresses []common.Address,
 	startBlock uint64,
 	endBlock *uint64,
 ) ([]*TBTCSystemRedemptionRequested, error) {
-	iterator, err := tsf.contract.FilterRedemptionRequested(
+	iterator, err := tsel.contract.FilterRedemptionRequested(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,

--- a/pkg/chain/ethereum/gen/filterer/TBTCSystemFilterer.go
+++ b/pkg/chain/ethereum/gen/filterer/TBTCSystemFilterer.go
@@ -1,0 +1,79 @@
+package filterer
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	abi "github.com/keep-network/tbtc/pkg/chain/ethereum/gen/abi/system"
+	"math/big"
+)
+
+// FIXME: This is a temporary structure allowing to access past events
+//  emitted by the `TBTCSystemFilterer` contract. This structure is
+//  here because the generated contract wrappers from `gen/contract`
+//  don't support `Filter*` methods yet. When the contract generator
+//  will support those methods, the below structure can be removed.
+type TBTCSystemFilterer struct {
+	contract *abi.TBTCSystem
+}
+
+func NewTBTCSystemFilterer(
+	contractAddress common.Address,
+	backend bind.ContractBackend,
+) (*TBTCSystemFilterer, error) {
+	contract, err := abi.NewTBTCSystem(contractAddress, backend)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TBTCSystemFilterer{contract}, nil
+}
+
+type TBTCSystemRedemptionRequested struct {
+	DepositContractAddress common.Address
+	Requester              common.Address
+	Digest                 [32]byte
+	UtxoValue              *big.Int
+	RedeemerOutputScript   []byte
+	RequestedFee           *big.Int
+	Outpoint               []byte
+}
+
+func (tsf *TBTCSystemFilterer) FilterRedemptionRequested(
+	depositsAddresses []common.Address,
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*TBTCSystemRedemptionRequested, error) {
+	iterator, err := tsf.contract.FilterRedemptionRequested(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+		depositsAddresses,
+		nil,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	events := make([]*TBTCSystemRedemptionRequested, 0)
+
+	for {
+		if !iterator.Next() {
+			break
+		}
+
+		event := iterator.Event
+		events = append(events, &TBTCSystemRedemptionRequested{
+			DepositContractAddress: event.DepositContractAddress,
+			Requester:              event.Requester,
+			Digest:                 event.Digest,
+			UtxoValue:              event.UtxoValue,
+			RedeemerOutputScript:   event.RedeemerOutputScript,
+			RequestedFee:           event.RequestedFee,
+			Outpoint:               event.Outpoint,
+		})
+	}
+
+	return events, nil
+}

--- a/pkg/chain/ethereum/gen/filterer/TBTCSystemFilterer.go
+++ b/pkg/chain/ethereum/gen/filterer/TBTCSystemFilterer.go
@@ -36,6 +36,7 @@ type TBTCSystemRedemptionRequested struct {
 	RedeemerOutputScript   []byte
 	RequestedFee           *big.Int
 	Outpoint               []byte
+	BlockNumber            uint64
 }
 
 func (tsf *TBTCSystemFilterer) FilterRedemptionRequested(
@@ -72,6 +73,7 @@ func (tsf *TBTCSystemFilterer) FilterRedemptionRequested(
 			RedeemerOutputScript:   event.RedeemerOutputScript,
 			RequestedFee:           event.RequestedFee,
 			Outpoint:               event.Outpoint,
+			BlockNumber:            event.Raw.BlockNumber,
 		})
 	}
 


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-ecdsa/issues/574

Added a `TBTCSystemEventLog` allowing to access past events emitted by the `TBTCSystem` contract. This is a temporary workaround because contract bindings generated by the `keep-common` generator don't support this feature yet.