### PR TITLE
Incorporate the `ethlike` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/ethereum/go-ethereum v1.9.10
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85
+	github.com/keep-network/keep-common v1.3.1-0.20210217111137-6949bf58ebd8
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/ethereum/go-ethereum v1.9.10
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6
+	github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/ethereum/go-ethereum v1.9.10
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.3.1-0.20210128152700-34905d2fe019
+	github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/ethereum/go-ethereum v1.9.10
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe
+	github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6
 )

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM5
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
-github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6 h1:dVAaGCTUVdKEwna+lh5rocAHENYLlcnOp/9NleMH2FQ=
-github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85 h1:lQAxWVvkB2tCDP7cl5xo7BDHFJJbU0wwgLuceiTjzKs=
+github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM5
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
-github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe h1:j5wD0t4SRdy23JxwssBVy7IKf2MGWENS02kkU33Z5dc=
-github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6 h1:dVAaGCTUVdKEwna+lh5rocAHENYLlcnOp/9NleMH2FQ=
+github.com/keep-network/keep-common v1.3.1-0.20210210135320-9301b4e728a6/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM5
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
-github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85 h1:lQAxWVvkB2tCDP7cl5xo7BDHFJJbU0wwgLuceiTjzKs=
-github.com/keep-network/keep-common v1.3.1-0.20210216125817-b8472bbfbd85/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.3.1-0.20210217111137-6949bf58ebd8 h1:M+Y3v63yyVDef2CrZbCe4m1QbWg4N6XuI/qwnSTbdsc=
+github.com/keep-network/keep-common v1.3.1-0.20210217111137-6949bf58ebd8/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM5
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
-github.com/keep-network/keep-common v1.3.1-0.20210128152700-34905d2fe019 h1:WBq6cP/N3PFPo25k6AVuM1Hh46GL8DRPr2YzV97quuc=
-github.com/keep-network/keep-common v1.3.1-0.20210128152700-34905d2fe019/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe h1:j5wD0t4SRdy23JxwssBVy7IKf2MGWENS02kkU33Z5dc=
+github.com/keep-network/keep-common v1.3.1-0.20210210114351-64c1c3a75dbe/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=

