### PR TITLE
Clean node_modules before npm i

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,6 +23,7 @@ KEEP_ECDSA_SOL_ARTIFACTS_PATH=$(realpath $KEEP_ECDSA_SOL_PATH/build/contracts)
 cd $TBTC_SOL_PATH
 
 printf "${LOG_START}Installing NPM dependencies...${LOG_END}"
+rm -rf node_modules
 npm install
 
 printf "${LOG_START}Unlocking ethereum accounts...${LOG_END}"


### PR DESCRIPTION
We experience CI build failures when running e2e tests. Some of the packages in `node_modules` crash the tests. It is safer to clean the `node_modules` first and then `npm i`.