### PR TITLE
Add a multiply-local-eth-btc-price Script

### DIFF
--- a/solidity/scripts/multiply-local-eth-btc-price.js
+++ b/solidity/scripts/multiply-local-eth-btc-price.js
@@ -1,0 +1,25 @@
+const ETHBTCPriceFeedMock = artifacts.require("ETHBTCPriceFeedMock")
+
+async function run() {
+  try {
+    if (process.argv.length <= 4 || process.argv[4] === "help") {
+      console.log("run `truffle exec multiply-local-eth-btc-price.js <factor>` to update the current price by a factor of <factor>")
+    } else if (isNaN(parseFloat(process.argv[4]))) {
+      console.log("<factor> must be a number.")
+    } else {
+      const ethBtcPriceFeedMock = await ETHBTCPriceFeedMock.deployed()
+      const currentPrice = parseInt(await ethBtcPriceFeedMock.read())
+      // the arguments are [node, truffle, exec, <script name>, arguments...]
+      const factor = parseFloat(process.argv[4])
+      const newPrice = Math.round(currentPrice * factor)
+      await ethBtcPriceFeedMock.setValue(newPrice.toString())
+      console.log(`Successfully updated the price by a factor of ${factor} from ${currentPrice} to ${newPrice}`)
+    }
+    process.exit(0)
+  } catch (ex) {
+    console.error(ex)
+    throw ex
+  }
+}
+
+module.exports = run

--- a/solidity/scripts/multiply-local-eth-btc-price.js
+++ b/solidity/scripts/multiply-local-eth-btc-price.js
@@ -3,7 +3,9 @@ const ETHBTCPriceFeedMock = artifacts.require("ETHBTCPriceFeedMock")
 async function run() {
   try {
     if (process.argv.length <= 4 || process.argv[4] === "help") {
-      console.log("run `truffle exec multiply-local-eth-btc-price.js <factor>` to update the current price by a factor of <factor>")
+      console.log(
+        "run `truffle exec multiply-local-eth-btc-price.js <factor>` to update the current price by a factor of <factor>",
+      )
     } else if (isNaN(parseFloat(process.argv[4]))) {
       console.log("<factor> must be a number.")
     } else {
@@ -13,7 +15,9 @@ async function run() {
       const factor = parseFloat(process.argv[4])
       const newPrice = Math.round(currentPrice * factor)
       await ethBtcPriceFeedMock.setValue(newPrice.toString())
-      console.log(`Successfully updated the price by a factor of ${factor} from ${currentPrice} to ${newPrice}`)
+      console.log(
+        `Successfully updated the price by a factor of ${factor} from ${currentPrice} to ${newPrice}`,
+      )
     }
     process.exit(0)
   } catch (ex) {


### PR DESCRIPTION
The script helps to update the local conversion rate of eth<->btc by multiplying the current rate by a flat factor. This makes it easy to trigger liquidation via undercollateralization by creating a deposit, and then running:

```
truffle exec multiply-local-eth-btc-price.js 0.5
```

examples:
```
beaushinkle@Beaus-MBP ~/l/t/s/scripts ((d25b8a11…))> truffle exec multiply-local-eth-btc-price.js help
Using network 'development'.

run `truffle exec multiply-local-eth-btc-price.js <factor>` to update the current price by a factor of <factor>
beaushinkle@Beaus-MBP ~/l/t/s/scripts ((d25b8a11…))> truffle exec multiply-local-eth-btc-price.js
Using network 'development'.

run `truffle exec multiply-local-eth-btc-price.js <factor>` to update the current price by a factor of <factor>
beaushinkle@Beaus-MBP ~/l/t/s/scripts ((d25b8a11…))> truffle exec multiply-local-eth-btc-price.js banana
Using network 'development'.

<factor> must be a number.
beaushinkle@Beaus-MBP ~/l/t/s/scripts ((d25b8a11…))> truffle exec multiply-local-eth-btc-price.js 0.5
Using network 'development'.

Successfully updated the price by a factor of 0.5 from 21428571428602040 to 10714285714301020
beaushinkle@Beaus-MBP ~/l/t/s/scripts ((d25b8a11…))> truffle exec multiply-local-eth-btc-price.js 0.5
Using network 'development'.

Successfully updated the price by a factor of 0.5 from 10714285714301020 to 5357142857150510
beaushinkle@Beaus-MBP ~/l/t/s/scripts ((d25b8a11…))> truffle exec multiply-local-eth-btc-price.js 4
Using network 'development'.

Successfully updated the price by a factor of 4 from 5357142857150510 to 21428571428602040
```

inspiration: https://github.com/keep-network/keep-ecdsa/pull/691#pullrequestreview-593741861