### PR TITLE
EIP155 signer support in Go contract bindings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/ethereum/go-ethereum v1.9.10
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.3.1-0.20210128152700-34905d2fe019
+	github.com/keep-network/keep-common v1.4.1
 )

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM5
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
 github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
-github.com/keep-network/keep-common v1.3.1-0.20210128152700-34905d2fe019 h1:WBq6cP/N3PFPo25k6AVuM1Hh46GL8DRPr2YzV97quuc=
-github.com/keep-network/keep-common v1.3.1-0.20210128152700-34905d2fe019/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.4.1 h1:nIjL7jP+iWXuMy5t74oPZaCo1qO7KertLZtSIplDBig=
+github.com/keep-network/keep-common v1.4.1/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=


### PR DESCRIPTION
go-ethereum 1.10.0 has switched to denying non-EIP155 signatures by default. Although keep-common code uses go-ethereum own ABI binding generation, the version currently in the dependencies always uses Homestead signers. The keep-common version updated in this PR ships EIP155-compatible signer without updating the referenced go-ethereum version. The regenerated `Deposit` and `TBTCSystem` Go bindings contract code includes now that signer.

See https://github.com/keep-network/keep-common/pull/71