### PR TITLE
Create GH Actions workflow for build&test of Solidity contracts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ jobs:
           paths:
             - solidity/package.json
             - solidity/package-lock.json
-
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml)
+  # has been created as part of work on RFC-18
   compile_contracts:
     executor: docker-node
     steps:
@@ -52,7 +53,8 @@ jobs:
           paths:
            - solidity/node_modules
            - solidity/build/contracts
-
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml)
+  # has been created as part of work on RFC-18
   lint:
     executor: docker-node
     steps:
@@ -65,6 +67,8 @@ jobs:
           command: |
             set -ex
             npm run lint
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml)
+  # has been created as part of work on RFC-18
   unit_test_contracts:
     executor: docker-node
     steps:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,0 +1,86 @@
+name: Solidity
+
+#TODO: extend the conditions once workflow gets tested together with other workflows
+on:
+  push:
+    branches:
+      # TODO: Run on master after we're fully migrated from Circle CI
+      # - master
+      - "rfc-18/**"
+    paths:
+      - "solidity/**"
+      - ".github/workflows/contracts.yml"
+  pull_request:
+    branches:
+      # TODO: Run on all branches after we're fully migrated from Circle CI
+      - "rfc-18/**"
+    paths:
+      - "solidity/**"
+      - ".github/workflows/contracts.yml"
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-solidity-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        working-directory: ./solidity
+        run: npm ci
+
+      - name: Compile contracts
+        working-directory: ./solidity
+        run: npx truffle compile
+
+      - name: Run tests
+        working-directory: ./solidity
+        run: npm run test:quick
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "12.x"
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-solidity-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        working-directory: ./solidity
+        run: npm ci
+
+      - name: Compile contracts
+        working-directory: ./solidity
+        run: npx truffle compile
+
+      - name: Lint
+        working-directory: ./solidity
+        run: npm run lint


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvement and make
the process less error prone. A part of this task is migration from
CircleCI to GitHub Actions. This commit creates a GitHub Action workflow
for building and testing of Solidity contracts.