### PR TITLE
Removing prefix bignumber.js@

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -25125,7 +25125,7 @@
       "integrity": "sha1-gewXhBRUkfLqqJVbMcBgSeB8Xn0=",
       "dev": true,
       "requires": {
-        "bignumber.js": "bignumber.js@2.0.7",
+        "bignumber.js": "2.0.7",
         "crypto-js": "^3.1.4",
         "utf8": "^2.1.1",
         "xhr2": "*",


### PR DESCRIPTION
This prefix breaks the installation of npm modules.

npm ERR! code EINVALIDTAGNAME
npm ERR! Invalid tag name "bignumber.js@2.0.7": Tags may not have any characters that encodeURIComponent encodes.

Alternative is to change `scripts/install.sh` and add `rm package-lock.json` before `npm install`