--- a/pkg/chain/ethereum/gen/contract/TBTCSystem.go
+++ b/pkg/chain/ethereum/gen/contract/TBTCSystem.go
@@ -100,138 +100,16 @@ func NewTBTCSystem(
 // ----- Non-const Methods ------
 
 // Transaction submission.
-func (tbtcs *TBTCSystem) FinalizeEthBtcPriceFeedAddition(
+func (tbtcs *TBTCSystem) BeginEthBtcPriceFeedAddition(
+	_ethBtcPriceFeed common.Address,
 
 	transactionOptions ...ethutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	tbtcsLogger.Debug(
-		"submitting transaction finalizeEthBtcPriceFeedAddition",
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.FinalizeEthBtcPriceFeedAddition(
-		transactorOptions,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"finalizeEthBtcPriceFeedAddition",
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction finalizeEthBtcPriceFeedAddition with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.FinalizeEthBtcPriceFeedAddition(
-				transactorOptions,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"finalizeEthBtcPriceFeedAddition",
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction finalizeEthBtcPriceFeedAddition with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallFinalizeEthBtcPriceFeedAddition(
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"finalizeEthBtcPriceFeedAddition",
-		&result,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) FinalizeEthBtcPriceFeedAdditionGasEstimate() (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"finalizeEthBtcPriceFeedAddition",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) LogFunderRequestedAbort(
-	_abortOutputScript []uint8,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction logFunderRequestedAbort",
+		"submitting transaction beginEthBtcPriceFeedAddition",
 		"params: ",
 		fmt.Sprint(
-			_abortOutputScript,
+			_ethBtcPriceFeed,
 		),
 	)
 
@@ -257,57 +135,57 @@ func (tbtcs *TBTCSystem) LogFunderRequestedAbort(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := tbtcs.contract.LogFunderRequestedAbort(
+	transaction, err := tbtcs.contract.BeginEthBtcPriceFeedAddition(
 		transactorOptions,
-		_abortOutputScript,
+		_ethBtcPriceFeed,
 	)
 	if err != nil {
 		return transaction, tbtcs.errorResolver.ResolveError(
 			err,
 			tbtcs.transactorOptions.From,
 			nil,
-			"logFunderRequestedAbort",
-			_abortOutputScript,
+			"beginEthBtcPriceFeedAddition",
+			_ethBtcPriceFeed,
 		)
 	}
 
 	tbtcsLogger.Infof(
-		"submitted transaction logFunderRequestedAbort with id: [%v] and nonce [%v]",
+		"submitted transaction beginEthBtcPriceFeedAddition with id: [%v] and nonce [%v]",
 		transaction.Hash().Hex(),
 		transaction.Nonce(),
 	)
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
 			transactorOptions.GasLimit = transaction.Gas()
 			transactorOptions.GasPrice = newGasPrice
 
-			transaction, err := tbtcs.contract.LogFunderRequestedAbort(
+			transaction, err := tbtcs.contract.BeginEthBtcPriceFeedAddition(
 				transactorOptions,
-				_abortOutputScript,
+				_ethBtcPriceFeed,
 			)
 			if err != nil {
 				return nil, tbtcs.errorResolver.ResolveError(
 					err,
 					tbtcs.transactorOptions.From,
 					nil,
-					"logFunderRequestedAbort",
-					_abortOutputScript,
+					"beginEthBtcPriceFeedAddition",
+					_ethBtcPriceFeed,
 				)
 			}
 
 			tbtcsLogger.Infof(
-				"submitted transaction logFunderRequestedAbort with id: [%v] and nonce [%v]",
+				"submitted transaction beginEthBtcPriceFeedAddition with id: [%v] and nonce [%v]",
 				transaction.Hash().Hex(),
 				transaction.Nonce(),
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -319,8 +197,8 @@ func (tbtcs *TBTCSystem) LogFunderRequestedAbort(
 }
 
 // Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallLogFunderRequestedAbort(
-	_abortOutputScript []uint8,
+func (tbtcs *TBTCSystem) CallBeginEthBtcPriceFeedAddition(
+	_ethBtcPriceFeed common.Address,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -332,164 +210,42 @@ func (tbtcs *TBTCSystem) CallLogFunderRequestedAbort(
 		tbtcs.caller,
 		tbtcs.errorResolver,
 		tbtcs.contractAddress,
-		"logFunderRequestedAbort",
+		"beginEthBtcPriceFeedAddition",
 		&result,
-		_abortOutputScript,
+		_ethBtcPriceFeed,
 	)
 
 	return err
 }
 
-func (tbtcs *TBTCSystem) LogFunderRequestedAbortGasEstimate(
-	_abortOutputScript []uint8,
+func (tbtcs *TBTCSystem) BeginEthBtcPriceFeedAdditionGasEstimate(
+	_ethBtcPriceFeed common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := ethutil.EstimateGas(
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
-		"logFunderRequestedAbort",
+		"beginEthBtcPriceFeedAddition",
 		tbtcs.contractABI,
 		tbtcs.transactor,
-		_abortOutputScript,
+		_ethBtcPriceFeed,
 	)
 
 	return result, err
 }
 
 // Transaction submission.
-func (tbtcs *TBTCSystem) ResumeNewDeposits(
+func (tbtcs *TBTCSystem) LogCreated(
+	_keepAddress common.Address,
 
 	transactionOptions ...ethutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	tbtcsLogger.Debug(
-		"submitting transaction resumeNewDeposits",
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.ResumeNewDeposits(
-		transactorOptions,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"resumeNewDeposits",
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction resumeNewDeposits with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.ResumeNewDeposits(
-				transactorOptions,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"resumeNewDeposits",
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction resumeNewDeposits with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallResumeNewDeposits(
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"resumeNewDeposits",
-		&result,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) ResumeNewDepositsGasEstimate() (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"resumeNewDeposits",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) BeginLotSizesUpdate(
-	_lotSizes []uint64,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction beginLotSizesUpdate",
+		"submitting transaction logCreated",
 		"params: ",
 		fmt.Sprint(
-			_lotSizes,
+			_keepAddress,
 		),
 	)
 
@@ -515,57 +271,57 @@ func (tbtcs *TBTCSystem) BeginLotSizesUpdate(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := tbtcs.contract.BeginLotSizesUpdate(
+	transaction, err := tbtcs.contract.LogCreated(
 		transactorOptions,
-		_lotSizes,
+		_keepAddress,
 	)
 	if err != nil {
 		return transaction, tbtcs.errorResolver.ResolveError(
 			err,
 			tbtcs.transactorOptions.From,
 			nil,
-			"beginLotSizesUpdate",
-			_lotSizes,
+			"logCreated",
+			_keepAddress,
 		)
 	}
 
 	tbtcsLogger.Infof(
-		"submitted transaction beginLotSizesUpdate with id: [%v] and nonce [%v]",
+		"submitted transaction logCreated with id: [%v] and nonce [%v]",
 		transaction.Hash().Hex(),
 		transaction.Nonce(),
 	)
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
 			transactorOptions.GasLimit = transaction.Gas()
 			transactorOptions.GasPrice = newGasPrice
 
-			transaction, err := tbtcs.contract.BeginLotSizesUpdate(
+			transaction, err := tbtcs.contract.LogCreated(
 				transactorOptions,
-				_lotSizes,
+				_keepAddress,
 			)
 			if err != nil {
 				return nil, tbtcs.errorResolver.ResolveError(
 					err,
 					tbtcs.transactorOptions.From,
 					nil,
-					"beginLotSizesUpdate",
-					_lotSizes,
+					"logCreated",
+					_keepAddress,
 				)
 			}
 
 			tbtcsLogger.Infof(
-				"submitted transaction beginLotSizesUpdate with id: [%v] and nonce [%v]",
+				"submitted transaction logCreated with id: [%v] and nonce [%v]",
 				transaction.Hash().Hex(),
 				transaction.Nonce(),
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -577,8 +333,8 @@ func (tbtcs *TBTCSystem) BeginLotSizesUpdate(
 }
 
 // Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallBeginLotSizesUpdate(
-	_lotSizes []uint64,
+func (tbtcs *TBTCSystem) CallLogCreated(
+	_keepAddress common.Address,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -590,26 +346,298 @@ func (tbtcs *TBTCSystem) CallBeginLotSizesUpdate(
 		tbtcs.caller,
 		tbtcs.errorResolver,
 		tbtcs.contractAddress,
-		"beginLotSizesUpdate",
+		"logCreated",
 		&result,
-		_lotSizes,
+		_keepAddress,
 	)
 
 	return err
 }
 
-func (tbtcs *TBTCSystem) BeginLotSizesUpdateGasEstimate(
-	_lotSizes []uint64,
+func (tbtcs *TBTCSystem) LogCreatedGasEstimate(
+	_keepAddress common.Address,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := ethutil.EstimateGas(
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
-		"beginLotSizesUpdate",
+		"logCreated",
 		tbtcs.contractABI,
 		tbtcs.transactor,
-		_lotSizes,
+		_keepAddress,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) LogRedeemed(
+	_txid [32]uint8,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction logRedeemed",
+		"params: ",
+		fmt.Sprint(
+			_txid,
+		),
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.LogRedeemed(
+		transactorOptions,
+		_txid,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"logRedeemed",
+			_txid,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction logRedeemed with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.LogRedeemed(
+				transactorOptions,
+				_txid,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"logRedeemed",
+					_txid,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction logRedeemed with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallLogRedeemed(
+	_txid [32]uint8,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"logRedeemed",
+		&result,
+		_txid,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) LogRedeemedGasEstimate(
+	_txid [32]uint8,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"logRedeemed",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+		_txid,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) LogFunded(
+	_txid [32]uint8,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction logFunded",
+		"params: ",
+		fmt.Sprint(
+			_txid,
+		),
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.LogFunded(
+		transactorOptions,
+		_txid,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"logFunded",
+			_txid,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction logFunded with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.LogFunded(
+				transactorOptions,
+				_txid,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"logFunded",
+					_txid,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction logFunded with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallLogFunded(
+	_txid [32]uint8,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"logFunded",
+		&result,
+		_txid,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) LogFundedGasEstimate(
+	_txid [32]uint8,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"logFunded",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+		_txid,
 	)
 
 	return result, err
@@ -666,7 +694,7 @@ func (tbtcs *TBTCSystem) EmergencyPauseNewDeposits(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -692,7 +720,7 @@ func (tbtcs *TBTCSystem) EmergencyPauseNewDeposits(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -730,6 +758,128 @@ func (tbtcs *TBTCSystem) EmergencyPauseNewDepositsGasEstimate() (uint64, error) 
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
 		"emergencyPauseNewDeposits",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdate(
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction finalizeSignerFeeDivisorUpdate",
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.FinalizeSignerFeeDivisorUpdate(
+		transactorOptions,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"finalizeSignerFeeDivisorUpdate",
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction finalizeSignerFeeDivisorUpdate with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.FinalizeSignerFeeDivisorUpdate(
+				transactorOptions,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"finalizeSignerFeeDivisorUpdate",
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction finalizeSignerFeeDivisorUpdate with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallFinalizeSignerFeeDivisorUpdate(
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"finalizeSignerFeeDivisorUpdate",
+		&result,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdateGasEstimate() (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"finalizeSignerFeeDivisorUpdate",
 		tbtcs.contractABI,
 		tbtcs.transactor,
 	)
@@ -788,7 +938,7 @@ func (tbtcs *TBTCSystem) LogLiquidated(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -814,7 +964,7 @@ func (tbtcs *TBTCSystem) LogLiquidated(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -852,6 +1002,992 @@ func (tbtcs *TBTCSystem) LogLiquidatedGasEstimate() (uint64, error) {
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
 		"logLiquidated",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) Initialize(
+	_defaultKeepFactory common.Address,
+	_depositFactory common.Address,
+	_masterDepositAddress common.Address,
+	_tbtcToken common.Address,
+	_tbtcDepositToken common.Address,
+	_feeRebateToken common.Address,
+	_vendingMachine common.Address,
+	_keepThreshold uint16,
+	_keepSize uint16,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction initialize",
+		"params: ",
+		fmt.Sprint(
+			_defaultKeepFactory,
+			_depositFactory,
+			_masterDepositAddress,
+			_tbtcToken,
+			_tbtcDepositToken,
+			_feeRebateToken,
+			_vendingMachine,
+			_keepThreshold,
+			_keepSize,
+		),
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.Initialize(
+		transactorOptions,
+		_defaultKeepFactory,
+		_depositFactory,
+		_masterDepositAddress,
+		_tbtcToken,
+		_tbtcDepositToken,
+		_feeRebateToken,
+		_vendingMachine,
+		_keepThreshold,
+		_keepSize,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"initialize",
+			_defaultKeepFactory,
+			_depositFactory,
+			_masterDepositAddress,
+			_tbtcToken,
+			_tbtcDepositToken,
+			_feeRebateToken,
+			_vendingMachine,
+			_keepThreshold,
+			_keepSize,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction initialize with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.Initialize(
+				transactorOptions,
+				_defaultKeepFactory,
+				_depositFactory,
+				_masterDepositAddress,
+				_tbtcToken,
+				_tbtcDepositToken,
+				_feeRebateToken,
+				_vendingMachine,
+				_keepThreshold,
+				_keepSize,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"initialize",
+					_defaultKeepFactory,
+					_depositFactory,
+					_masterDepositAddress,
+					_tbtcToken,
+					_tbtcDepositToken,
+					_feeRebateToken,
+					_vendingMachine,
+					_keepThreshold,
+					_keepSize,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction initialize with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallInitialize(
+	_defaultKeepFactory common.Address,
+	_depositFactory common.Address,
+	_masterDepositAddress common.Address,
+	_tbtcToken common.Address,
+	_tbtcDepositToken common.Address,
+	_feeRebateToken common.Address,
+	_vendingMachine common.Address,
+	_keepThreshold uint16,
+	_keepSize uint16,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"initialize",
+		&result,
+		_defaultKeepFactory,
+		_depositFactory,
+		_masterDepositAddress,
+		_tbtcToken,
+		_tbtcDepositToken,
+		_feeRebateToken,
+		_vendingMachine,
+		_keepThreshold,
+		_keepSize,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) InitializeGasEstimate(
+	_defaultKeepFactory common.Address,
+	_depositFactory common.Address,
+	_masterDepositAddress common.Address,
+	_tbtcToken common.Address,
+	_tbtcDepositToken common.Address,
+	_feeRebateToken common.Address,
+	_vendingMachine common.Address,
+	_keepThreshold uint16,
+	_keepSize uint16,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"initialize",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+		_defaultKeepFactory,
+		_depositFactory,
+		_masterDepositAddress,
+		_tbtcToken,
+		_tbtcDepositToken,
+		_feeRebateToken,
+		_vendingMachine,
+		_keepThreshold,
+		_keepSize,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) ResumeNewDeposits(
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction resumeNewDeposits",
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.ResumeNewDeposits(
+		transactorOptions,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"resumeNewDeposits",
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction resumeNewDeposits with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.ResumeNewDeposits(
+				transactorOptions,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"resumeNewDeposits",
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction resumeNewDeposits with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallResumeNewDeposits(
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"resumeNewDeposits",
+		&result,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) ResumeNewDepositsGasEstimate() (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"resumeNewDeposits",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) TransferOwnership(
+	newOwner common.Address,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction transferOwnership",
+		"params: ",
+		fmt.Sprint(
+			newOwner,
+		),
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.TransferOwnership(
+		transactorOptions,
+		newOwner,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"transferOwnership",
+			newOwner,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction transferOwnership with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.TransferOwnership(
+				transactorOptions,
+				newOwner,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"transferOwnership",
+					newOwner,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction transferOwnership with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallTransferOwnership(
+	newOwner common.Address,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"transferOwnership",
+		&result,
+		newOwner,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) TransferOwnershipGasEstimate(
+	newOwner common.Address,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"transferOwnership",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+		newOwner,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) RefreshMinimumBondableValue(
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction refreshMinimumBondableValue",
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.RefreshMinimumBondableValue(
+		transactorOptions,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"refreshMinimumBondableValue",
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction refreshMinimumBondableValue with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.RefreshMinimumBondableValue(
+				transactorOptions,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"refreshMinimumBondableValue",
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction refreshMinimumBondableValue with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallRefreshMinimumBondableValue(
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"refreshMinimumBondableValue",
+		&result,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) RefreshMinimumBondableValueGasEstimate() (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"refreshMinimumBondableValue",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) LogRegisteredPubkey(
+	_signingGroupPubkeyX [32]uint8,
+	_signingGroupPubkeyY [32]uint8,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction logRegisteredPubkey",
+		"params: ",
+		fmt.Sprint(
+			_signingGroupPubkeyX,
+			_signingGroupPubkeyY,
+		),
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.LogRegisteredPubkey(
+		transactorOptions,
+		_signingGroupPubkeyX,
+		_signingGroupPubkeyY,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"logRegisteredPubkey",
+			_signingGroupPubkeyX,
+			_signingGroupPubkeyY,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction logRegisteredPubkey with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.LogRegisteredPubkey(
+				transactorOptions,
+				_signingGroupPubkeyX,
+				_signingGroupPubkeyY,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"logRegisteredPubkey",
+					_signingGroupPubkeyX,
+					_signingGroupPubkeyY,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction logRegisteredPubkey with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallLogRegisteredPubkey(
+	_signingGroupPubkeyX [32]uint8,
+	_signingGroupPubkeyY [32]uint8,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"logRegisteredPubkey",
+		&result,
+		_signingGroupPubkeyX,
+		_signingGroupPubkeyY,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) LogRegisteredPubkeyGasEstimate(
+	_signingGroupPubkeyX [32]uint8,
+	_signingGroupPubkeyY [32]uint8,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"logRegisteredPubkey",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+		_signingGroupPubkeyX,
+		_signingGroupPubkeyY,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) LogCourtesyCalled(
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction logCourtesyCalled",
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.LogCourtesyCalled(
+		transactorOptions,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"logCourtesyCalled",
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction logCourtesyCalled with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.LogCourtesyCalled(
+				transactorOptions,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"logCourtesyCalled",
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction logCourtesyCalled with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallLogCourtesyCalled(
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"logCourtesyCalled",
+		&result,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) LogCourtesyCalledGasEstimate() (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"logCourtesyCalled",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) LogExitedCourtesyCall(
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction logExitedCourtesyCall",
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.LogExitedCourtesyCall(
+		transactorOptions,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"logExitedCourtesyCall",
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction logExitedCourtesyCall with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.LogExitedCourtesyCall(
+				transactorOptions,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"logExitedCourtesyCall",
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction logExitedCourtesyCall with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallLogExitedCourtesyCall(
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"logExitedCourtesyCall",
+		&result,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) LogExitedCourtesyCallGasEstimate() (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"logExitedCourtesyCall",
 		tbtcs.contractABI,
 		tbtcs.transactor,
 	)
@@ -917,7 +2053,7 @@ func (tbtcs *TBTCSystem) LogStartedLiquidation(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -945,7 +2081,7 @@ func (tbtcs *TBTCSystem) LogStartedLiquidation(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -1046,7 +2182,7 @@ func (tbtcs *TBTCSystem) RenounceOwnership(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -1072,7 +2208,7 @@ func (tbtcs *TBTCSystem) RenounceOwnership(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -1110,724 +2246,6 @@ func (tbtcs *TBTCSystem) RenounceOwnershipGasEstimate() (uint64, error) {
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
 		"renounceOwnership",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) Initialize(
-	_defaultKeepFactory common.Address,
-	_depositFactory common.Address,
-	_masterDepositAddress common.Address,
-	_tbtcToken common.Address,
-	_tbtcDepositToken common.Address,
-	_feeRebateToken common.Address,
-	_vendingMachine common.Address,
-	_keepThreshold uint16,
-	_keepSize uint16,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction initialize",
-		"params: ",
-		fmt.Sprint(
-			_defaultKeepFactory,
-			_depositFactory,
-			_masterDepositAddress,
-			_tbtcToken,
-			_tbtcDepositToken,
-			_feeRebateToken,
-			_vendingMachine,
-			_keepThreshold,
-			_keepSize,
-		),
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.Initialize(
-		transactorOptions,
-		_defaultKeepFactory,
-		_depositFactory,
-		_masterDepositAddress,
-		_tbtcToken,
-		_tbtcDepositToken,
-		_feeRebateToken,
-		_vendingMachine,
-		_keepThreshold,
-		_keepSize,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"initialize",
-			_defaultKeepFactory,
-			_depositFactory,
-			_masterDepositAddress,
-			_tbtcToken,
-			_tbtcDepositToken,
-			_feeRebateToken,
-			_vendingMachine,
-			_keepThreshold,
-			_keepSize,
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction initialize with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.Initialize(
-				transactorOptions,
-				_defaultKeepFactory,
-				_depositFactory,
-				_masterDepositAddress,
-				_tbtcToken,
-				_tbtcDepositToken,
-				_feeRebateToken,
-				_vendingMachine,
-				_keepThreshold,
-				_keepSize,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"initialize",
-					_defaultKeepFactory,
-					_depositFactory,
-					_masterDepositAddress,
-					_tbtcToken,
-					_tbtcDepositToken,
-					_feeRebateToken,
-					_vendingMachine,
-					_keepThreshold,
-					_keepSize,
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction initialize with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallInitialize(
-	_defaultKeepFactory common.Address,
-	_depositFactory common.Address,
-	_masterDepositAddress common.Address,
-	_tbtcToken common.Address,
-	_tbtcDepositToken common.Address,
-	_feeRebateToken common.Address,
-	_vendingMachine common.Address,
-	_keepThreshold uint16,
-	_keepSize uint16,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"initialize",
-		&result,
-		_defaultKeepFactory,
-		_depositFactory,
-		_masterDepositAddress,
-		_tbtcToken,
-		_tbtcDepositToken,
-		_feeRebateToken,
-		_vendingMachine,
-		_keepThreshold,
-		_keepSize,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) InitializeGasEstimate(
-	_defaultKeepFactory common.Address,
-	_depositFactory common.Address,
-	_masterDepositAddress common.Address,
-	_tbtcToken common.Address,
-	_tbtcDepositToken common.Address,
-	_feeRebateToken common.Address,
-	_vendingMachine common.Address,
-	_keepThreshold uint16,
-	_keepSize uint16,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"initialize",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-		_defaultKeepFactory,
-		_depositFactory,
-		_masterDepositAddress,
-		_tbtcToken,
-		_tbtcDepositToken,
-		_feeRebateToken,
-		_vendingMachine,
-		_keepThreshold,
-		_keepSize,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) FinalizeLotSizesUpdate(
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction finalizeLotSizesUpdate",
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.FinalizeLotSizesUpdate(
-		transactorOptions,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"finalizeLotSizesUpdate",
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction finalizeLotSizesUpdate with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.FinalizeLotSizesUpdate(
-				transactorOptions,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"finalizeLotSizesUpdate",
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction finalizeLotSizesUpdate with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallFinalizeLotSizesUpdate(
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"finalizeLotSizesUpdate",
-		&result,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) FinalizeLotSizesUpdateGasEstimate() (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"finalizeLotSizesUpdate",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) LogExitedCourtesyCall(
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction logExitedCourtesyCall",
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.LogExitedCourtesyCall(
-		transactorOptions,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"logExitedCourtesyCall",
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction logExitedCourtesyCall with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.LogExitedCourtesyCall(
-				transactorOptions,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"logExitedCourtesyCall",
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction logExitedCourtesyCall with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallLogExitedCourtesyCall(
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"logExitedCourtesyCall",
-		&result,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) LogExitedCourtesyCallGasEstimate() (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"logExitedCourtesyCall",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) TransferOwnership(
-	newOwner common.Address,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction transferOwnership",
-		"params: ",
-		fmt.Sprint(
-			newOwner,
-		),
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.TransferOwnership(
-		transactorOptions,
-		newOwner,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"transferOwnership",
-			newOwner,
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction transferOwnership with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.TransferOwnership(
-				transactorOptions,
-				newOwner,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"transferOwnership",
-					newOwner,
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction transferOwnership with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallTransferOwnership(
-	newOwner common.Address,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"transferOwnership",
-		&result,
-		newOwner,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) TransferOwnershipGasEstimate(
-	newOwner common.Address,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"transferOwnership",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-		newOwner,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) LogCourtesyCalled(
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction logCourtesyCalled",
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.LogCourtesyCalled(
-		transactorOptions,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"logCourtesyCalled",
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction logCourtesyCalled with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.LogCourtesyCalled(
-				transactorOptions,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"logCourtesyCalled",
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction logCourtesyCalled with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallLogCourtesyCalled(
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"logCourtesyCalled",
-		&result,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) LogCourtesyCalledGasEstimate() (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"logCourtesyCalled",
 		tbtcs.contractABI,
 		tbtcs.transactor,
 	)
@@ -1886,7 +2304,7 @@ func (tbtcs *TBTCSystem) LogFraudDuringSetup(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -1912,7 +2330,7 @@ func (tbtcs *TBTCSystem) LogFraudDuringSetup(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -1950,809 +2368,6 @@ func (tbtcs *TBTCSystem) LogFraudDuringSetupGasEstimate() (uint64, error) {
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
 		"logFraudDuringSetup",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) LogFunded(
-	_txid [32]uint8,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction logFunded",
-		"params: ",
-		fmt.Sprint(
-			_txid,
-		),
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.LogFunded(
-		transactorOptions,
-		_txid,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"logFunded",
-			_txid,
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction logFunded with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.LogFunded(
-				transactorOptions,
-				_txid,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"logFunded",
-					_txid,
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction logFunded with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallLogFunded(
-	_txid [32]uint8,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"logFunded",
-		&result,
-		_txid,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) LogFundedGasEstimate(
-	_txid [32]uint8,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"logFunded",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-		_txid,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) RequestNewKeep(
-	_requestedLotSizeSatoshis uint64,
-	_maxSecuredLifetime *big.Int,
-	value *big.Int,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction requestNewKeep",
-		"params: ",
-		fmt.Sprint(
-			_requestedLotSizeSatoshis,
-			_maxSecuredLifetime,
-		),
-		"value: ", value,
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	transactorOptions.Value = value
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.RequestNewKeep(
-		transactorOptions,
-		_requestedLotSizeSatoshis,
-		_maxSecuredLifetime,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			value,
-			"requestNewKeep",
-			_requestedLotSizeSatoshis,
-			_maxSecuredLifetime,
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction requestNewKeep with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.RequestNewKeep(
-				transactorOptions,
-				_requestedLotSizeSatoshis,
-				_maxSecuredLifetime,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					value,
-					"requestNewKeep",
-					_requestedLotSizeSatoshis,
-					_maxSecuredLifetime,
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction requestNewKeep with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallRequestNewKeep(
-	_requestedLotSizeSatoshis uint64,
-	_maxSecuredLifetime *big.Int,
-	value *big.Int,
-	blockNumber *big.Int,
-) (common.Address, error) {
-	var result common.Address
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, value,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"requestNewKeep",
-		&result,
-		_requestedLotSizeSatoshis,
-		_maxSecuredLifetime,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) RequestNewKeepGasEstimate(
-	_requestedLotSizeSatoshis uint64,
-	_maxSecuredLifetime *big.Int,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"requestNewKeep",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-		_requestedLotSizeSatoshis,
-		_maxSecuredLifetime,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) FinalizeKeepFactoriesUpdate(
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction finalizeKeepFactoriesUpdate",
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.FinalizeKeepFactoriesUpdate(
-		transactorOptions,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"finalizeKeepFactoriesUpdate",
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction finalizeKeepFactoriesUpdate with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.FinalizeKeepFactoriesUpdate(
-				transactorOptions,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"finalizeKeepFactoriesUpdate",
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction finalizeKeepFactoriesUpdate with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallFinalizeKeepFactoriesUpdate(
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"finalizeKeepFactoriesUpdate",
-		&result,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) FinalizeKeepFactoriesUpdateGasEstimate() (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"finalizeKeepFactoriesUpdate",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) LogRedeemed(
-	_txid [32]uint8,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction logRedeemed",
-		"params: ",
-		fmt.Sprint(
-			_txid,
-		),
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.LogRedeemed(
-		transactorOptions,
-		_txid,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"logRedeemed",
-			_txid,
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction logRedeemed with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.LogRedeemed(
-				transactorOptions,
-				_txid,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"logRedeemed",
-					_txid,
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction logRedeemed with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallLogRedeemed(
-	_txid [32]uint8,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"logRedeemed",
-		&result,
-		_txid,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) LogRedeemedGasEstimate(
-	_txid [32]uint8,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"logRedeemed",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-		_txid,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) BeginEthBtcPriceFeedAddition(
-	_ethBtcPriceFeed common.Address,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction beginEthBtcPriceFeedAddition",
-		"params: ",
-		fmt.Sprint(
-			_ethBtcPriceFeed,
-		),
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.BeginEthBtcPriceFeedAddition(
-		transactorOptions,
-		_ethBtcPriceFeed,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"beginEthBtcPriceFeedAddition",
-			_ethBtcPriceFeed,
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction beginEthBtcPriceFeedAddition with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.BeginEthBtcPriceFeedAddition(
-				transactorOptions,
-				_ethBtcPriceFeed,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"beginEthBtcPriceFeedAddition",
-					_ethBtcPriceFeed,
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction beginEthBtcPriceFeedAddition with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallBeginEthBtcPriceFeedAddition(
-	_ethBtcPriceFeed common.Address,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"beginEthBtcPriceFeedAddition",
-		&result,
-		_ethBtcPriceFeed,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) BeginEthBtcPriceFeedAdditionGasEstimate(
-	_ethBtcPriceFeed common.Address,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"beginEthBtcPriceFeedAddition",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-		_ethBtcPriceFeed,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) RefreshMinimumBondableValue(
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction refreshMinimumBondableValue",
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.RefreshMinimumBondableValue(
-		transactorOptions,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"refreshMinimumBondableValue",
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction refreshMinimumBondableValue with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.RefreshMinimumBondableValue(
-				transactorOptions,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"refreshMinimumBondableValue",
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction refreshMinimumBondableValue with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallRefreshMinimumBondableValue(
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"refreshMinimumBondableValue",
-		&result,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) RefreshMinimumBondableValueGasEstimate() (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"refreshMinimumBondableValue",
 		tbtcs.contractABI,
 		tbtcs.transactor,
 	)
@@ -2826,7 +2441,7 @@ func (tbtcs *TBTCSystem) BeginKeepFactoriesUpdate(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -2858,7 +2473,7 @@ func (tbtcs *TBTCSystem) BeginKeepFactoriesUpdate(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -2917,12 +2532,12 @@ func (tbtcs *TBTCSystem) BeginKeepFactoriesUpdateGasEstimate(
 }
 
 // Transaction submission.
-func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdate(
+func (tbtcs *TBTCSystem) FinalizeEthBtcPriceFeedAddition(
 
 	transactionOptions ...ethutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	tbtcsLogger.Debug(
-		"submitting transaction finalizeSignerFeeDivisorUpdate",
+		"submitting transaction finalizeEthBtcPriceFeedAddition",
 	)
 
 	tbtcs.transactionMutex.Lock()
@@ -2947,7 +2562,7 @@ func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdate(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := tbtcs.contract.FinalizeSignerFeeDivisorUpdate(
+	transaction, err := tbtcs.contract.FinalizeEthBtcPriceFeedAddition(
 		transactorOptions,
 	)
 	if err != nil {
@@ -2955,26 +2570,26 @@ func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdate(
 			err,
 			tbtcs.transactorOptions.From,
 			nil,
-			"finalizeSignerFeeDivisorUpdate",
+			"finalizeEthBtcPriceFeedAddition",
 		)
 	}
 
 	tbtcsLogger.Infof(
-		"submitted transaction finalizeSignerFeeDivisorUpdate with id: [%v] and nonce [%v]",
+		"submitted transaction finalizeEthBtcPriceFeedAddition with id: [%v] and nonce [%v]",
 		transaction.Hash().Hex(),
 		transaction.Nonce(),
 	)
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
 			transactorOptions.GasLimit = transaction.Gas()
 			transactorOptions.GasPrice = newGasPrice
 
-			transaction, err := tbtcs.contract.FinalizeSignerFeeDivisorUpdate(
+			transaction, err := tbtcs.contract.FinalizeEthBtcPriceFeedAddition(
 				transactorOptions,
 			)
 			if err != nil {
@@ -2982,18 +2597,18 @@ func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdate(
 					err,
 					tbtcs.transactorOptions.From,
 					nil,
-					"finalizeSignerFeeDivisorUpdate",
+					"finalizeEthBtcPriceFeedAddition",
 				)
 			}
 
 			tbtcsLogger.Infof(
-				"submitted transaction finalizeSignerFeeDivisorUpdate with id: [%v] and nonce [%v]",
+				"submitted transaction finalizeEthBtcPriceFeedAddition with id: [%v] and nonce [%v]",
 				transaction.Hash().Hex(),
 				transaction.Nonce(),
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -3005,7 +2620,7 @@ func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdate(
 }
 
 // Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallFinalizeSignerFeeDivisorUpdate(
+func (tbtcs *TBTCSystem) CallFinalizeEthBtcPriceFeedAddition(
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -3017,20 +2632,20 @@ func (tbtcs *TBTCSystem) CallFinalizeSignerFeeDivisorUpdate(
 		tbtcs.caller,
 		tbtcs.errorResolver,
 		tbtcs.contractAddress,
-		"finalizeSignerFeeDivisorUpdate",
+		"finalizeEthBtcPriceFeedAddition",
 		&result,
 	)
 
 	return err
 }
 
-func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdateGasEstimate() (uint64, error) {
+func (tbtcs *TBTCSystem) FinalizeEthBtcPriceFeedAdditionGasEstimate() (uint64, error) {
 	var result uint64
 
 	result, err := ethutil.EstimateGas(
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
-		"finalizeSignerFeeDivisorUpdate",
+		"finalizeEthBtcPriceFeedAddition",
 		tbtcs.contractABI,
 		tbtcs.transactor,
 	)
@@ -3039,17 +2654,12 @@ func (tbtcs *TBTCSystem) FinalizeSignerFeeDivisorUpdateGasEstimate() (uint64, er
 }
 
 // Transaction submission.
-func (tbtcs *TBTCSystem) BeginSignerFeeDivisorUpdate(
-	_signerFeeDivisor uint16,
+func (tbtcs *TBTCSystem) FinalizeLotSizesUpdate(
 
 	transactionOptions ...ethutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	tbtcsLogger.Debug(
-		"submitting transaction beginSignerFeeDivisorUpdate",
-		"params: ",
-		fmt.Sprint(
-			_signerFeeDivisor,
-		),
+		"submitting transaction finalizeLotSizesUpdate",
 	)
 
 	tbtcs.transactionMutex.Lock()
@@ -3074,57 +2684,53 @@ func (tbtcs *TBTCSystem) BeginSignerFeeDivisorUpdate(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := tbtcs.contract.BeginSignerFeeDivisorUpdate(
+	transaction, err := tbtcs.contract.FinalizeLotSizesUpdate(
 		transactorOptions,
-		_signerFeeDivisor,
 	)
 	if err != nil {
 		return transaction, tbtcs.errorResolver.ResolveError(
 			err,
 			tbtcs.transactorOptions.From,
 			nil,
-			"beginSignerFeeDivisorUpdate",
-			_signerFeeDivisor,
+			"finalizeLotSizesUpdate",
 		)
 	}
 
 	tbtcsLogger.Infof(
-		"submitted transaction beginSignerFeeDivisorUpdate with id: [%v] and nonce [%v]",
+		"submitted transaction finalizeLotSizesUpdate with id: [%v] and nonce [%v]",
 		transaction.Hash().Hex(),
 		transaction.Nonce(),
 	)
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
 			transactorOptions.GasLimit = transaction.Gas()
 			transactorOptions.GasPrice = newGasPrice
 
-			transaction, err := tbtcs.contract.BeginSignerFeeDivisorUpdate(
+			transaction, err := tbtcs.contract.FinalizeLotSizesUpdate(
 				transactorOptions,
-				_signerFeeDivisor,
 			)
 			if err != nil {
 				return nil, tbtcs.errorResolver.ResolveError(
 					err,
 					tbtcs.transactorOptions.From,
 					nil,
-					"beginSignerFeeDivisorUpdate",
-					_signerFeeDivisor,
+					"finalizeLotSizesUpdate",
 				)
 			}
 
 			tbtcsLogger.Infof(
-				"submitted transaction beginSignerFeeDivisorUpdate with id: [%v] and nonce [%v]",
+				"submitted transaction finalizeLotSizesUpdate with id: [%v] and nonce [%v]",
 				transaction.Hash().Hex(),
 				transaction.Nonce(),
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -3136,8 +2742,7 @@ func (tbtcs *TBTCSystem) BeginSignerFeeDivisorUpdate(
 }
 
 // Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallBeginSignerFeeDivisorUpdate(
-	_signerFeeDivisor uint16,
+func (tbtcs *TBTCSystem) CallFinalizeLotSizesUpdate(
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -3149,26 +2754,173 @@ func (tbtcs *TBTCSystem) CallBeginSignerFeeDivisorUpdate(
 		tbtcs.caller,
 		tbtcs.errorResolver,
 		tbtcs.contractAddress,
-		"beginSignerFeeDivisorUpdate",
+		"finalizeLotSizesUpdate",
 		&result,
-		_signerFeeDivisor,
 	)
 
 	return err
 }
 
-func (tbtcs *TBTCSystem) BeginSignerFeeDivisorUpdateGasEstimate(
-	_signerFeeDivisor uint16,
+func (tbtcs *TBTCSystem) FinalizeLotSizesUpdateGasEstimate() (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"finalizeLotSizesUpdate",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) RequestNewKeep(
+	_requestedLotSizeSatoshis uint64,
+	_maxSecuredLifetime *big.Int,
+	value *big.Int,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction requestNewKeep",
+		"params: ",
+		fmt.Sprint(
+			_requestedLotSizeSatoshis,
+			_maxSecuredLifetime,
+		),
+		"value: ", value,
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	transactorOptions.Value = value
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.RequestNewKeep(
+		transactorOptions,
+		_requestedLotSizeSatoshis,
+		_maxSecuredLifetime,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			value,
+			"requestNewKeep",
+			_requestedLotSizeSatoshis,
+			_maxSecuredLifetime,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction requestNewKeep with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.RequestNewKeep(
+				transactorOptions,
+				_requestedLotSizeSatoshis,
+				_maxSecuredLifetime,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					value,
+					"requestNewKeep",
+					_requestedLotSizeSatoshis,
+					_maxSecuredLifetime,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction requestNewKeep with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallRequestNewKeep(
+	_requestedLotSizeSatoshis uint64,
+	_maxSecuredLifetime *big.Int,
+	value *big.Int,
+	blockNumber *big.Int,
+) (common.Address, error) {
+	var result common.Address
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, value,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"requestNewKeep",
+		&result,
+		_requestedLotSizeSatoshis,
+		_maxSecuredLifetime,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) RequestNewKeepGasEstimate(
+	_requestedLotSizeSatoshis uint64,
+	_maxSecuredLifetime *big.Int,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := ethutil.EstimateGas(
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
-		"beginSignerFeeDivisorUpdate",
+		"requestNewKeep",
 		tbtcs.contractABI,
 		tbtcs.transactor,
-		_signerFeeDivisor,
+		_requestedLotSizeSatoshis,
+		_maxSecuredLifetime,
 	)
 
 	return result, err
@@ -3240,7 +2992,7 @@ func (tbtcs *TBTCSystem) BeginCollateralizationThresholdsUpdate(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -3272,7 +3024,7 @@ func (tbtcs *TBTCSystem) BeginCollateralizationThresholdsUpdate(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -3331,16 +3083,16 @@ func (tbtcs *TBTCSystem) BeginCollateralizationThresholdsUpdateGasEstimate(
 }
 
 // Transaction submission.
-func (tbtcs *TBTCSystem) LogCreated(
-	_keepAddress common.Address,
+func (tbtcs *TBTCSystem) BeginLotSizesUpdate(
+	_lotSizes []uint64,
 
 	transactionOptions ...ethutil.TransactionOptions,
 ) (*types.Transaction, error) {
 	tbtcsLogger.Debug(
-		"submitting transaction logCreated",
+		"submitting transaction beginLotSizesUpdate",
 		"params: ",
 		fmt.Sprint(
-			_keepAddress,
+			_lotSizes,
 		),
 	)
 
@@ -3366,57 +3118,57 @@ func (tbtcs *TBTCSystem) LogCreated(
 
 	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
 
-	transaction, err := tbtcs.contract.LogCreated(
+	transaction, err := tbtcs.contract.BeginLotSizesUpdate(
 		transactorOptions,
-		_keepAddress,
+		_lotSizes,
 	)
 	if err != nil {
 		return transaction, tbtcs.errorResolver.ResolveError(
 			err,
 			tbtcs.transactorOptions.From,
 			nil,
-			"logCreated",
-			_keepAddress,
+			"beginLotSizesUpdate",
+			_lotSizes,
 		)
 	}
 
 	tbtcsLogger.Infof(
-		"submitted transaction logCreated with id: [%v] and nonce [%v]",
+		"submitted transaction beginLotSizesUpdate with id: [%v] and nonce [%v]",
 		transaction.Hash().Hex(),
 		transaction.Nonce(),
 	)
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
 			transactorOptions.GasLimit = transaction.Gas()
 			transactorOptions.GasPrice = newGasPrice
 
-			transaction, err := tbtcs.contract.LogCreated(
+			transaction, err := tbtcs.contract.BeginLotSizesUpdate(
 				transactorOptions,
-				_keepAddress,
+				_lotSizes,
 			)
 			if err != nil {
 				return nil, tbtcs.errorResolver.ResolveError(
 					err,
 					tbtcs.transactorOptions.From,
 					nil,
-					"logCreated",
-					_keepAddress,
+					"beginLotSizesUpdate",
+					_lotSizes,
 				)
 			}
 
 			tbtcsLogger.Infof(
-				"submitted transaction logCreated with id: [%v] and nonce [%v]",
+				"submitted transaction beginLotSizesUpdate with id: [%v] and nonce [%v]",
 				transaction.Hash().Hex(),
 				transaction.Nonce(),
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -3428,8 +3180,8 @@ func (tbtcs *TBTCSystem) LogCreated(
 }
 
 // Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallLogCreated(
-	_keepAddress common.Address,
+func (tbtcs *TBTCSystem) CallBeginLotSizesUpdate(
+	_lotSizes []uint64,
 	blockNumber *big.Int,
 ) error {
 	var result interface{} = nil
@@ -3441,26 +3193,698 @@ func (tbtcs *TBTCSystem) CallLogCreated(
 		tbtcs.caller,
 		tbtcs.errorResolver,
 		tbtcs.contractAddress,
-		"logCreated",
+		"beginLotSizesUpdate",
 		&result,
-		_keepAddress,
+		_lotSizes,
 	)
 
 	return err
 }
 
-func (tbtcs *TBTCSystem) LogCreatedGasEstimate(
-	_keepAddress common.Address,
+func (tbtcs *TBTCSystem) BeginLotSizesUpdateGasEstimate(
+	_lotSizes []uint64,
 ) (uint64, error) {
 	var result uint64
 
 	result, err := ethutil.EstimateGas(
 		tbtcs.callerOptions.From,
 		tbtcs.contractAddress,
-		"logCreated",
+		"beginLotSizesUpdate",
 		tbtcs.contractABI,
 		tbtcs.transactor,
-		_keepAddress,
+		_lotSizes,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) BeginSignerFeeDivisorUpdate(
+	_signerFeeDivisor uint16,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction beginSignerFeeDivisorUpdate",
+		"params: ",
+		fmt.Sprint(
+			_signerFeeDivisor,
+		),
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.BeginSignerFeeDivisorUpdate(
+		transactorOptions,
+		_signerFeeDivisor,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"beginSignerFeeDivisorUpdate",
+			_signerFeeDivisor,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction beginSignerFeeDivisorUpdate with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.BeginSignerFeeDivisorUpdate(
+				transactorOptions,
+				_signerFeeDivisor,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"beginSignerFeeDivisorUpdate",
+					_signerFeeDivisor,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction beginSignerFeeDivisorUpdate with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallBeginSignerFeeDivisorUpdate(
+	_signerFeeDivisor uint16,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"beginSignerFeeDivisorUpdate",
+		&result,
+		_signerFeeDivisor,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) BeginSignerFeeDivisorUpdateGasEstimate(
+	_signerFeeDivisor uint16,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"beginSignerFeeDivisorUpdate",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+		_signerFeeDivisor,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) FinalizeKeepFactoriesUpdate(
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction finalizeKeepFactoriesUpdate",
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.FinalizeKeepFactoriesUpdate(
+		transactorOptions,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"finalizeKeepFactoriesUpdate",
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction finalizeKeepFactoriesUpdate with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.FinalizeKeepFactoriesUpdate(
+				transactorOptions,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"finalizeKeepFactoriesUpdate",
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction finalizeKeepFactoriesUpdate with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallFinalizeKeepFactoriesUpdate(
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"finalizeKeepFactoriesUpdate",
+		&result,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) FinalizeKeepFactoriesUpdateGasEstimate() (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"finalizeKeepFactoriesUpdate",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) LogFunderRequestedAbort(
+	_abortOutputScript []uint8,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction logFunderRequestedAbort",
+		"params: ",
+		fmt.Sprint(
+			_abortOutputScript,
+		),
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.LogFunderRequestedAbort(
+		transactorOptions,
+		_abortOutputScript,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"logFunderRequestedAbort",
+			_abortOutputScript,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction logFunderRequestedAbort with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.LogFunderRequestedAbort(
+				transactorOptions,
+				_abortOutputScript,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"logFunderRequestedAbort",
+					_abortOutputScript,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction logFunderRequestedAbort with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallLogFunderRequestedAbort(
+	_abortOutputScript []uint8,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"logFunderRequestedAbort",
+		&result,
+		_abortOutputScript,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) LogFunderRequestedAbortGasEstimate(
+	_abortOutputScript []uint8,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"logFunderRequestedAbort",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+		_abortOutputScript,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) LogGotRedemptionSignature(
+	_digest [32]uint8,
+	_r [32]uint8,
+	_s [32]uint8,
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction logGotRedemptionSignature",
+		"params: ",
+		fmt.Sprint(
+			_digest,
+			_r,
+			_s,
+		),
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.LogGotRedemptionSignature(
+		transactorOptions,
+		_digest,
+		_r,
+		_s,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"logGotRedemptionSignature",
+			_digest,
+			_r,
+			_s,
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction logGotRedemptionSignature with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.LogGotRedemptionSignature(
+				transactorOptions,
+				_digest,
+				_r,
+				_s,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"logGotRedemptionSignature",
+					_digest,
+					_r,
+					_s,
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction logGotRedemptionSignature with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallLogGotRedemptionSignature(
+	_digest [32]uint8,
+	_r [32]uint8,
+	_s [32]uint8,
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"logGotRedemptionSignature",
+		&result,
+		_digest,
+		_r,
+		_s,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) LogGotRedemptionSignatureGasEstimate(
+	_digest [32]uint8,
+	_r [32]uint8,
+	_s [32]uint8,
+) (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"logGotRedemptionSignature",
+		tbtcs.contractABI,
+		tbtcs.transactor,
+		_digest,
+		_r,
+		_s,
+	)
+
+	return result, err
+}
+
+// Transaction submission.
+func (tbtcs *TBTCSystem) FinalizeCollateralizationThresholdsUpdate(
+
+	transactionOptions ...ethutil.TransactionOptions,
+) (*types.Transaction, error) {
+	tbtcsLogger.Debug(
+		"submitting transaction finalizeCollateralizationThresholdsUpdate",
+	)
+
+	tbtcs.transactionMutex.Lock()
+	defer tbtcs.transactionMutex.Unlock()
+
+	// create a copy
+	transactorOptions := new(bind.TransactOpts)
+	*transactorOptions = *tbtcs.transactorOptions
+
+	if len(transactionOptions) > 1 {
+		return nil, fmt.Errorf(
+			"could not process multiple transaction options sets",
+		)
+	} else if len(transactionOptions) > 0 {
+		transactionOptions[0].Apply(transactorOptions)
+	}
+
+	nonce, err := tbtcs.nonceManager.CurrentNonce()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
+	}
+
+	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
+
+	transaction, err := tbtcs.contract.FinalizeCollateralizationThresholdsUpdate(
+		transactorOptions,
+	)
+	if err != nil {
+		return transaction, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.transactorOptions.From,
+			nil,
+			"finalizeCollateralizationThresholdsUpdate",
+		)
+	}
+
+	tbtcsLogger.Infof(
+		"submitted transaction finalizeCollateralizationThresholdsUpdate with id: [%v] and nonce [%v]",
+		transaction.Hash().Hex(),
+		transaction.Nonce(),
+	)
+
+	go tbtcs.miningWaiter.ForceMining(
+		&ethlike.Transaction{
+			Hash:     ethlike.Hash(transaction.Hash()),
+			GasPrice: transaction.GasPrice(),
+		},
+		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
+			transactorOptions.GasLimit = transaction.Gas()
+			transactorOptions.GasPrice = newGasPrice
+
+			transaction, err := tbtcs.contract.FinalizeCollateralizationThresholdsUpdate(
+				transactorOptions,
+			)
+			if err != nil {
+				return nil, tbtcs.errorResolver.ResolveError(
+					err,
+					tbtcs.transactorOptions.From,
+					nil,
+					"finalizeCollateralizationThresholdsUpdate",
+				)
+			}
+
+			tbtcsLogger.Infof(
+				"submitted transaction finalizeCollateralizationThresholdsUpdate with id: [%v] and nonce [%v]",
+				transaction.Hash().Hex(),
+				transaction.Nonce(),
+			)
+
+			return &ethlike.Transaction{
+				Hash:     ethlike.Hash(transaction.Hash()),
+				GasPrice: transaction.GasPrice(),
+			}, nil
+		},
+	)
+
+	tbtcs.nonceManager.IncrementNonce()
+
+	return transaction, err
+}
+
+// Non-mutating call, not a transaction submission.
+func (tbtcs *TBTCSystem) CallFinalizeCollateralizationThresholdsUpdate(
+	blockNumber *big.Int,
+) error {
+	var result interface{} = nil
+
+	err := ethutil.CallAtBlock(
+		tbtcs.transactorOptions.From,
+		blockNumber, nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"finalizeCollateralizationThresholdsUpdate",
+		&result,
+	)
+
+	return err
+}
+
+func (tbtcs *TBTCSystem) FinalizeCollateralizationThresholdsUpdateGasEstimate() (uint64, error) {
+	var result uint64
+
+	result, err := ethutil.EstimateGas(
+		tbtcs.callerOptions.From,
+		tbtcs.contractAddress,
+		"finalizeCollateralizationThresholdsUpdate",
+		tbtcs.contractABI,
+		tbtcs.transactor,
 	)
 
 	return result, err
@@ -3544,7 +3968,7 @@ func (tbtcs *TBTCSystem) LogRedemptionRequested(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -3582,7 +4006,7 @@ func (tbtcs *TBTCSystem) LogRedemptionRequested(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -3703,7 +4127,7 @@ func (tbtcs *TBTCSystem) LogSetupFailed(
 
 	go tbtcs.miningWaiter.ForceMining(
 		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
+			Hash:     ethlike.Hash(transaction.Hash()),
 			GasPrice: transaction.GasPrice(),
 		},
 		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
@@ -3729,7 +4153,7 @@ func (tbtcs *TBTCSystem) LogSetupFailed(
 			)
 
 			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
+				Hash:     ethlike.Hash(transaction.Hash()),
 				GasPrice: transaction.GasPrice(),
 			}, nil
 		},
@@ -3774,431 +4198,45 @@ func (tbtcs *TBTCSystem) LogSetupFailedGasEstimate() (uint64, error) {
 	return result, err
 }
 
-// Transaction submission.
-func (tbtcs *TBTCSystem) FinalizeCollateralizationThresholdsUpdate(
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction finalizeCollateralizationThresholdsUpdate",
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.FinalizeCollateralizationThresholdsUpdate(
-		transactorOptions,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"finalizeCollateralizationThresholdsUpdate",
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction finalizeCollateralizationThresholdsUpdate with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.FinalizeCollateralizationThresholdsUpdate(
-				transactorOptions,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"finalizeCollateralizationThresholdsUpdate",
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction finalizeCollateralizationThresholdsUpdate with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallFinalizeCollateralizationThresholdsUpdate(
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"finalizeCollateralizationThresholdsUpdate",
-		&result,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) FinalizeCollateralizationThresholdsUpdateGasEstimate() (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"finalizeCollateralizationThresholdsUpdate",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) LogGotRedemptionSignature(
-	_digest [32]uint8,
-	_r [32]uint8,
-	_s [32]uint8,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction logGotRedemptionSignature",
-		"params: ",
-		fmt.Sprint(
-			_digest,
-			_r,
-			_s,
-		),
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.LogGotRedemptionSignature(
-		transactorOptions,
-		_digest,
-		_r,
-		_s,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"logGotRedemptionSignature",
-			_digest,
-			_r,
-			_s,
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction logGotRedemptionSignature with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.LogGotRedemptionSignature(
-				transactorOptions,
-				_digest,
-				_r,
-				_s,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"logGotRedemptionSignature",
-					_digest,
-					_r,
-					_s,
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction logGotRedemptionSignature with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallLogGotRedemptionSignature(
-	_digest [32]uint8,
-	_r [32]uint8,
-	_s [32]uint8,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"logGotRedemptionSignature",
-		&result,
-		_digest,
-		_r,
-		_s,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) LogGotRedemptionSignatureGasEstimate(
-	_digest [32]uint8,
-	_r [32]uint8,
-	_s [32]uint8,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"logGotRedemptionSignature",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-		_digest,
-		_r,
-		_s,
-	)
-
-	return result, err
-}
-
-// Transaction submission.
-func (tbtcs *TBTCSystem) LogRegisteredPubkey(
-	_signingGroupPubkeyX [32]uint8,
-	_signingGroupPubkeyY [32]uint8,
-
-	transactionOptions ...ethutil.TransactionOptions,
-) (*types.Transaction, error) {
-	tbtcsLogger.Debug(
-		"submitting transaction logRegisteredPubkey",
-		"params: ",
-		fmt.Sprint(
-			_signingGroupPubkeyX,
-			_signingGroupPubkeyY,
-		),
-	)
-
-	tbtcs.transactionMutex.Lock()
-	defer tbtcs.transactionMutex.Unlock()
-
-	// create a copy
-	transactorOptions := new(bind.TransactOpts)
-	*transactorOptions = *tbtcs.transactorOptions
-
-	if len(transactionOptions) > 1 {
-		return nil, fmt.Errorf(
-			"could not process multiple transaction options sets",
-		)
-	} else if len(transactionOptions) > 0 {
-		transactionOptions[0].Apply(transactorOptions)
-	}
-
-	nonce, err := tbtcs.nonceManager.CurrentNonce()
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve account nonce: %v", err)
-	}
-
-	transactorOptions.Nonce = new(big.Int).SetUint64(nonce)
-
-	transaction, err := tbtcs.contract.LogRegisteredPubkey(
-		transactorOptions,
-		_signingGroupPubkeyX,
-		_signingGroupPubkeyY,
-	)
-	if err != nil {
-		return transaction, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.transactorOptions.From,
-			nil,
-			"logRegisteredPubkey",
-			_signingGroupPubkeyX,
-			_signingGroupPubkeyY,
-		)
-	}
-
-	tbtcsLogger.Infof(
-		"submitted transaction logRegisteredPubkey with id: [%v] and nonce [%v]",
-		transaction.Hash().Hex(),
-		transaction.Nonce(),
-	)
-
-	go tbtcs.miningWaiter.ForceMining(
-		&ethlike.Transaction{
-			Hash:     transaction.Hash().Hex(),
-			GasPrice: transaction.GasPrice(),
-		},
-		func(newGasPrice *big.Int) (*ethlike.Transaction, error) {
-			transactorOptions.GasLimit = transaction.Gas()
-			transactorOptions.GasPrice = newGasPrice
-
-			transaction, err := tbtcs.contract.LogRegisteredPubkey(
-				transactorOptions,
-				_signingGroupPubkeyX,
-				_signingGroupPubkeyY,
-			)
-			if err != nil {
-				return nil, tbtcs.errorResolver.ResolveError(
-					err,
-					tbtcs.transactorOptions.From,
-					nil,
-					"logRegisteredPubkey",
-					_signingGroupPubkeyX,
-					_signingGroupPubkeyY,
-				)
-			}
-
-			tbtcsLogger.Infof(
-				"submitted transaction logRegisteredPubkey with id: [%v] and nonce [%v]",
-				transaction.Hash().Hex(),
-				transaction.Nonce(),
-			)
-
-			return &ethlike.Transaction{
-				Hash:     transaction.Hash().Hex(),
-				GasPrice: transaction.GasPrice(),
-			}, nil
-		},
-	)
-
-	tbtcs.nonceManager.IncrementNonce()
-
-	return transaction, err
-}
-
-// Non-mutating call, not a transaction submission.
-func (tbtcs *TBTCSystem) CallLogRegisteredPubkey(
-	_signingGroupPubkeyX [32]uint8,
-	_signingGroupPubkeyY [32]uint8,
-	blockNumber *big.Int,
-) error {
-	var result interface{} = nil
-
-	err := ethutil.CallAtBlock(
-		tbtcs.transactorOptions.From,
-		blockNumber, nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"logRegisteredPubkey",
-		&result,
-		_signingGroupPubkeyX,
-		_signingGroupPubkeyY,
-	)
-
-	return err
-}
-
-func (tbtcs *TBTCSystem) LogRegisteredPubkeyGasEstimate(
-	_signingGroupPubkeyX [32]uint8,
-	_signingGroupPubkeyY [32]uint8,
-) (uint64, error) {
-	var result uint64
-
-	result, err := ethutil.EstimateGas(
-		tbtcs.callerOptions.From,
-		tbtcs.contractAddress,
-		"logRegisteredPubkey",
-		tbtcs.contractABI,
-		tbtcs.transactor,
-		_signingGroupPubkeyX,
-		_signingGroupPubkeyY,
-	)
-
-	return result, err
-}
-
 // ----- Const Methods ------
+
+func (tbtcs *TBTCSystem) GetRemainingCollateralizationThresholdsUpdateTime() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.GetRemainingCollateralizationThresholdsUpdateTime(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getRemainingCollateralizationThresholdsUpdateTime",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetRemainingCollateralizationThresholdsUpdateTimeAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getRemainingCollateralizationThresholdsUpdateTime",
+		&result,
+	)
+
+	return result, err
+}
 
 func (tbtcs *TBTCSystem) IsAllowedLotSize(
 	_requestedLotSizeSatoshis uint64,
@@ -4239,544 +4277,6 @@ func (tbtcs *TBTCSystem) IsAllowedLotSizeAtBlock(
 		"isAllowedLotSize",
 		&result,
 		_requestedLotSizeSatoshis,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetRemainingCollateralizationThresholdsUpdateTime() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.GetRemainingCollateralizationThresholdsUpdateTime(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getRemainingCollateralizationThresholdsUpdateTime",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetRemainingCollateralizationThresholdsUpdateTimeAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getRemainingCollateralizationThresholdsUpdateTime",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetRemainingKeepFactoriesUpdateTime() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.GetRemainingKeepFactoriesUpdateTime(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getRemainingKeepFactoriesUpdateTime",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetRemainingKeepFactoriesUpdateTimeAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getRemainingKeepFactoriesUpdateTime",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) Owner() (common.Address, error) {
-	var result common.Address
-	result, err := tbtcs.contract.Owner(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"owner",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) OwnerAtBlock(
-	blockNumber *big.Int,
-) (common.Address, error) {
-	var result common.Address
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"owner",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) ApprovedToLog(
-	_caller common.Address,
-) (bool, error) {
-	var result bool
-	result, err := tbtcs.contract.ApprovedToLog(
-		tbtcs.callerOptions,
-		_caller,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"approvedToLog",
-			_caller,
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) ApprovedToLogAtBlock(
-	_caller common.Address,
-	blockNumber *big.Int,
-) (bool, error) {
-	var result bool
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"approvedToLog",
-		&result,
-		_caller,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) Relay() (common.Address, error) {
-	var result common.Address
-	result, err := tbtcs.contract.Relay(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"relay",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) RelayAtBlock(
-	blockNumber *big.Int,
-) (common.Address, error) {
-	var result common.Address
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"relay",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetSeverelyUndercollateralizedThresholdPercent() (uint16, error) {
-	var result uint16
-	result, err := tbtcs.contract.GetSeverelyUndercollateralizedThresholdPercent(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getSeverelyUndercollateralizedThresholdPercent",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetSeverelyUndercollateralizedThresholdPercentAtBlock(
-	blockNumber *big.Int,
-) (uint16, error) {
-	var result uint16
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getSeverelyUndercollateralizedThresholdPercent",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) IsOwner() (bool, error) {
-	var result bool
-	result, err := tbtcs.contract.IsOwner(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"isOwner",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) IsOwnerAtBlock(
-	blockNumber *big.Int,
-) (bool, error) {
-	var result bool
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"isOwner",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetMinimumLotSize() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.GetMinimumLotSize(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getMinimumLotSize",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetMinimumLotSizeAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getMinimumLotSize",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) PriceFeed() (common.Address, error) {
-	var result common.Address
-	result, err := tbtcs.contract.PriceFeed(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"priceFeed",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) PriceFeedAtBlock(
-	blockNumber *big.Int,
-) (common.Address, error) {
-	var result common.Address
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"priceFeed",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) FetchRelayPreviousDifficulty() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.FetchRelayPreviousDifficulty(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"fetchRelayPreviousDifficulty",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) FetchRelayPreviousDifficultyAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"fetchRelayPreviousDifficulty",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetAllowNewDeposits() (bool, error) {
-	var result bool
-	result, err := tbtcs.contract.GetAllowNewDeposits(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getAllowNewDeposits",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetAllowNewDepositsAtBlock(
-	blockNumber *big.Int,
-) (bool, error) {
-	var result bool
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getAllowNewDeposits",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) KeepSize() (uint16, error) {
-	var result uint16
-	result, err := tbtcs.contract.KeepSize(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"keepSize",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) KeepSizeAtBlock(
-	blockNumber *big.Int,
-) (uint16, error) {
-	var result uint16
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"keepSize",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetAllowedLotSizes() ([]uint64, error) {
-	var result []uint64
-	result, err := tbtcs.contract.GetAllowedLotSizes(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getAllowedLotSizes",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetAllowedLotSizesAtBlock(
-	blockNumber *big.Int,
-) ([]uint64, error) {
-	var result []uint64
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getAllowedLotSizes",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetPriceFeedGovernanceTimeDelay() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.GetPriceFeedGovernanceTimeDelay(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getPriceFeedGovernanceTimeDelay",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetPriceFeedGovernanceTimeDelayAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getPriceFeedGovernanceTimeDelay",
-		&result,
 	)
 
 	return result, err
@@ -4896,6 +4396,582 @@ func (tbtcs *TBTCSystem) GetRemainingKeepFactoriesUpgradeabilityTimeAtBlock(
 	return result, err
 }
 
+func (tbtcs *TBTCSystem) KeepSize() (uint16, error) {
+	var result uint16
+	result, err := tbtcs.contract.KeepSize(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"keepSize",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) KeepSizeAtBlock(
+	blockNumber *big.Int,
+) (uint16, error) {
+	var result uint16
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"keepSize",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetRemainingKeepFactoriesUpdateTime() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.GetRemainingKeepFactoriesUpdateTime(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getRemainingKeepFactoriesUpdateTime",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetRemainingKeepFactoriesUpdateTimeAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getRemainingKeepFactoriesUpdateTime",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetSeverelyUndercollateralizedThresholdPercent() (uint16, error) {
+	var result uint16
+	result, err := tbtcs.contract.GetSeverelyUndercollateralizedThresholdPercent(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getSeverelyUndercollateralizedThresholdPercent",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetSeverelyUndercollateralizedThresholdPercentAtBlock(
+	blockNumber *big.Int,
+) (uint16, error) {
+	var result uint16
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getSeverelyUndercollateralizedThresholdPercent",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) FetchRelayCurrentDifficulty() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.FetchRelayCurrentDifficulty(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"fetchRelayCurrentDifficulty",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) FetchRelayCurrentDifficultyAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"fetchRelayCurrentDifficulty",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetRemainingLotSizesUpdateTime() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.GetRemainingLotSizesUpdateTime(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getRemainingLotSizesUpdateTime",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetRemainingLotSizesUpdateTimeAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getRemainingLotSizesUpdateTime",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) Relay() (common.Address, error) {
+	var result common.Address
+	result, err := tbtcs.contract.Relay(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"relay",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) RelayAtBlock(
+	blockNumber *big.Int,
+) (common.Address, error) {
+	var result common.Address
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"relay",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetMaximumLotSize() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.GetMaximumLotSize(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getMaximumLotSize",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetMaximumLotSizeAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getMaximumLotSize",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetUndercollateralizedThresholdPercent() (uint16, error) {
+	var result uint16
+	result, err := tbtcs.contract.GetUndercollateralizedThresholdPercent(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getUndercollateralizedThresholdPercent",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetUndercollateralizedThresholdPercentAtBlock(
+	blockNumber *big.Int,
+) (uint16, error) {
+	var result uint16
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getUndercollateralizedThresholdPercent",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) ApprovedToLog(
+	_caller common.Address,
+) (bool, error) {
+	var result bool
+	result, err := tbtcs.contract.ApprovedToLog(
+		tbtcs.callerOptions,
+		_caller,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"approvedToLog",
+			_caller,
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) ApprovedToLogAtBlock(
+	_caller common.Address,
+	blockNumber *big.Int,
+) (bool, error) {
+	var result bool
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"approvedToLog",
+		&result,
+		_caller,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetSignerFeeDivisor() (uint16, error) {
+	var result uint16
+	result, err := tbtcs.contract.GetSignerFeeDivisor(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getSignerFeeDivisor",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetSignerFeeDivisorAtBlock(
+	blockNumber *big.Int,
+) (uint16, error) {
+	var result uint16
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getSignerFeeDivisor",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetMinimumLotSize() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.GetMinimumLotSize(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getMinimumLotSize",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetMinimumLotSizeAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getMinimumLotSize",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) IsOwner() (bool, error) {
+	var result bool
+	result, err := tbtcs.contract.IsOwner(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"isOwner",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) IsOwnerAtBlock(
+	blockNumber *big.Int,
+) (bool, error) {
+	var result bool
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"isOwner",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetKeepFactoriesUpgradeabilityPeriod() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.GetKeepFactoriesUpgradeabilityPeriod(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getKeepFactoriesUpgradeabilityPeriod",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetKeepFactoriesUpgradeabilityPeriodAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getKeepFactoriesUpgradeabilityPeriod",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) PriceFeed() (common.Address, error) {
+	var result common.Address
+	result, err := tbtcs.contract.PriceFeed(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"priceFeed",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) PriceFeedAtBlock(
+	blockNumber *big.Int,
+) (common.Address, error) {
+	var result common.Address
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"priceFeed",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) FetchRelayPreviousDifficulty() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.FetchRelayPreviousDifficulty(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"fetchRelayPreviousDifficulty",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) FetchRelayPreviousDifficultyAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"fetchRelayPreviousDifficulty",
+		&result,
+	)
+
+	return result, err
+}
+
 func (tbtcs *TBTCSystem) GetRemainingPauseTerm() (*big.Int, error) {
 	var result *big.Int
 	result, err := tbtcs.contract.GetRemainingPauseTerm(
@@ -4928,6 +5004,234 @@ func (tbtcs *TBTCSystem) GetRemainingPauseTermAtBlock(
 		tbtcs.errorResolver,
 		tbtcs.contractAddress,
 		"getRemainingPauseTerm",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) KeepThreshold() (uint16, error) {
+	var result uint16
+	result, err := tbtcs.contract.KeepThreshold(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"keepThreshold",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) KeepThresholdAtBlock(
+	blockNumber *big.Int,
+) (uint16, error) {
+	var result uint16
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"keepThreshold",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetAllowNewDeposits() (bool, error) {
+	var result bool
+	result, err := tbtcs.contract.GetAllowNewDeposits(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getAllowNewDeposits",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetAllowNewDepositsAtBlock(
+	blockNumber *big.Int,
+) (bool, error) {
+	var result bool
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getAllowNewDeposits",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetAllowedLotSizes() ([]uint64, error) {
+	var result []uint64
+	result, err := tbtcs.contract.GetAllowedLotSizes(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getAllowedLotSizes",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetAllowedLotSizesAtBlock(
+	blockNumber *big.Int,
+) ([]uint64, error) {
+	var result []uint64
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getAllowedLotSizes",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetPriceFeedGovernanceTimeDelay() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.GetPriceFeedGovernanceTimeDelay(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getPriceFeedGovernanceTimeDelay",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetPriceFeedGovernanceTimeDelayAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getPriceFeedGovernanceTimeDelay",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetRemainingSignerFeeDivisorUpdateTime() (*big.Int, error) {
+	var result *big.Int
+	result, err := tbtcs.contract.GetRemainingSignerFeeDivisorUpdateTime(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"getRemainingSignerFeeDivisorUpdateTime",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) GetRemainingSignerFeeDivisorUpdateTimeAtBlock(
+	blockNumber *big.Int,
+) (*big.Int, error) {
+	var result *big.Int
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"getRemainingSignerFeeDivisorUpdateTime",
+		&result,
+	)
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) Owner() (common.Address, error) {
+	var result common.Address
+	result, err := tbtcs.contract.Owner(
+		tbtcs.callerOptions,
+	)
+
+	if err != nil {
+		return result, tbtcs.errorResolver.ResolveError(
+			err,
+			tbtcs.callerOptions.From,
+			nil,
+			"owner",
+		)
+	}
+
+	return result, err
+}
+
+func (tbtcs *TBTCSystem) OwnerAtBlock(
+	blockNumber *big.Int,
+) (common.Address, error) {
+	var result common.Address
+
+	err := ethutil.CallAtBlock(
+		tbtcs.callerOptions.From,
+		blockNumber,
+		nil,
+		tbtcs.contractABI,
+		tbtcs.caller,
+		tbtcs.errorResolver,
+		tbtcs.contractAddress,
+		"owner",
 		&result,
 	)
 
@@ -5010,120 +5314,6 @@ func (tbtcs *TBTCSystem) GetInitialCollateralizedPercentAtBlock(
 	return result, err
 }
 
-func (tbtcs *TBTCSystem) GetKeepFactoriesUpgradeabilityPeriod() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.GetKeepFactoriesUpgradeabilityPeriod(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getKeepFactoriesUpgradeabilityPeriod",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetKeepFactoriesUpgradeabilityPeriodAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getKeepFactoriesUpgradeabilityPeriod",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetRemainingLotSizesUpdateTime() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.GetRemainingLotSizesUpdateTime(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getRemainingLotSizesUpdateTime",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetRemainingLotSizesUpdateTimeAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getRemainingLotSizesUpdateTime",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) KeepThreshold() (uint16, error) {
-	var result uint16
-	result, err := tbtcs.contract.KeepThreshold(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"keepThreshold",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) KeepThresholdAtBlock(
-	blockNumber *big.Int,
-) (uint16, error) {
-	var result uint16
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"keepThreshold",
-		&result,
-	)
-
-	return result, err
-}
-
 func (tbtcs *TBTCSystem) GetRemainingEthBtcPriceFeedAdditionTime() (*big.Int, error) {
 	var result *big.Int
 	result, err := tbtcs.contract.GetRemainingEthBtcPriceFeedAdditionTime(
@@ -5156,196 +5346,6 @@ func (tbtcs *TBTCSystem) GetRemainingEthBtcPriceFeedAdditionTimeAtBlock(
 		tbtcs.errorResolver,
 		tbtcs.contractAddress,
 		"getRemainingEthBtcPriceFeedAdditionTime",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetUndercollateralizedThresholdPercent() (uint16, error) {
-	var result uint16
-	result, err := tbtcs.contract.GetUndercollateralizedThresholdPercent(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getUndercollateralizedThresholdPercent",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetUndercollateralizedThresholdPercentAtBlock(
-	blockNumber *big.Int,
-) (uint16, error) {
-	var result uint16
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getUndercollateralizedThresholdPercent",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) FetchRelayCurrentDifficulty() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.FetchRelayCurrentDifficulty(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"fetchRelayCurrentDifficulty",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) FetchRelayCurrentDifficultyAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"fetchRelayCurrentDifficulty",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetRemainingSignerFeeDivisorUpdateTime() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.GetRemainingSignerFeeDivisorUpdateTime(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getRemainingSignerFeeDivisorUpdateTime",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetRemainingSignerFeeDivisorUpdateTimeAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getRemainingSignerFeeDivisorUpdateTime",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetMaximumLotSize() (*big.Int, error) {
-	var result *big.Int
-	result, err := tbtcs.contract.GetMaximumLotSize(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getMaximumLotSize",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetMaximumLotSizeAtBlock(
-	blockNumber *big.Int,
-) (*big.Int, error) {
-	var result *big.Int
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getMaximumLotSize",
-		&result,
-	)
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetSignerFeeDivisor() (uint16, error) {
-	var result uint16
-	result, err := tbtcs.contract.GetSignerFeeDivisor(
-		tbtcs.callerOptions,
-	)
-
-	if err != nil {
-		return result, tbtcs.errorResolver.ResolveError(
-			err,
-			tbtcs.callerOptions.From,
-			nil,
-			"getSignerFeeDivisor",
-		)
-	}
-
-	return result, err
-}
-
-func (tbtcs *TBTCSystem) GetSignerFeeDivisorAtBlock(
-	blockNumber *big.Int,
-) (uint16, error) {
-	var result uint16
-
-	err := ethutil.CallAtBlock(
-		tbtcs.callerOptions.From,
-		blockNumber,
-		nil,
-		tbtcs.contractABI,
-		tbtcs.caller,
-		tbtcs.errorResolver,
-		tbtcs.contractAddress,
-		"getSignerFeeDivisor",
 		&result,
 	)
 
@@ -5537,192 +5537,10 @@ func (tbtcs *TBTCSystem) PastKeepFactoriesUpdatedEvents(
 	return events, nil
 }
 
-func (tbtcs *TBTCSystem) LotSizesUpdateStarted(
-	opts *ethutil.SubscribeOpts,
-) *TbtcsLotSizesUpdateStartedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsLotSizesUpdateStartedSubscription{
-		tbtcs,
-		opts,
-	}
-}
-
-type TbtcsLotSizesUpdateStartedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
-}
-
-type tBTCSystemLotSizesUpdateStartedFunc func(
-	LotSizes []uint64,
-	Timestamp *big.Int,
-	blockNumber uint64,
-)
-
-func (lsuss *TbtcsLotSizesUpdateStartedSubscription) OnEvent(
-	handler tBTCSystemLotSizesUpdateStartedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemLotSizesUpdateStarted)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.LotSizes,
-					event.Timestamp,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := lsuss.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (lsuss *TbtcsLotSizesUpdateStartedSubscription) Pipe(
-	sink chan *abi.TBTCSystemLotSizesUpdateStarted,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(lsuss.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := lsuss.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - lsuss.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past LotSizesUpdateStarted events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := lsuss.contract.PastLotSizesUpdateStartedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past LotSizesUpdateStarted events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := lsuss.contract.watchLotSizesUpdateStarted(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchLotSizesUpdateStarted(
-	sink chan *abi.TBTCSystemLotSizesUpdateStarted,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchLotSizesUpdateStarted(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event LotSizesUpdateStarted had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event LotSizesUpdateStarted failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastLotSizesUpdateStartedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.TBTCSystemLotSizesUpdateStarted, error) {
-	iterator, err := tbtcs.contract.FilterLotSizesUpdateStarted(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past LotSizesUpdateStarted events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemLotSizesUpdateStarted, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) Redeemed(
+func (tbtcs *TBTCSystem) Liquidated(
 	opts *ethutil.SubscribeOpts,
 	_depositContractAddressFilter []common.Address,
-	_txidFilter [][32]uint8,
-) *TbtcsRedeemedSubscription {
+) *TbtcsLiquidatedSubscription {
 	if opts == nil {
 		opts = new(ethutil.SubscribeOpts)
 	}
@@ -5733,32 +5551,29 @@ func (tbtcs *TBTCSystem) Redeemed(
 		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &TbtcsRedeemedSubscription{
+	return &TbtcsLiquidatedSubscription{
 		tbtcs,
 		opts,
 		_depositContractAddressFilter,
-		_txidFilter,
 	}
 }
 
-type TbtcsRedeemedSubscription struct {
+type TbtcsLiquidatedSubscription struct {
 	contract                      *TBTCSystem
 	opts                          *ethutil.SubscribeOpts
 	_depositContractAddressFilter []common.Address
-	_txidFilter                   [][32]uint8
 }
 
-type tBTCSystemRedeemedFunc func(
+type tBTCSystemLiquidatedFunc func(
 	DepositContractAddress common.Address,
-	Txid [32]uint8,
 	Timestamp *big.Int,
 	blockNumber uint64,
 )
 
-func (rs *TbtcsRedeemedSubscription) OnEvent(
-	handler tBTCSystemRedeemedFunc,
+func (ls *TbtcsLiquidatedSubscription) OnEvent(
+	handler tBTCSystemLiquidatedFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemRedeemed)
+	eventChan := make(chan *abi.TBTCSystemLiquidated)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -5769,7 +5584,6 @@ func (rs *TbtcsRedeemedSubscription) OnEvent(
 			case event := <-eventChan:
 				handler(
 					event.DepositContractAddress,
-					event.Txid,
 					event.Timestamp,
 					event.Raw.BlockNumber,
 				)
@@ -5777,44 +5591,43 @@ func (rs *TbtcsRedeemedSubscription) OnEvent(
 		}
 	}()
 
-	sub := rs.Pipe(eventChan)
+	sub := ls.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancelCtx()
 	})
 }
 
-func (rs *TbtcsRedeemedSubscription) Pipe(
-	sink chan *abi.TBTCSystemRedeemed,
+func (ls *TbtcsLiquidatedSubscription) Pipe(
+	sink chan *abi.TBTCSystemLiquidated,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker(rs.opts.Tick)
+		ticker := time.NewTicker(ls.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				lastBlock, err := rs.contract.blockCounter.CurrentBlock()
+				lastBlock, err := ls.contract.blockCounter.CurrentBlock()
 				if err != nil {
 					tbtcsLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
-				fromBlock := lastBlock - rs.opts.PastBlocks
+				fromBlock := lastBlock - ls.opts.PastBlocks
 
 				tbtcsLogger.Infof(
-					"subscription monitoring fetching past Redeemed events "+
+					"subscription monitoring fetching past Liquidated events "+
 						"starting from block [%v]",
 					fromBlock,
 				)
-				events, err := rs.contract.PastRedeemedEvents(
+				events, err := ls.contract.PastLiquidatedEvents(
 					fromBlock,
 					nil,
-					rs._depositContractAddressFilter,
-					rs._txidFilter,
+					ls._depositContractAddressFilter,
 				)
 				if err != nil {
 					tbtcsLogger.Errorf(
@@ -5824,7 +5637,7 @@ func (rs *TbtcsRedeemedSubscription) Pipe(
 					continue
 				}
 				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past Redeemed events",
+					"subscription monitoring fetched [%v] past Liquidated events",
 					len(events),
 				)
 
@@ -5835,10 +5648,9 @@ func (rs *TbtcsRedeemedSubscription) Pipe(
 		}
 	}()
 
-	sub := rs.contract.watchRedeemed(
+	sub := ls.contract.watchLiquidated(
 		sink,
-		rs._depositContractAddressFilter,
-		rs._txidFilter,
+		ls._depositContractAddressFilter,
 	)
 
 	return subscription.NewEventSubscription(func() {
@@ -5847,23 +5659,21 @@ func (rs *TbtcsRedeemedSubscription) Pipe(
 	})
 }
 
-func (tbtcs *TBTCSystem) watchRedeemed(
-	sink chan *abi.TBTCSystemRedeemed,
+func (tbtcs *TBTCSystem) watchLiquidated(
+	sink chan *abi.TBTCSystemLiquidated,
 	_depositContractAddressFilter []common.Address,
-	_txidFilter [][32]uint8,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchRedeemed(
+		return tbtcs.contract.WatchLiquidated(
 			&bind.WatchOpts{Context: ctx},
 			sink,
 			_depositContractAddressFilter,
-			_txidFilter,
 		)
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		tbtcsLogger.Errorf(
-			"subscription to event Redeemed had to be "+
+			"subscription to event Liquidated had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"Ethereum connectivity",
 			elapsed,
@@ -5872,7 +5682,7 @@ func (tbtcs *TBTCSystem) watchRedeemed(
 
 	subscriptionFailedFn := func(err error) {
 		tbtcsLogger.Errorf(
-			"subscription to event Redeemed failed "+
+			"subscription to event Liquidated failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
 			err,
@@ -5888,28 +5698,205 @@ func (tbtcs *TBTCSystem) watchRedeemed(
 	)
 }
 
-func (tbtcs *TBTCSystem) PastRedeemedEvents(
+func (tbtcs *TBTCSystem) PastLiquidatedEvents(
 	startBlock uint64,
 	endBlock *uint64,
 	_depositContractAddressFilter []common.Address,
-	_txidFilter [][32]uint8,
-) ([]*abi.TBTCSystemRedeemed, error) {
-	iterator, err := tbtcs.contract.FilterRedeemed(
+) ([]*abi.TBTCSystemLiquidated, error) {
+	iterator, err := tbtcs.contract.FilterLiquidated(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
 		},
 		_depositContractAddressFilter,
-		_txidFilter,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error retrieving past Redeemed events: [%v]",
+			"error retrieving past Liquidated events: [%v]",
 			err,
 		)
 	}
 
-	events := make([]*abi.TBTCSystemRedeemed, 0)
+	events := make([]*abi.TBTCSystemLiquidated, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) LotSizesUpdated(
+	opts *ethutil.SubscribeOpts,
+) *TbtcsLotSizesUpdatedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsLotSizesUpdatedSubscription{
+		tbtcs,
+		opts,
+	}
+}
+
+type TbtcsLotSizesUpdatedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
+}
+
+type tBTCSystemLotSizesUpdatedFunc func(
+	LotSizes []uint64,
+	blockNumber uint64,
+)
+
+func (lsus *TbtcsLotSizesUpdatedSubscription) OnEvent(
+	handler tBTCSystemLotSizesUpdatedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemLotSizesUpdated)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.LotSizes,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := lsus.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (lsus *TbtcsLotSizesUpdatedSubscription) Pipe(
+	sink chan *abi.TBTCSystemLotSizesUpdated,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(lsus.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := lsus.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - lsus.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past LotSizesUpdated events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := lsus.contract.PastLotSizesUpdatedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past LotSizesUpdated events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := lsus.contract.watchLotSizesUpdated(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchLotSizesUpdated(
+	sink chan *abi.TBTCSystemLotSizesUpdated,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchLotSizesUpdated(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event LotSizesUpdated had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event LotSizesUpdated failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastLotSizesUpdatedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemLotSizesUpdated, error) {
+	iterator, err := tbtcs.contract.FilterLotSizesUpdated(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past LotSizesUpdated events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemLotSizesUpdated, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -6137,9 +6124,10 @@ func (tbtcs *TBTCSystem) PastRedemptionRequestedEvents(
 	return events, nil
 }
 
-func (tbtcs *TBTCSystem) AllowNewDepositsUpdated(
+func (tbtcs *TBTCSystem) SetupFailed(
 	opts *ethutil.SubscribeOpts,
-) *TbtcsAllowNewDepositsUpdatedSubscription {
+	_depositContractAddressFilter []common.Address,
+) *TbtcsSetupFailedSubscription {
 	if opts == nil {
 		opts = new(ethutil.SubscribeOpts)
 	}
@@ -6150,208 +6138,29 @@ func (tbtcs *TBTCSystem) AllowNewDepositsUpdated(
 		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &TbtcsAllowNewDepositsUpdatedSubscription{
+	return &TbtcsSetupFailedSubscription{
 		tbtcs,
 		opts,
+		_depositContractAddressFilter,
 	}
 }
 
-type TbtcsAllowNewDepositsUpdatedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
+type TbtcsSetupFailedSubscription struct {
+	contract                      *TBTCSystem
+	opts                          *ethutil.SubscribeOpts
+	_depositContractAddressFilter []common.Address
 }
 
-type tBTCSystemAllowNewDepositsUpdatedFunc func(
-	AllowNewDeposits bool,
-	blockNumber uint64,
-)
-
-func (andus *TbtcsAllowNewDepositsUpdatedSubscription) OnEvent(
-	handler tBTCSystemAllowNewDepositsUpdatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemAllowNewDepositsUpdated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.AllowNewDeposits,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := andus.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (andus *TbtcsAllowNewDepositsUpdatedSubscription) Pipe(
-	sink chan *abi.TBTCSystemAllowNewDepositsUpdated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(andus.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := andus.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - andus.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past AllowNewDepositsUpdated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := andus.contract.PastAllowNewDepositsUpdatedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past AllowNewDepositsUpdated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := andus.contract.watchAllowNewDepositsUpdated(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchAllowNewDepositsUpdated(
-	sink chan *abi.TBTCSystemAllowNewDepositsUpdated,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchAllowNewDepositsUpdated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event AllowNewDepositsUpdated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event AllowNewDepositsUpdated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastAllowNewDepositsUpdatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.TBTCSystemAllowNewDepositsUpdated, error) {
-	iterator, err := tbtcs.contract.FilterAllowNewDepositsUpdated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past AllowNewDepositsUpdated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemAllowNewDepositsUpdated, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) CollateralizationThresholdsUpdateStarted(
-	opts *ethutil.SubscribeOpts,
-) *TbtcsCollateralizationThresholdsUpdateStartedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsCollateralizationThresholdsUpdateStartedSubscription{
-		tbtcs,
-		opts,
-	}
-}
-
-type TbtcsCollateralizationThresholdsUpdateStartedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
-}
-
-type tBTCSystemCollateralizationThresholdsUpdateStartedFunc func(
-	InitialCollateralizedPercent uint16,
-	UndercollateralizedThresholdPercent uint16,
-	SeverelyUndercollateralizedThresholdPercent uint16,
+type tBTCSystemSetupFailedFunc func(
+	DepositContractAddress common.Address,
 	Timestamp *big.Int,
 	blockNumber uint64,
 )
 
-func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) OnEvent(
-	handler tBTCSystemCollateralizationThresholdsUpdateStartedFunc,
+func (sfs *TbtcsSetupFailedSubscription) OnEvent(
+	handler tBTCSystemSetupFailedFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemCollateralizationThresholdsUpdateStarted)
+	eventChan := make(chan *abi.TBTCSystemSetupFailed)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -6361,9 +6170,7 @@ func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) OnEvent(
 				return
 			case event := <-eventChan:
 				handler(
-					event.InitialCollateralizedPercent,
-					event.UndercollateralizedThresholdPercent,
-					event.SeverelyUndercollateralizedThresholdPercent,
+					event.DepositContractAddress,
 					event.Timestamp,
 					event.Raw.BlockNumber,
 				)
@@ -6371,42 +6178,43 @@ func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) OnEvent(
 		}
 	}()
 
-	sub := ctuss.Pipe(eventChan)
+	sub := sfs.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancelCtx()
 	})
 }
 
-func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) Pipe(
-	sink chan *abi.TBTCSystemCollateralizationThresholdsUpdateStarted,
+func (sfs *TbtcsSetupFailedSubscription) Pipe(
+	sink chan *abi.TBTCSystemSetupFailed,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker(ctuss.opts.Tick)
+		ticker := time.NewTicker(sfs.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				lastBlock, err := ctuss.contract.blockCounter.CurrentBlock()
+				lastBlock, err := sfs.contract.blockCounter.CurrentBlock()
 				if err != nil {
 					tbtcsLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
-				fromBlock := lastBlock - ctuss.opts.PastBlocks
+				fromBlock := lastBlock - sfs.opts.PastBlocks
 
 				tbtcsLogger.Infof(
-					"subscription monitoring fetching past CollateralizationThresholdsUpdateStarted events "+
+					"subscription monitoring fetching past SetupFailed events "+
 						"starting from block [%v]",
 					fromBlock,
 				)
-				events, err := ctuss.contract.PastCollateralizationThresholdsUpdateStartedEvents(
+				events, err := sfs.contract.PastSetupFailedEvents(
 					fromBlock,
 					nil,
+					sfs._depositContractAddressFilter,
 				)
 				if err != nil {
 					tbtcsLogger.Errorf(
@@ -6416,7 +6224,7 @@ func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) Pipe(
 					continue
 				}
 				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past CollateralizationThresholdsUpdateStarted events",
+					"subscription monitoring fetched [%v] past SetupFailed events",
 					len(events),
 				)
 
@@ -6427,8 +6235,9 @@ func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) Pipe(
 		}
 	}()
 
-	sub := ctuss.contract.watchCollateralizationThresholdsUpdateStarted(
+	sub := sfs.contract.watchSetupFailed(
 		sink,
+		sfs._depositContractAddressFilter,
 	)
 
 	return subscription.NewEventSubscription(func() {
@@ -6437,19 +6246,21 @@ func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) Pipe(
 	})
 }
 
-func (tbtcs *TBTCSystem) watchCollateralizationThresholdsUpdateStarted(
-	sink chan *abi.TBTCSystemCollateralizationThresholdsUpdateStarted,
+func (tbtcs *TBTCSystem) watchSetupFailed(
+	sink chan *abi.TBTCSystemSetupFailed,
+	_depositContractAddressFilter []common.Address,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchCollateralizationThresholdsUpdateStarted(
+		return tbtcs.contract.WatchSetupFailed(
 			&bind.WatchOpts{Context: ctx},
 			sink,
+			_depositContractAddressFilter,
 		)
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		tbtcsLogger.Errorf(
-			"subscription to event CollateralizationThresholdsUpdateStarted had to be "+
+			"subscription to event SetupFailed had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"Ethereum connectivity",
 			elapsed,
@@ -6458,7 +6269,7 @@ func (tbtcs *TBTCSystem) watchCollateralizationThresholdsUpdateStarted(
 
 	subscriptionFailedFn := func(err error) {
 		tbtcsLogger.Errorf(
-			"subscription to event CollateralizationThresholdsUpdateStarted failed "+
+			"subscription to event SetupFailed failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
 			err,
@@ -6474,24 +6285,26 @@ func (tbtcs *TBTCSystem) watchCollateralizationThresholdsUpdateStarted(
 	)
 }
 
-func (tbtcs *TBTCSystem) PastCollateralizationThresholdsUpdateStartedEvents(
+func (tbtcs *TBTCSystem) PastSetupFailedEvents(
 	startBlock uint64,
 	endBlock *uint64,
-) ([]*abi.TBTCSystemCollateralizationThresholdsUpdateStarted, error) {
-	iterator, err := tbtcs.contract.FilterCollateralizationThresholdsUpdateStarted(
+	_depositContractAddressFilter []common.Address,
+) ([]*abi.TBTCSystemSetupFailed, error) {
+	iterator, err := tbtcs.contract.FilterSetupFailed(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
 		},
+		_depositContractAddressFilter,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error retrieving past CollateralizationThresholdsUpdateStarted events: [%v]",
+			"error retrieving past SetupFailed events: [%v]",
 			err,
 		)
 	}
 
-	events := make([]*abi.TBTCSystemCollateralizationThresholdsUpdateStarted, 0)
+	events := make([]*abi.TBTCSystemSetupFailed, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -6881,6 +6694,207 @@ func (tbtcs *TBTCSystem) PastFraudDuringSetupEvents(
 	return events, nil
 }
 
+func (tbtcs *TBTCSystem) Funded(
+	opts *ethutil.SubscribeOpts,
+	_depositContractAddressFilter []common.Address,
+	_txidFilter [][32]uint8,
+) *TbtcsFundedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsFundedSubscription{
+		tbtcs,
+		opts,
+		_depositContractAddressFilter,
+		_txidFilter,
+	}
+}
+
+type TbtcsFundedSubscription struct {
+	contract                      *TBTCSystem
+	opts                          *ethutil.SubscribeOpts
+	_depositContractAddressFilter []common.Address
+	_txidFilter                   [][32]uint8
+}
+
+type tBTCSystemFundedFunc func(
+	DepositContractAddress common.Address,
+	Txid [32]uint8,
+	Timestamp *big.Int,
+	blockNumber uint64,
+)
+
+func (fs *TbtcsFundedSubscription) OnEvent(
+	handler tBTCSystemFundedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemFunded)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.DepositContractAddress,
+					event.Txid,
+					event.Timestamp,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := fs.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (fs *TbtcsFundedSubscription) Pipe(
+	sink chan *abi.TBTCSystemFunded,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(fs.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := fs.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - fs.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past Funded events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := fs.contract.PastFundedEvents(
+					fromBlock,
+					nil,
+					fs._depositContractAddressFilter,
+					fs._txidFilter,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past Funded events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := fs.contract.watchFunded(
+		sink,
+		fs._depositContractAddressFilter,
+		fs._txidFilter,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchFunded(
+	sink chan *abi.TBTCSystemFunded,
+	_depositContractAddressFilter []common.Address,
+	_txidFilter [][32]uint8,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchFunded(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			_depositContractAddressFilter,
+			_txidFilter,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event Funded had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event Funded failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastFundedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+	_depositContractAddressFilter []common.Address,
+	_txidFilter [][32]uint8,
+) ([]*abi.TBTCSystemFunded, error) {
+	iterator, err := tbtcs.contract.FilterFunded(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+		_depositContractAddressFilter,
+		_txidFilter,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past Funded events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemFunded, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
 func (tbtcs *TBTCSystem) StartedLiquidation(
 	opts *ethutil.SubscribeOpts,
 	_depositContractAddressFilter []common.Address,
@@ -7073,10 +7087,9 @@ func (tbtcs *TBTCSystem) PastStartedLiquidationEvents(
 	return events, nil
 }
 
-func (tbtcs *TBTCSystem) FunderAbortRequested(
+func (tbtcs *TBTCSystem) KeepFactoriesUpdateStarted(
 	opts *ethutil.SubscribeOpts,
-	_depositContractAddressFilter []common.Address,
-) *TbtcsFunderAbortRequestedSubscription {
+) *TbtcsKeepFactoriesUpdateStartedSubscription {
 	if opts == nil {
 		opts = new(ethutil.SubscribeOpts)
 	}
@@ -7087,418 +7100,29 @@ func (tbtcs *TBTCSystem) FunderAbortRequested(
 		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &TbtcsFunderAbortRequestedSubscription{
+	return &TbtcsKeepFactoriesUpdateStartedSubscription{
 		tbtcs,
 		opts,
-		_depositContractAddressFilter,
 	}
 }
 
-type TbtcsFunderAbortRequestedSubscription struct {
-	contract                      *TBTCSystem
-	opts                          *ethutil.SubscribeOpts
-	_depositContractAddressFilter []common.Address
+type TbtcsKeepFactoriesUpdateStartedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
 }
 
-type tBTCSystemFunderAbortRequestedFunc func(
-	DepositContractAddress common.Address,
-	AbortOutputScript []uint8,
-	blockNumber uint64,
-)
-
-func (fars *TbtcsFunderAbortRequestedSubscription) OnEvent(
-	handler tBTCSystemFunderAbortRequestedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemFunderAbortRequested)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.DepositContractAddress,
-					event.AbortOutputScript,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := fars.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (fars *TbtcsFunderAbortRequestedSubscription) Pipe(
-	sink chan *abi.TBTCSystemFunderAbortRequested,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(fars.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := fars.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - fars.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past FunderAbortRequested events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := fars.contract.PastFunderAbortRequestedEvents(
-					fromBlock,
-					nil,
-					fars._depositContractAddressFilter,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past FunderAbortRequested events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := fars.contract.watchFunderAbortRequested(
-		sink,
-		fars._depositContractAddressFilter,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchFunderAbortRequested(
-	sink chan *abi.TBTCSystemFunderAbortRequested,
-	_depositContractAddressFilter []common.Address,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchFunderAbortRequested(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-			_depositContractAddressFilter,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event FunderAbortRequested had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event FunderAbortRequested failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastFunderAbortRequestedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-	_depositContractAddressFilter []common.Address,
-) ([]*abi.TBTCSystemFunderAbortRequested, error) {
-	iterator, err := tbtcs.contract.FilterFunderAbortRequested(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-		_depositContractAddressFilter,
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past FunderAbortRequested events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemFunderAbortRequested, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) OwnershipTransferred(
-	opts *ethutil.SubscribeOpts,
-	previousOwnerFilter []common.Address,
-	newOwnerFilter []common.Address,
-) *TbtcsOwnershipTransferredSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsOwnershipTransferredSubscription{
-		tbtcs,
-		opts,
-		previousOwnerFilter,
-		newOwnerFilter,
-	}
-}
-
-type TbtcsOwnershipTransferredSubscription struct {
-	contract            *TBTCSystem
-	opts                *ethutil.SubscribeOpts
-	previousOwnerFilter []common.Address
-	newOwnerFilter      []common.Address
-}
-
-type tBTCSystemOwnershipTransferredFunc func(
-	PreviousOwner common.Address,
-	NewOwner common.Address,
-	blockNumber uint64,
-)
-
-func (ots *TbtcsOwnershipTransferredSubscription) OnEvent(
-	handler tBTCSystemOwnershipTransferredFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemOwnershipTransferred)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.PreviousOwner,
-					event.NewOwner,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := ots.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (ots *TbtcsOwnershipTransferredSubscription) Pipe(
-	sink chan *abi.TBTCSystemOwnershipTransferred,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(ots.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := ots.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - ots.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past OwnershipTransferred events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := ots.contract.PastOwnershipTransferredEvents(
-					fromBlock,
-					nil,
-					ots.previousOwnerFilter,
-					ots.newOwnerFilter,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past OwnershipTransferred events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := ots.contract.watchOwnershipTransferred(
-		sink,
-		ots.previousOwnerFilter,
-		ots.newOwnerFilter,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchOwnershipTransferred(
-	sink chan *abi.TBTCSystemOwnershipTransferred,
-	previousOwnerFilter []common.Address,
-	newOwnerFilter []common.Address,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchOwnershipTransferred(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-			previousOwnerFilter,
-			newOwnerFilter,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event OwnershipTransferred had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event OwnershipTransferred failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastOwnershipTransferredEvents(
-	startBlock uint64,
-	endBlock *uint64,
-	previousOwnerFilter []common.Address,
-	newOwnerFilter []common.Address,
-) ([]*abi.TBTCSystemOwnershipTransferred, error) {
-	iterator, err := tbtcs.contract.FilterOwnershipTransferred(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-		previousOwnerFilter,
-		newOwnerFilter,
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past OwnershipTransferred events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemOwnershipTransferred, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) SetupFailed(
-	opts *ethutil.SubscribeOpts,
-	_depositContractAddressFilter []common.Address,
-) *TbtcsSetupFailedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsSetupFailedSubscription{
-		tbtcs,
-		opts,
-		_depositContractAddressFilter,
-	}
-}
-
-type TbtcsSetupFailedSubscription struct {
-	contract                      *TBTCSystem
-	opts                          *ethutil.SubscribeOpts
-	_depositContractAddressFilter []common.Address
-}
-
-type tBTCSystemSetupFailedFunc func(
-	DepositContractAddress common.Address,
+type tBTCSystemKeepFactoriesUpdateStartedFunc func(
+	KeepStakedFactory common.Address,
+	FullyBackedFactory common.Address,
+	FactorySelector common.Address,
 	Timestamp *big.Int,
 	blockNumber uint64,
 )
 
-func (sfs *TbtcsSetupFailedSubscription) OnEvent(
-	handler tBTCSystemSetupFailedFunc,
+func (kfuss *TbtcsKeepFactoriesUpdateStartedSubscription) OnEvent(
+	handler tBTCSystemKeepFactoriesUpdateStartedFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemSetupFailed)
+	eventChan := make(chan *abi.TBTCSystemKeepFactoriesUpdateStarted)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -7508,7 +7132,9 @@ func (sfs *TbtcsSetupFailedSubscription) OnEvent(
 				return
 			case event := <-eventChan:
 				handler(
-					event.DepositContractAddress,
+					event.KeepStakedFactory,
+					event.FullyBackedFactory,
+					event.FactorySelector,
 					event.Timestamp,
 					event.Raw.BlockNumber,
 				)
@@ -7516,43 +7142,42 @@ func (sfs *TbtcsSetupFailedSubscription) OnEvent(
 		}
 	}()
 
-	sub := sfs.Pipe(eventChan)
+	sub := kfuss.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancelCtx()
 	})
 }
 
-func (sfs *TbtcsSetupFailedSubscription) Pipe(
-	sink chan *abi.TBTCSystemSetupFailed,
+func (kfuss *TbtcsKeepFactoriesUpdateStartedSubscription) Pipe(
+	sink chan *abi.TBTCSystemKeepFactoriesUpdateStarted,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker(sfs.opts.Tick)
+		ticker := time.NewTicker(kfuss.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				lastBlock, err := sfs.contract.blockCounter.CurrentBlock()
+				lastBlock, err := kfuss.contract.blockCounter.CurrentBlock()
 				if err != nil {
 					tbtcsLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
-				fromBlock := lastBlock - sfs.opts.PastBlocks
+				fromBlock := lastBlock - kfuss.opts.PastBlocks
 
 				tbtcsLogger.Infof(
-					"subscription monitoring fetching past SetupFailed events "+
+					"subscription monitoring fetching past KeepFactoriesUpdateStarted events "+
 						"starting from block [%v]",
 					fromBlock,
 				)
-				events, err := sfs.contract.PastSetupFailedEvents(
+				events, err := kfuss.contract.PastKeepFactoriesUpdateStartedEvents(
 					fromBlock,
 					nil,
-					sfs._depositContractAddressFilter,
 				)
 				if err != nil {
 					tbtcsLogger.Errorf(
@@ -7562,7 +7187,7 @@ func (sfs *TbtcsSetupFailedSubscription) Pipe(
 					continue
 				}
 				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past SetupFailed events",
+					"subscription monitoring fetched [%v] past KeepFactoriesUpdateStarted events",
 					len(events),
 				)
 
@@ -7573,9 +7198,8 @@ func (sfs *TbtcsSetupFailedSubscription) Pipe(
 		}
 	}()
 
-	sub := sfs.contract.watchSetupFailed(
+	sub := kfuss.contract.watchKeepFactoriesUpdateStarted(
 		sink,
-		sfs._depositContractAddressFilter,
 	)
 
 	return subscription.NewEventSubscription(func() {
@@ -7584,21 +7208,19 @@ func (sfs *TbtcsSetupFailedSubscription) Pipe(
 	})
 }
 
-func (tbtcs *TBTCSystem) watchSetupFailed(
-	sink chan *abi.TBTCSystemSetupFailed,
-	_depositContractAddressFilter []common.Address,
+func (tbtcs *TBTCSystem) watchKeepFactoriesUpdateStarted(
+	sink chan *abi.TBTCSystemKeepFactoriesUpdateStarted,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchSetupFailed(
+		return tbtcs.contract.WatchKeepFactoriesUpdateStarted(
 			&bind.WatchOpts{Context: ctx},
 			sink,
-			_depositContractAddressFilter,
 		)
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		tbtcsLogger.Errorf(
-			"subscription to event SetupFailed had to be "+
+			"subscription to event KeepFactoriesUpdateStarted had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"Ethereum connectivity",
 			elapsed,
@@ -7607,7 +7229,7 @@ func (tbtcs *TBTCSystem) watchSetupFailed(
 
 	subscriptionFailedFn := func(err error) {
 		tbtcsLogger.Errorf(
-			"subscription to event SetupFailed failed "+
+			"subscription to event KeepFactoriesUpdateStarted failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
 			err,
@@ -7623,26 +7245,408 @@ func (tbtcs *TBTCSystem) watchSetupFailed(
 	)
 }
 
-func (tbtcs *TBTCSystem) PastSetupFailedEvents(
+func (tbtcs *TBTCSystem) PastKeepFactoriesUpdateStartedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemKeepFactoriesUpdateStarted, error) {
+	iterator, err := tbtcs.contract.FilterKeepFactoriesUpdateStarted(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past KeepFactoriesUpdateStarted events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemKeepFactoriesUpdateStarted, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) Redeemed(
+	opts *ethutil.SubscribeOpts,
+	_depositContractAddressFilter []common.Address,
+	_txidFilter [][32]uint8,
+) *TbtcsRedeemedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsRedeemedSubscription{
+		tbtcs,
+		opts,
+		_depositContractAddressFilter,
+		_txidFilter,
+	}
+}
+
+type TbtcsRedeemedSubscription struct {
+	contract                      *TBTCSystem
+	opts                          *ethutil.SubscribeOpts
+	_depositContractAddressFilter []common.Address
+	_txidFilter                   [][32]uint8
+}
+
+type tBTCSystemRedeemedFunc func(
+	DepositContractAddress common.Address,
+	Txid [32]uint8,
+	Timestamp *big.Int,
+	blockNumber uint64,
+)
+
+func (rs *TbtcsRedeemedSubscription) OnEvent(
+	handler tBTCSystemRedeemedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemRedeemed)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.DepositContractAddress,
+					event.Txid,
+					event.Timestamp,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := rs.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (rs *TbtcsRedeemedSubscription) Pipe(
+	sink chan *abi.TBTCSystemRedeemed,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(rs.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := rs.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - rs.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past Redeemed events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := rs.contract.PastRedeemedEvents(
+					fromBlock,
+					nil,
+					rs._depositContractAddressFilter,
+					rs._txidFilter,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past Redeemed events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := rs.contract.watchRedeemed(
+		sink,
+		rs._depositContractAddressFilter,
+		rs._txidFilter,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchRedeemed(
+	sink chan *abi.TBTCSystemRedeemed,
+	_depositContractAddressFilter []common.Address,
+	_txidFilter [][32]uint8,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchRedeemed(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			_depositContractAddressFilter,
+			_txidFilter,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event Redeemed had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event Redeemed failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastRedeemedEvents(
 	startBlock uint64,
 	endBlock *uint64,
 	_depositContractAddressFilter []common.Address,
-) ([]*abi.TBTCSystemSetupFailed, error) {
-	iterator, err := tbtcs.contract.FilterSetupFailed(
+	_txidFilter [][32]uint8,
+) ([]*abi.TBTCSystemRedeemed, error) {
+	iterator, err := tbtcs.contract.FilterRedeemed(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
 		},
 		_depositContractAddressFilter,
+		_txidFilter,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error retrieving past SetupFailed events: [%v]",
+			"error retrieving past Redeemed events: [%v]",
 			err,
 		)
 	}
 
-	events := make([]*abi.TBTCSystemSetupFailed, 0)
+	events := make([]*abi.TBTCSystemRedeemed, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) CollateralizationThresholdsUpdated(
+	opts *ethutil.SubscribeOpts,
+) *TbtcsCollateralizationThresholdsUpdatedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsCollateralizationThresholdsUpdatedSubscription{
+		tbtcs,
+		opts,
+	}
+}
+
+type TbtcsCollateralizationThresholdsUpdatedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
+}
+
+type tBTCSystemCollateralizationThresholdsUpdatedFunc func(
+	InitialCollateralizedPercent uint16,
+	UndercollateralizedThresholdPercent uint16,
+	SeverelyUndercollateralizedThresholdPercent uint16,
+	blockNumber uint64,
+)
+
+func (ctus *TbtcsCollateralizationThresholdsUpdatedSubscription) OnEvent(
+	handler tBTCSystemCollateralizationThresholdsUpdatedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemCollateralizationThresholdsUpdated)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.InitialCollateralizedPercent,
+					event.UndercollateralizedThresholdPercent,
+					event.SeverelyUndercollateralizedThresholdPercent,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := ctus.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (ctus *TbtcsCollateralizationThresholdsUpdatedSubscription) Pipe(
+	sink chan *abi.TBTCSystemCollateralizationThresholdsUpdated,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(ctus.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := ctus.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - ctus.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past CollateralizationThresholdsUpdated events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := ctus.contract.PastCollateralizationThresholdsUpdatedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past CollateralizationThresholdsUpdated events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := ctus.contract.watchCollateralizationThresholdsUpdated(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchCollateralizationThresholdsUpdated(
+	sink chan *abi.TBTCSystemCollateralizationThresholdsUpdated,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchCollateralizationThresholdsUpdated(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event CollateralizationThresholdsUpdated had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event CollateralizationThresholdsUpdated failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastCollateralizationThresholdsUpdatedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemCollateralizationThresholdsUpdated, error) {
+	iterator, err := tbtcs.contract.FilterCollateralizationThresholdsUpdated(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past CollateralizationThresholdsUpdated events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemCollateralizationThresholdsUpdated, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -7853,9 +7857,10 @@ func (tbtcs *TBTCSystem) PastCreatedEvents(
 	return events, nil
 }
 
-func (tbtcs *TBTCSystem) EthBtcPriceFeedAdded(
+func (tbtcs *TBTCSystem) FunderAbortRequested(
 	opts *ethutil.SubscribeOpts,
-) *TbtcsEthBtcPriceFeedAddedSubscription {
+	_depositContractAddressFilter []common.Address,
+) *TbtcsFunderAbortRequestedSubscription {
 	if opts == nil {
 		opts = new(ethutil.SubscribeOpts)
 	}
@@ -7866,26 +7871,29 @@ func (tbtcs *TBTCSystem) EthBtcPriceFeedAdded(
 		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &TbtcsEthBtcPriceFeedAddedSubscription{
+	return &TbtcsFunderAbortRequestedSubscription{
 		tbtcs,
 		opts,
+		_depositContractAddressFilter,
 	}
 }
 
-type TbtcsEthBtcPriceFeedAddedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
+type TbtcsFunderAbortRequestedSubscription struct {
+	contract                      *TBTCSystem
+	opts                          *ethutil.SubscribeOpts
+	_depositContractAddressFilter []common.Address
 }
 
-type tBTCSystemEthBtcPriceFeedAddedFunc func(
-	PriceFeed common.Address,
+type tBTCSystemFunderAbortRequestedFunc func(
+	DepositContractAddress common.Address,
+	AbortOutputScript []uint8,
 	blockNumber uint64,
 )
 
-func (ebpfas *TbtcsEthBtcPriceFeedAddedSubscription) OnEvent(
-	handler tBTCSystemEthBtcPriceFeedAddedFunc,
+func (fars *TbtcsFunderAbortRequestedSubscription) OnEvent(
+	handler tBTCSystemFunderAbortRequestedFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemEthBtcPriceFeedAdded)
+	eventChan := make(chan *abi.TBTCSystemFunderAbortRequested)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -7895,49 +7903,51 @@ func (ebpfas *TbtcsEthBtcPriceFeedAddedSubscription) OnEvent(
 				return
 			case event := <-eventChan:
 				handler(
-					event.PriceFeed,
+					event.DepositContractAddress,
+					event.AbortOutputScript,
 					event.Raw.BlockNumber,
 				)
 			}
 		}
 	}()
 
-	sub := ebpfas.Pipe(eventChan)
+	sub := fars.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancelCtx()
 	})
 }
 
-func (ebpfas *TbtcsEthBtcPriceFeedAddedSubscription) Pipe(
-	sink chan *abi.TBTCSystemEthBtcPriceFeedAdded,
+func (fars *TbtcsFunderAbortRequestedSubscription) Pipe(
+	sink chan *abi.TBTCSystemFunderAbortRequested,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker(ebpfas.opts.Tick)
+		ticker := time.NewTicker(fars.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				lastBlock, err := ebpfas.contract.blockCounter.CurrentBlock()
+				lastBlock, err := fars.contract.blockCounter.CurrentBlock()
 				if err != nil {
 					tbtcsLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
-				fromBlock := lastBlock - ebpfas.opts.PastBlocks
+				fromBlock := lastBlock - fars.opts.PastBlocks
 
 				tbtcsLogger.Infof(
-					"subscription monitoring fetching past EthBtcPriceFeedAdded events "+
+					"subscription monitoring fetching past FunderAbortRequested events "+
 						"starting from block [%v]",
 					fromBlock,
 				)
-				events, err := ebpfas.contract.PastEthBtcPriceFeedAddedEvents(
+				events, err := fars.contract.PastFunderAbortRequestedEvents(
 					fromBlock,
 					nil,
+					fars._depositContractAddressFilter,
 				)
 				if err != nil {
 					tbtcsLogger.Errorf(
@@ -7947,7 +7957,7 @@ func (ebpfas *TbtcsEthBtcPriceFeedAddedSubscription) Pipe(
 					continue
 				}
 				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past EthBtcPriceFeedAdded events",
+					"subscription monitoring fetched [%v] past FunderAbortRequested events",
 					len(events),
 				)
 
@@ -7958,8 +7968,9 @@ func (ebpfas *TbtcsEthBtcPriceFeedAddedSubscription) Pipe(
 		}
 	}()
 
-	sub := ebpfas.contract.watchEthBtcPriceFeedAdded(
+	sub := fars.contract.watchFunderAbortRequested(
 		sink,
+		fars._depositContractAddressFilter,
 	)
 
 	return subscription.NewEventSubscription(func() {
@@ -7968,19 +7979,21 @@ func (ebpfas *TbtcsEthBtcPriceFeedAddedSubscription) Pipe(
 	})
 }
 
-func (tbtcs *TBTCSystem) watchEthBtcPriceFeedAdded(
-	sink chan *abi.TBTCSystemEthBtcPriceFeedAdded,
+func (tbtcs *TBTCSystem) watchFunderAbortRequested(
+	sink chan *abi.TBTCSystemFunderAbortRequested,
+	_depositContractAddressFilter []common.Address,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchEthBtcPriceFeedAdded(
+		return tbtcs.contract.WatchFunderAbortRequested(
 			&bind.WatchOpts{Context: ctx},
 			sink,
+			_depositContractAddressFilter,
 		)
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		tbtcsLogger.Errorf(
-			"subscription to event EthBtcPriceFeedAdded had to be "+
+			"subscription to event FunderAbortRequested had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"Ethereum connectivity",
 			elapsed,
@@ -7989,7 +8002,7 @@ func (tbtcs *TBTCSystem) watchEthBtcPriceFeedAdded(
 
 	subscriptionFailedFn := func(err error) {
 		tbtcsLogger.Errorf(
-			"subscription to event EthBtcPriceFeedAdded failed "+
+			"subscription to event FunderAbortRequested failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
 			err,
@@ -8005,11 +8018,194 @@ func (tbtcs *TBTCSystem) watchEthBtcPriceFeedAdded(
 	)
 }
 
-func (tbtcs *TBTCSystem) PastEthBtcPriceFeedAddedEvents(
+func (tbtcs *TBTCSystem) PastFunderAbortRequestedEvents(
 	startBlock uint64,
 	endBlock *uint64,
-) ([]*abi.TBTCSystemEthBtcPriceFeedAdded, error) {
-	iterator, err := tbtcs.contract.FilterEthBtcPriceFeedAdded(
+	_depositContractAddressFilter []common.Address,
+) ([]*abi.TBTCSystemFunderAbortRequested, error) {
+	iterator, err := tbtcs.contract.FilterFunderAbortRequested(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+		_depositContractAddressFilter,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past FunderAbortRequested events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemFunderAbortRequested, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) LotSizesUpdateStarted(
+	opts *ethutil.SubscribeOpts,
+) *TbtcsLotSizesUpdateStartedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsLotSizesUpdateStartedSubscription{
+		tbtcs,
+		opts,
+	}
+}
+
+type TbtcsLotSizesUpdateStartedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
+}
+
+type tBTCSystemLotSizesUpdateStartedFunc func(
+	LotSizes []uint64,
+	Timestamp *big.Int,
+	blockNumber uint64,
+)
+
+func (lsuss *TbtcsLotSizesUpdateStartedSubscription) OnEvent(
+	handler tBTCSystemLotSizesUpdateStartedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemLotSizesUpdateStarted)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.LotSizes,
+					event.Timestamp,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := lsuss.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (lsuss *TbtcsLotSizesUpdateStartedSubscription) Pipe(
+	sink chan *abi.TBTCSystemLotSizesUpdateStarted,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(lsuss.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := lsuss.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - lsuss.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past LotSizesUpdateStarted events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := lsuss.contract.PastLotSizesUpdateStartedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past LotSizesUpdateStarted events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := lsuss.contract.watchLotSizesUpdateStarted(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchLotSizesUpdateStarted(
+	sink chan *abi.TBTCSystemLotSizesUpdateStarted,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchLotSizesUpdateStarted(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event LotSizesUpdateStarted had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event LotSizesUpdateStarted failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastLotSizesUpdateStartedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemLotSizesUpdateStarted, error) {
+	iterator, err := tbtcs.contract.FilterLotSizesUpdateStarted(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
@@ -8017,12 +8213,756 @@ func (tbtcs *TBTCSystem) PastEthBtcPriceFeedAddedEvents(
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error retrieving past EthBtcPriceFeedAdded events: [%v]",
+			"error retrieving past LotSizesUpdateStarted events: [%v]",
 			err,
 		)
 	}
 
-	events := make([]*abi.TBTCSystemEthBtcPriceFeedAdded, 0)
+	events := make([]*abi.TBTCSystemLotSizesUpdateStarted, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) OwnershipTransferred(
+	opts *ethutil.SubscribeOpts,
+	previousOwnerFilter []common.Address,
+	newOwnerFilter []common.Address,
+) *TbtcsOwnershipTransferredSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsOwnershipTransferredSubscription{
+		tbtcs,
+		opts,
+		previousOwnerFilter,
+		newOwnerFilter,
+	}
+}
+
+type TbtcsOwnershipTransferredSubscription struct {
+	contract            *TBTCSystem
+	opts                *ethutil.SubscribeOpts
+	previousOwnerFilter []common.Address
+	newOwnerFilter      []common.Address
+}
+
+type tBTCSystemOwnershipTransferredFunc func(
+	PreviousOwner common.Address,
+	NewOwner common.Address,
+	blockNumber uint64,
+)
+
+func (ots *TbtcsOwnershipTransferredSubscription) OnEvent(
+	handler tBTCSystemOwnershipTransferredFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemOwnershipTransferred)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.PreviousOwner,
+					event.NewOwner,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := ots.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (ots *TbtcsOwnershipTransferredSubscription) Pipe(
+	sink chan *abi.TBTCSystemOwnershipTransferred,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(ots.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := ots.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - ots.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past OwnershipTransferred events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := ots.contract.PastOwnershipTransferredEvents(
+					fromBlock,
+					nil,
+					ots.previousOwnerFilter,
+					ots.newOwnerFilter,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past OwnershipTransferred events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := ots.contract.watchOwnershipTransferred(
+		sink,
+		ots.previousOwnerFilter,
+		ots.newOwnerFilter,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchOwnershipTransferred(
+	sink chan *abi.TBTCSystemOwnershipTransferred,
+	previousOwnerFilter []common.Address,
+	newOwnerFilter []common.Address,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchOwnershipTransferred(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+			previousOwnerFilter,
+			newOwnerFilter,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event OwnershipTransferred had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event OwnershipTransferred failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastOwnershipTransferredEvents(
+	startBlock uint64,
+	endBlock *uint64,
+	previousOwnerFilter []common.Address,
+	newOwnerFilter []common.Address,
+) ([]*abi.TBTCSystemOwnershipTransferred, error) {
+	iterator, err := tbtcs.contract.FilterOwnershipTransferred(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+		previousOwnerFilter,
+		newOwnerFilter,
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past OwnershipTransferred events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemOwnershipTransferred, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) SignerFeeDivisorUpdateStarted(
+	opts *ethutil.SubscribeOpts,
+) *TbtcsSignerFeeDivisorUpdateStartedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsSignerFeeDivisorUpdateStartedSubscription{
+		tbtcs,
+		opts,
+	}
+}
+
+type TbtcsSignerFeeDivisorUpdateStartedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
+}
+
+type tBTCSystemSignerFeeDivisorUpdateStartedFunc func(
+	SignerFeeDivisor uint16,
+	Timestamp *big.Int,
+	blockNumber uint64,
+)
+
+func (sfduss *TbtcsSignerFeeDivisorUpdateStartedSubscription) OnEvent(
+	handler tBTCSystemSignerFeeDivisorUpdateStartedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemSignerFeeDivisorUpdateStarted)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.SignerFeeDivisor,
+					event.Timestamp,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := sfduss.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (sfduss *TbtcsSignerFeeDivisorUpdateStartedSubscription) Pipe(
+	sink chan *abi.TBTCSystemSignerFeeDivisorUpdateStarted,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(sfduss.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := sfduss.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - sfduss.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past SignerFeeDivisorUpdateStarted events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := sfduss.contract.PastSignerFeeDivisorUpdateStartedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past SignerFeeDivisorUpdateStarted events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := sfduss.contract.watchSignerFeeDivisorUpdateStarted(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchSignerFeeDivisorUpdateStarted(
+	sink chan *abi.TBTCSystemSignerFeeDivisorUpdateStarted,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchSignerFeeDivisorUpdateStarted(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event SignerFeeDivisorUpdateStarted had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event SignerFeeDivisorUpdateStarted failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastSignerFeeDivisorUpdateStartedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemSignerFeeDivisorUpdateStarted, error) {
+	iterator, err := tbtcs.contract.FilterSignerFeeDivisorUpdateStarted(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past SignerFeeDivisorUpdateStarted events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemSignerFeeDivisorUpdateStarted, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) SignerFeeDivisorUpdated(
+	opts *ethutil.SubscribeOpts,
+) *TbtcsSignerFeeDivisorUpdatedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsSignerFeeDivisorUpdatedSubscription{
+		tbtcs,
+		opts,
+	}
+}
+
+type TbtcsSignerFeeDivisorUpdatedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
+}
+
+type tBTCSystemSignerFeeDivisorUpdatedFunc func(
+	SignerFeeDivisor uint16,
+	blockNumber uint64,
+)
+
+func (sfdus *TbtcsSignerFeeDivisorUpdatedSubscription) OnEvent(
+	handler tBTCSystemSignerFeeDivisorUpdatedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemSignerFeeDivisorUpdated)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.SignerFeeDivisor,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := sfdus.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (sfdus *TbtcsSignerFeeDivisorUpdatedSubscription) Pipe(
+	sink chan *abi.TBTCSystemSignerFeeDivisorUpdated,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(sfdus.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := sfdus.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - sfdus.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past SignerFeeDivisorUpdated events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := sfdus.contract.PastSignerFeeDivisorUpdatedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past SignerFeeDivisorUpdated events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := sfdus.contract.watchSignerFeeDivisorUpdated(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchSignerFeeDivisorUpdated(
+	sink chan *abi.TBTCSystemSignerFeeDivisorUpdated,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchSignerFeeDivisorUpdated(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event SignerFeeDivisorUpdated had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event SignerFeeDivisorUpdated failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastSignerFeeDivisorUpdatedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemSignerFeeDivisorUpdated, error) {
+	iterator, err := tbtcs.contract.FilterSignerFeeDivisorUpdated(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past SignerFeeDivisorUpdated events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemSignerFeeDivisorUpdated, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) CollateralizationThresholdsUpdateStarted(
+	opts *ethutil.SubscribeOpts,
+) *TbtcsCollateralizationThresholdsUpdateStartedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsCollateralizationThresholdsUpdateStartedSubscription{
+		tbtcs,
+		opts,
+	}
+}
+
+type TbtcsCollateralizationThresholdsUpdateStartedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
+}
+
+type tBTCSystemCollateralizationThresholdsUpdateStartedFunc func(
+	InitialCollateralizedPercent uint16,
+	UndercollateralizedThresholdPercent uint16,
+	SeverelyUndercollateralizedThresholdPercent uint16,
+	Timestamp *big.Int,
+	blockNumber uint64,
+)
+
+func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) OnEvent(
+	handler tBTCSystemCollateralizationThresholdsUpdateStartedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemCollateralizationThresholdsUpdateStarted)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.InitialCollateralizedPercent,
+					event.UndercollateralizedThresholdPercent,
+					event.SeverelyUndercollateralizedThresholdPercent,
+					event.Timestamp,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := ctuss.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (ctuss *TbtcsCollateralizationThresholdsUpdateStartedSubscription) Pipe(
+	sink chan *abi.TBTCSystemCollateralizationThresholdsUpdateStarted,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(ctuss.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := ctuss.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - ctuss.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past CollateralizationThresholdsUpdateStarted events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := ctuss.contract.PastCollateralizationThresholdsUpdateStartedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past CollateralizationThresholdsUpdateStarted events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := ctuss.contract.watchCollateralizationThresholdsUpdateStarted(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchCollateralizationThresholdsUpdateStarted(
+	sink chan *abi.TBTCSystemCollateralizationThresholdsUpdateStarted,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchCollateralizationThresholdsUpdateStarted(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event CollateralizationThresholdsUpdateStarted had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event CollateralizationThresholdsUpdateStarted failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastCollateralizationThresholdsUpdateStartedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemCollateralizationThresholdsUpdateStarted, error) {
+	iterator, err := tbtcs.contract.FilterCollateralizationThresholdsUpdateStarted(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past CollateralizationThresholdsUpdateStarted events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemCollateralizationThresholdsUpdateStarted, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -8403,11 +9343,10 @@ func (tbtcs *TBTCSystem) PastExitedCourtesyCallEvents(
 	return events, nil
 }
 
-func (tbtcs *TBTCSystem) Funded(
+func (tbtcs *TBTCSystem) RegisteredPubkey(
 	opts *ethutil.SubscribeOpts,
 	_depositContractAddressFilter []common.Address,
-	_txidFilter [][32]uint8,
-) *TbtcsFundedSubscription {
+) *TbtcsRegisteredPubkeySubscription {
 	if opts == nil {
 		opts = new(ethutil.SubscribeOpts)
 	}
@@ -8418,32 +9357,31 @@ func (tbtcs *TBTCSystem) Funded(
 		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
 	}
 
-	return &TbtcsFundedSubscription{
+	return &TbtcsRegisteredPubkeySubscription{
 		tbtcs,
 		opts,
 		_depositContractAddressFilter,
-		_txidFilter,
 	}
 }
 
-type TbtcsFundedSubscription struct {
+type TbtcsRegisteredPubkeySubscription struct {
 	contract                      *TBTCSystem
 	opts                          *ethutil.SubscribeOpts
 	_depositContractAddressFilter []common.Address
-	_txidFilter                   [][32]uint8
 }
 
-type tBTCSystemFundedFunc func(
+type tBTCSystemRegisteredPubkeyFunc func(
 	DepositContractAddress common.Address,
-	Txid [32]uint8,
+	SigningGroupPubkeyX [32]uint8,
+	SigningGroupPubkeyY [32]uint8,
 	Timestamp *big.Int,
 	blockNumber uint64,
 )
 
-func (fs *TbtcsFundedSubscription) OnEvent(
-	handler tBTCSystemFundedFunc,
+func (rps *TbtcsRegisteredPubkeySubscription) OnEvent(
+	handler tBTCSystemRegisteredPubkeyFunc,
 ) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemFunded)
+	eventChan := make(chan *abi.TBTCSystemRegisteredPubkey)
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
 	go func() {
@@ -8454,7 +9392,8 @@ func (fs *TbtcsFundedSubscription) OnEvent(
 			case event := <-eventChan:
 				handler(
 					event.DepositContractAddress,
-					event.Txid,
+					event.SigningGroupPubkeyX,
+					event.SigningGroupPubkeyY,
 					event.Timestamp,
 					event.Raw.BlockNumber,
 				)
@@ -8462,44 +9401,43 @@ func (fs *TbtcsFundedSubscription) OnEvent(
 		}
 	}()
 
-	sub := fs.Pipe(eventChan)
+	sub := rps.Pipe(eventChan)
 	return subscription.NewEventSubscription(func() {
 		sub.Unsubscribe()
 		cancelCtx()
 	})
 }
 
-func (fs *TbtcsFundedSubscription) Pipe(
-	sink chan *abi.TBTCSystemFunded,
+func (rps *TbtcsRegisteredPubkeySubscription) Pipe(
+	sink chan *abi.TBTCSystemRegisteredPubkey,
 ) subscription.EventSubscription {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 	go func() {
-		ticker := time.NewTicker(fs.opts.Tick)
+		ticker := time.NewTicker(rps.opts.Tick)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				lastBlock, err := fs.contract.blockCounter.CurrentBlock()
+				lastBlock, err := rps.contract.blockCounter.CurrentBlock()
 				if err != nil {
 					tbtcsLogger.Errorf(
 						"subscription failed to pull events: [%v]",
 						err,
 					)
 				}
-				fromBlock := lastBlock - fs.opts.PastBlocks
+				fromBlock := lastBlock - rps.opts.PastBlocks
 
 				tbtcsLogger.Infof(
-					"subscription monitoring fetching past Funded events "+
+					"subscription monitoring fetching past RegisteredPubkey events "+
 						"starting from block [%v]",
 					fromBlock,
 				)
-				events, err := fs.contract.PastFundedEvents(
+				events, err := rps.contract.PastRegisteredPubkeyEvents(
 					fromBlock,
 					nil,
-					fs._depositContractAddressFilter,
-					fs._txidFilter,
+					rps._depositContractAddressFilter,
 				)
 				if err != nil {
 					tbtcsLogger.Errorf(
@@ -8509,7 +9447,7 @@ func (fs *TbtcsFundedSubscription) Pipe(
 					continue
 				}
 				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past Funded events",
+					"subscription monitoring fetched [%v] past RegisteredPubkey events",
 					len(events),
 				)
 
@@ -8520,10 +9458,9 @@ func (fs *TbtcsFundedSubscription) Pipe(
 		}
 	}()
 
-	sub := fs.contract.watchFunded(
+	sub := rps.contract.watchRegisteredPubkey(
 		sink,
-		fs._depositContractAddressFilter,
-		fs._txidFilter,
+		rps._depositContractAddressFilter,
 	)
 
 	return subscription.NewEventSubscription(func() {
@@ -8532,23 +9469,21 @@ func (fs *TbtcsFundedSubscription) Pipe(
 	})
 }
 
-func (tbtcs *TBTCSystem) watchFunded(
-	sink chan *abi.TBTCSystemFunded,
+func (tbtcs *TBTCSystem) watchRegisteredPubkey(
+	sink chan *abi.TBTCSystemRegisteredPubkey,
 	_depositContractAddressFilter []common.Address,
-	_txidFilter [][32]uint8,
 ) event.Subscription {
 	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchFunded(
+		return tbtcs.contract.WatchRegisteredPubkey(
 			&bind.WatchOpts{Context: ctx},
 			sink,
 			_depositContractAddressFilter,
-			_txidFilter,
 		)
 	}
 
 	thresholdViolatedFn := func(elapsed time.Duration) {
 		tbtcsLogger.Errorf(
-			"subscription to event Funded had to be "+
+			"subscription to event RegisteredPubkey had to be "+
 				"retried [%s] since the last attempt; please inspect "+
 				"Ethereum connectivity",
 			elapsed,
@@ -8557,7 +9492,7 @@ func (tbtcs *TBTCSystem) watchFunded(
 
 	subscriptionFailedFn := func(err error) {
 		tbtcsLogger.Errorf(
-			"subscription to event Funded failed "+
+			"subscription to event RegisteredPubkey failed "+
 				"with error: [%v]; resubscription attempt will be "+
 				"performed",
 			err,
@@ -8573,28 +9508,384 @@ func (tbtcs *TBTCSystem) watchFunded(
 	)
 }
 
-func (tbtcs *TBTCSystem) PastFundedEvents(
+func (tbtcs *TBTCSystem) PastRegisteredPubkeyEvents(
 	startBlock uint64,
 	endBlock *uint64,
 	_depositContractAddressFilter []common.Address,
-	_txidFilter [][32]uint8,
-) ([]*abi.TBTCSystemFunded, error) {
-	iterator, err := tbtcs.contract.FilterFunded(
+) ([]*abi.TBTCSystemRegisteredPubkey, error) {
+	iterator, err := tbtcs.contract.FilterRegisteredPubkey(
 		&bind.FilterOpts{
 			Start: startBlock,
 			End:   endBlock,
 		},
 		_depositContractAddressFilter,
-		_txidFilter,
 	)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"error retrieving past Funded events: [%v]",
+			"error retrieving past RegisteredPubkey events: [%v]",
 			err,
 		)
 	}
 
-	events := make([]*abi.TBTCSystemFunded, 0)
+	events := make([]*abi.TBTCSystemRegisteredPubkey, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) AllowNewDepositsUpdated(
+	opts *ethutil.SubscribeOpts,
+) *TbtcsAllowNewDepositsUpdatedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsAllowNewDepositsUpdatedSubscription{
+		tbtcs,
+		opts,
+	}
+}
+
+type TbtcsAllowNewDepositsUpdatedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
+}
+
+type tBTCSystemAllowNewDepositsUpdatedFunc func(
+	AllowNewDeposits bool,
+	blockNumber uint64,
+)
+
+func (andus *TbtcsAllowNewDepositsUpdatedSubscription) OnEvent(
+	handler tBTCSystemAllowNewDepositsUpdatedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemAllowNewDepositsUpdated)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.AllowNewDeposits,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := andus.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (andus *TbtcsAllowNewDepositsUpdatedSubscription) Pipe(
+	sink chan *abi.TBTCSystemAllowNewDepositsUpdated,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(andus.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := andus.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - andus.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past AllowNewDepositsUpdated events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := andus.contract.PastAllowNewDepositsUpdatedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past AllowNewDepositsUpdated events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := andus.contract.watchAllowNewDepositsUpdated(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchAllowNewDepositsUpdated(
+	sink chan *abi.TBTCSystemAllowNewDepositsUpdated,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchAllowNewDepositsUpdated(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event AllowNewDepositsUpdated had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event AllowNewDepositsUpdated failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastAllowNewDepositsUpdatedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemAllowNewDepositsUpdated, error) {
+	iterator, err := tbtcs.contract.FilterAllowNewDepositsUpdated(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past AllowNewDepositsUpdated events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemAllowNewDepositsUpdated, 0)
+
+	for iterator.Next() {
+		event := iterator.Event
+		events = append(events, event)
+	}
+
+	return events, nil
+}
+
+func (tbtcs *TBTCSystem) EthBtcPriceFeedAdded(
+	opts *ethutil.SubscribeOpts,
+) *TbtcsEthBtcPriceFeedAddedSubscription {
+	if opts == nil {
+		opts = new(ethutil.SubscribeOpts)
+	}
+	if opts.Tick == 0 {
+		opts.Tick = ethutil.DefaultSubscribeOptsTick
+	}
+	if opts.PastBlocks == 0 {
+		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
+	}
+
+	return &TbtcsEthBtcPriceFeedAddedSubscription{
+		tbtcs,
+		opts,
+	}
+}
+
+type TbtcsEthBtcPriceFeedAddedSubscription struct {
+	contract *TBTCSystem
+	opts     *ethutil.SubscribeOpts
+}
+
+type tBTCSystemEthBtcPriceFeedAddedFunc func(
+	PriceFeed common.Address,
+	blockNumber uint64,
+)
+
+func (ebpfas *TbtcsEthBtcPriceFeedAddedSubscription) OnEvent(
+	handler tBTCSystemEthBtcPriceFeedAddedFunc,
+) subscription.EventSubscription {
+	eventChan := make(chan *abi.TBTCSystemEthBtcPriceFeedAdded)
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case event := <-eventChan:
+				handler(
+					event.PriceFeed,
+					event.Raw.BlockNumber,
+				)
+			}
+		}
+	}()
+
+	sub := ebpfas.Pipe(eventChan)
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (ebpfas *TbtcsEthBtcPriceFeedAddedSubscription) Pipe(
+	sink chan *abi.TBTCSystemEthBtcPriceFeedAdded,
+) subscription.EventSubscription {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	go func() {
+		ticker := time.NewTicker(ebpfas.opts.Tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				lastBlock, err := ebpfas.contract.blockCounter.CurrentBlock()
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+				}
+				fromBlock := lastBlock - ebpfas.opts.PastBlocks
+
+				tbtcsLogger.Infof(
+					"subscription monitoring fetching past EthBtcPriceFeedAdded events "+
+						"starting from block [%v]",
+					fromBlock,
+				)
+				events, err := ebpfas.contract.PastEthBtcPriceFeedAddedEvents(
+					fromBlock,
+					nil,
+				)
+				if err != nil {
+					tbtcsLogger.Errorf(
+						"subscription failed to pull events: [%v]",
+						err,
+					)
+					continue
+				}
+				tbtcsLogger.Infof(
+					"subscription monitoring fetched [%v] past EthBtcPriceFeedAdded events",
+					len(events),
+				)
+
+				for _, event := range events {
+					sink <- event
+				}
+			}
+		}
+	}()
+
+	sub := ebpfas.contract.watchEthBtcPriceFeedAdded(
+		sink,
+	)
+
+	return subscription.NewEventSubscription(func() {
+		sub.Unsubscribe()
+		cancelCtx()
+	})
+}
+
+func (tbtcs *TBTCSystem) watchEthBtcPriceFeedAdded(
+	sink chan *abi.TBTCSystemEthBtcPriceFeedAdded,
+) event.Subscription {
+	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
+		return tbtcs.contract.WatchEthBtcPriceFeedAdded(
+			&bind.WatchOpts{Context: ctx},
+			sink,
+		)
+	}
+
+	thresholdViolatedFn := func(elapsed time.Duration) {
+		tbtcsLogger.Errorf(
+			"subscription to event EthBtcPriceFeedAdded had to be "+
+				"retried [%s] since the last attempt; please inspect "+
+				"Ethereum connectivity",
+			elapsed,
+		)
+	}
+
+	subscriptionFailedFn := func(err error) {
+		tbtcsLogger.Errorf(
+			"subscription to event EthBtcPriceFeedAdded failed "+
+				"with error: [%v]; resubscription attempt will be "+
+				"performed",
+			err,
+		)
+	}
+
+	return ethutil.WithResubscription(
+		ethutil.SubscriptionBackoffMax,
+		subscribeFn,
+		ethutil.SubscriptionAlertThreshold,
+		thresholdViolatedFn,
+		subscriptionFailedFn,
+	)
+}
+
+func (tbtcs *TBTCSystem) PastEthBtcPriceFeedAddedEvents(
+	startBlock uint64,
+	endBlock *uint64,
+) ([]*abi.TBTCSystemEthBtcPriceFeedAdded, error) {
+	iterator, err := tbtcs.contract.FilterEthBtcPriceFeedAdded(
+		&bind.FilterOpts{
+			Start: startBlock,
+			End:   endBlock,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"error retrieving past EthBtcPriceFeedAdded events: [%v]",
+			err,
+		)
+	}
+
+	events := make([]*abi.TBTCSystemEthBtcPriceFeedAdded, 0)
 
 	for iterator.Next() {
 		event := iterator.Event
@@ -8800,1297 +10091,6 @@ func (tbtcs *TBTCSystem) PastGotRedemptionSignatureEvents(
 	}
 
 	events := make([]*abi.TBTCSystemGotRedemptionSignature, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) LotSizesUpdated(
-	opts *ethutil.SubscribeOpts,
-) *TbtcsLotSizesUpdatedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsLotSizesUpdatedSubscription{
-		tbtcs,
-		opts,
-	}
-}
-
-type TbtcsLotSizesUpdatedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
-}
-
-type tBTCSystemLotSizesUpdatedFunc func(
-	LotSizes []uint64,
-	blockNumber uint64,
-)
-
-func (lsus *TbtcsLotSizesUpdatedSubscription) OnEvent(
-	handler tBTCSystemLotSizesUpdatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemLotSizesUpdated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.LotSizes,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := lsus.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (lsus *TbtcsLotSizesUpdatedSubscription) Pipe(
-	sink chan *abi.TBTCSystemLotSizesUpdated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(lsus.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := lsus.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - lsus.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past LotSizesUpdated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := lsus.contract.PastLotSizesUpdatedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past LotSizesUpdated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := lsus.contract.watchLotSizesUpdated(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchLotSizesUpdated(
-	sink chan *abi.TBTCSystemLotSizesUpdated,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchLotSizesUpdated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event LotSizesUpdated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event LotSizesUpdated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastLotSizesUpdatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.TBTCSystemLotSizesUpdated, error) {
-	iterator, err := tbtcs.contract.FilterLotSizesUpdated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past LotSizesUpdated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemLotSizesUpdated, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) SignerFeeDivisorUpdated(
-	opts *ethutil.SubscribeOpts,
-) *TbtcsSignerFeeDivisorUpdatedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsSignerFeeDivisorUpdatedSubscription{
-		tbtcs,
-		opts,
-	}
-}
-
-type TbtcsSignerFeeDivisorUpdatedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
-}
-
-type tBTCSystemSignerFeeDivisorUpdatedFunc func(
-	SignerFeeDivisor uint16,
-	blockNumber uint64,
-)
-
-func (sfdus *TbtcsSignerFeeDivisorUpdatedSubscription) OnEvent(
-	handler tBTCSystemSignerFeeDivisorUpdatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemSignerFeeDivisorUpdated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.SignerFeeDivisor,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := sfdus.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (sfdus *TbtcsSignerFeeDivisorUpdatedSubscription) Pipe(
-	sink chan *abi.TBTCSystemSignerFeeDivisorUpdated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(sfdus.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := sfdus.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - sfdus.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past SignerFeeDivisorUpdated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := sfdus.contract.PastSignerFeeDivisorUpdatedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past SignerFeeDivisorUpdated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := sfdus.contract.watchSignerFeeDivisorUpdated(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchSignerFeeDivisorUpdated(
-	sink chan *abi.TBTCSystemSignerFeeDivisorUpdated,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchSignerFeeDivisorUpdated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event SignerFeeDivisorUpdated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event SignerFeeDivisorUpdated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastSignerFeeDivisorUpdatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.TBTCSystemSignerFeeDivisorUpdated, error) {
-	iterator, err := tbtcs.contract.FilterSignerFeeDivisorUpdated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past SignerFeeDivisorUpdated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemSignerFeeDivisorUpdated, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) SignerFeeDivisorUpdateStarted(
-	opts *ethutil.SubscribeOpts,
-) *TbtcsSignerFeeDivisorUpdateStartedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsSignerFeeDivisorUpdateStartedSubscription{
-		tbtcs,
-		opts,
-	}
-}
-
-type TbtcsSignerFeeDivisorUpdateStartedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
-}
-
-type tBTCSystemSignerFeeDivisorUpdateStartedFunc func(
-	SignerFeeDivisor uint16,
-	Timestamp *big.Int,
-	blockNumber uint64,
-)
-
-func (sfduss *TbtcsSignerFeeDivisorUpdateStartedSubscription) OnEvent(
-	handler tBTCSystemSignerFeeDivisorUpdateStartedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemSignerFeeDivisorUpdateStarted)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.SignerFeeDivisor,
-					event.Timestamp,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := sfduss.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (sfduss *TbtcsSignerFeeDivisorUpdateStartedSubscription) Pipe(
-	sink chan *abi.TBTCSystemSignerFeeDivisorUpdateStarted,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(sfduss.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := sfduss.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - sfduss.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past SignerFeeDivisorUpdateStarted events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := sfduss.contract.PastSignerFeeDivisorUpdateStartedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past SignerFeeDivisorUpdateStarted events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := sfduss.contract.watchSignerFeeDivisorUpdateStarted(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchSignerFeeDivisorUpdateStarted(
-	sink chan *abi.TBTCSystemSignerFeeDivisorUpdateStarted,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchSignerFeeDivisorUpdateStarted(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event SignerFeeDivisorUpdateStarted had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event SignerFeeDivisorUpdateStarted failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastSignerFeeDivisorUpdateStartedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.TBTCSystemSignerFeeDivisorUpdateStarted, error) {
-	iterator, err := tbtcs.contract.FilterSignerFeeDivisorUpdateStarted(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past SignerFeeDivisorUpdateStarted events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemSignerFeeDivisorUpdateStarted, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) CollateralizationThresholdsUpdated(
-	opts *ethutil.SubscribeOpts,
-) *TbtcsCollateralizationThresholdsUpdatedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsCollateralizationThresholdsUpdatedSubscription{
-		tbtcs,
-		opts,
-	}
-}
-
-type TbtcsCollateralizationThresholdsUpdatedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
-}
-
-type tBTCSystemCollateralizationThresholdsUpdatedFunc func(
-	InitialCollateralizedPercent uint16,
-	UndercollateralizedThresholdPercent uint16,
-	SeverelyUndercollateralizedThresholdPercent uint16,
-	blockNumber uint64,
-)
-
-func (ctus *TbtcsCollateralizationThresholdsUpdatedSubscription) OnEvent(
-	handler tBTCSystemCollateralizationThresholdsUpdatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemCollateralizationThresholdsUpdated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.InitialCollateralizedPercent,
-					event.UndercollateralizedThresholdPercent,
-					event.SeverelyUndercollateralizedThresholdPercent,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := ctus.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (ctus *TbtcsCollateralizationThresholdsUpdatedSubscription) Pipe(
-	sink chan *abi.TBTCSystemCollateralizationThresholdsUpdated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(ctus.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := ctus.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - ctus.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past CollateralizationThresholdsUpdated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := ctus.contract.PastCollateralizationThresholdsUpdatedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past CollateralizationThresholdsUpdated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := ctus.contract.watchCollateralizationThresholdsUpdated(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchCollateralizationThresholdsUpdated(
-	sink chan *abi.TBTCSystemCollateralizationThresholdsUpdated,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchCollateralizationThresholdsUpdated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event CollateralizationThresholdsUpdated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event CollateralizationThresholdsUpdated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastCollateralizationThresholdsUpdatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.TBTCSystemCollateralizationThresholdsUpdated, error) {
-	iterator, err := tbtcs.contract.FilterCollateralizationThresholdsUpdated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past CollateralizationThresholdsUpdated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemCollateralizationThresholdsUpdated, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) KeepFactoriesUpdateStarted(
-	opts *ethutil.SubscribeOpts,
-) *TbtcsKeepFactoriesUpdateStartedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsKeepFactoriesUpdateStartedSubscription{
-		tbtcs,
-		opts,
-	}
-}
-
-type TbtcsKeepFactoriesUpdateStartedSubscription struct {
-	contract *TBTCSystem
-	opts     *ethutil.SubscribeOpts
-}
-
-type tBTCSystemKeepFactoriesUpdateStartedFunc func(
-	KeepStakedFactory common.Address,
-	FullyBackedFactory common.Address,
-	FactorySelector common.Address,
-	Timestamp *big.Int,
-	blockNumber uint64,
-)
-
-func (kfuss *TbtcsKeepFactoriesUpdateStartedSubscription) OnEvent(
-	handler tBTCSystemKeepFactoriesUpdateStartedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemKeepFactoriesUpdateStarted)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.KeepStakedFactory,
-					event.FullyBackedFactory,
-					event.FactorySelector,
-					event.Timestamp,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := kfuss.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (kfuss *TbtcsKeepFactoriesUpdateStartedSubscription) Pipe(
-	sink chan *abi.TBTCSystemKeepFactoriesUpdateStarted,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(kfuss.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := kfuss.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - kfuss.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past KeepFactoriesUpdateStarted events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := kfuss.contract.PastKeepFactoriesUpdateStartedEvents(
-					fromBlock,
-					nil,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past KeepFactoriesUpdateStarted events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := kfuss.contract.watchKeepFactoriesUpdateStarted(
-		sink,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchKeepFactoriesUpdateStarted(
-	sink chan *abi.TBTCSystemKeepFactoriesUpdateStarted,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchKeepFactoriesUpdateStarted(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event KeepFactoriesUpdateStarted had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event KeepFactoriesUpdateStarted failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastKeepFactoriesUpdateStartedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-) ([]*abi.TBTCSystemKeepFactoriesUpdateStarted, error) {
-	iterator, err := tbtcs.contract.FilterKeepFactoriesUpdateStarted(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past KeepFactoriesUpdateStarted events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemKeepFactoriesUpdateStarted, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) Liquidated(
-	opts *ethutil.SubscribeOpts,
-	_depositContractAddressFilter []common.Address,
-) *TbtcsLiquidatedSubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsLiquidatedSubscription{
-		tbtcs,
-		opts,
-		_depositContractAddressFilter,
-	}
-}
-
-type TbtcsLiquidatedSubscription struct {
-	contract                      *TBTCSystem
-	opts                          *ethutil.SubscribeOpts
-	_depositContractAddressFilter []common.Address
-}
-
-type tBTCSystemLiquidatedFunc func(
-	DepositContractAddress common.Address,
-	Timestamp *big.Int,
-	blockNumber uint64,
-)
-
-func (ls *TbtcsLiquidatedSubscription) OnEvent(
-	handler tBTCSystemLiquidatedFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemLiquidated)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.DepositContractAddress,
-					event.Timestamp,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := ls.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (ls *TbtcsLiquidatedSubscription) Pipe(
-	sink chan *abi.TBTCSystemLiquidated,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(ls.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := ls.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - ls.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past Liquidated events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := ls.contract.PastLiquidatedEvents(
-					fromBlock,
-					nil,
-					ls._depositContractAddressFilter,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past Liquidated events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := ls.contract.watchLiquidated(
-		sink,
-		ls._depositContractAddressFilter,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchLiquidated(
-	sink chan *abi.TBTCSystemLiquidated,
-	_depositContractAddressFilter []common.Address,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchLiquidated(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-			_depositContractAddressFilter,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event Liquidated had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event Liquidated failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastLiquidatedEvents(
-	startBlock uint64,
-	endBlock *uint64,
-	_depositContractAddressFilter []common.Address,
-) ([]*abi.TBTCSystemLiquidated, error) {
-	iterator, err := tbtcs.contract.FilterLiquidated(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-		_depositContractAddressFilter,
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past Liquidated events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemLiquidated, 0)
-
-	for iterator.Next() {
-		event := iterator.Event
-		events = append(events, event)
-	}
-
-	return events, nil
-}
-
-func (tbtcs *TBTCSystem) RegisteredPubkey(
-	opts *ethutil.SubscribeOpts,
-	_depositContractAddressFilter []common.Address,
-) *TbtcsRegisteredPubkeySubscription {
-	if opts == nil {
-		opts = new(ethutil.SubscribeOpts)
-	}
-	if opts.Tick == 0 {
-		opts.Tick = ethutil.DefaultSubscribeOptsTick
-	}
-	if opts.PastBlocks == 0 {
-		opts.PastBlocks = ethutil.DefaultSubscribeOptsPastBlocks
-	}
-
-	return &TbtcsRegisteredPubkeySubscription{
-		tbtcs,
-		opts,
-		_depositContractAddressFilter,
-	}
-}
-
-type TbtcsRegisteredPubkeySubscription struct {
-	contract                      *TBTCSystem
-	opts                          *ethutil.SubscribeOpts
-	_depositContractAddressFilter []common.Address
-}
-
-type tBTCSystemRegisteredPubkeyFunc func(
-	DepositContractAddress common.Address,
-	SigningGroupPubkeyX [32]uint8,
-	SigningGroupPubkeyY [32]uint8,
-	Timestamp *big.Int,
-	blockNumber uint64,
-)
-
-func (rps *TbtcsRegisteredPubkeySubscription) OnEvent(
-	handler tBTCSystemRegisteredPubkeyFunc,
-) subscription.EventSubscription {
-	eventChan := make(chan *abi.TBTCSystemRegisteredPubkey)
-	ctx, cancelCtx := context.WithCancel(context.Background())
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case event := <-eventChan:
-				handler(
-					event.DepositContractAddress,
-					event.SigningGroupPubkeyX,
-					event.SigningGroupPubkeyY,
-					event.Timestamp,
-					event.Raw.BlockNumber,
-				)
-			}
-		}
-	}()
-
-	sub := rps.Pipe(eventChan)
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (rps *TbtcsRegisteredPubkeySubscription) Pipe(
-	sink chan *abi.TBTCSystemRegisteredPubkey,
-) subscription.EventSubscription {
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go func() {
-		ticker := time.NewTicker(rps.opts.Tick)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				lastBlock, err := rps.contract.blockCounter.CurrentBlock()
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-				}
-				fromBlock := lastBlock - rps.opts.PastBlocks
-
-				tbtcsLogger.Infof(
-					"subscription monitoring fetching past RegisteredPubkey events "+
-						"starting from block [%v]",
-					fromBlock,
-				)
-				events, err := rps.contract.PastRegisteredPubkeyEvents(
-					fromBlock,
-					nil,
-					rps._depositContractAddressFilter,
-				)
-				if err != nil {
-					tbtcsLogger.Errorf(
-						"subscription failed to pull events: [%v]",
-						err,
-					)
-					continue
-				}
-				tbtcsLogger.Infof(
-					"subscription monitoring fetched [%v] past RegisteredPubkey events",
-					len(events),
-				)
-
-				for _, event := range events {
-					sink <- event
-				}
-			}
-		}
-	}()
-
-	sub := rps.contract.watchRegisteredPubkey(
-		sink,
-		rps._depositContractAddressFilter,
-	)
-
-	return subscription.NewEventSubscription(func() {
-		sub.Unsubscribe()
-		cancelCtx()
-	})
-}
-
-func (tbtcs *TBTCSystem) watchRegisteredPubkey(
-	sink chan *abi.TBTCSystemRegisteredPubkey,
-	_depositContractAddressFilter []common.Address,
-) event.Subscription {
-	subscribeFn := func(ctx context.Context) (event.Subscription, error) {
-		return tbtcs.contract.WatchRegisteredPubkey(
-			&bind.WatchOpts{Context: ctx},
-			sink,
-			_depositContractAddressFilter,
-		)
-	}
-
-	thresholdViolatedFn := func(elapsed time.Duration) {
-		tbtcsLogger.Errorf(
-			"subscription to event RegisteredPubkey had to be "+
-				"retried [%s] since the last attempt; please inspect "+
-				"Ethereum connectivity",
-			elapsed,
-		)
-	}
-
-	subscriptionFailedFn := func(err error) {
-		tbtcsLogger.Errorf(
-			"subscription to event RegisteredPubkey failed "+
-				"with error: [%v]; resubscription attempt will be "+
-				"performed",
-			err,
-		)
-	}
-
-	return ethutil.WithResubscription(
-		ethutil.SubscriptionBackoffMax,
-		subscribeFn,
-		ethutil.SubscriptionAlertThreshold,
-		thresholdViolatedFn,
-		subscriptionFailedFn,
-	)
-}
-
-func (tbtcs *TBTCSystem) PastRegisteredPubkeyEvents(
-	startBlock uint64,
-	endBlock *uint64,
-	_depositContractAddressFilter []common.Address,
-) ([]*abi.TBTCSystemRegisteredPubkey, error) {
-	iterator, err := tbtcs.contract.FilterRegisteredPubkey(
-		&bind.FilterOpts{
-			Start: startBlock,
-			End:   endBlock,
-		},
-		_depositContractAddressFilter,
-	)
-	if err != nil {
-		return nil, fmt.Errorf(
-			"error retrieving past RegisteredPubkey events: [%v]",
-			err,
-		)
-	}
-
-	events := make([]*abi.TBTCSystemRegisteredPubkey, 0)
 
 	for iterator.Next() {
 		event := iterator.Event


### PR DESCRIPTION
Depends on: https://github.com/keep-network/keep-common/pull/64

Updated the keep-common dependency version to use the new `ethlike` package and regenerated contract bindings. This change is one of the steps which prepares the codebase to be ready for supporting new chains.