### PR TITLE
Dockerfile and basic CI for Go relay maintainer

### DIFF
--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -1,0 +1,80 @@
+name: Relay
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "relay/**"
+      - ".github/workflows/relay.yml"
+  pull_request:
+    branches:
+    paths:
+      - "relay/**"
+      - ".github/workflows/relay.yml"
+  workflow_dispatch:
+
+jobs:
+  build-test-publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./relay
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-relay-cache
+          key: ${{ runner.os }}-buildx-relay-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-relay-
+
+      - run: sudo df -h
+
+      - name: Build Docker Build Image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./relay
+          target: gobuild
+          tags: go-build-env
+          load: true # load image to local registry to use it in next steps
+          cache-from: type=local,src=/tmp/.buildx-relay-cache
+          cache-to: type=local,dest=/tmp/.buildx-relay-cache
+
+      - name: Run Go tests
+        run: |
+          docker run \
+            --workdir /go/src/github.com/keep-network/tbtc/relay \
+            go-build-env \
+            gotestsum
+
+      - name: Login to Google Container Registry
+        if:  |
+          startsWith(github.ref, 'refs/heads/releases/')
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.GCR_REGISTRY_URL }}
+          username: _json_key
+          password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
+
+      - name: Build and publish Docker Runtime Image
+        uses: docker/build-push-action@v2
+        env:
+          IMAGE_NAME: 'relay'
+          GOOGLE_PROJECT_ID: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
+        with:
+          context: ./relay
+          # GCR image should be named according to following convention:
+          # HOSTNAME/PROJECT-ID/IMAGE:TAG
+          # We don't use TAG yet.
+          tags: ${{ secrets.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
+          labels: revision=${{ github.sha }}
+          build-args: |
+            REVISION=${{ github.sha }}
+          push: |
+            ${{ startsWith(github.ref, 'refs/heads/releases/') }}

--- a/relay/.dockerignore
+++ b/relay/.dockerignore
@@ -1,0 +1,6 @@
+# Hidden files and directories.
+.*
+
+# Top-level files unrealted to the build.
+Dockerfile
+*.adoc

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -1,0 +1,48 @@
+FROM golang:1.15.7-alpine3.13 AS gobuild
+
+# Client Versioning.
+ARG VERSION
+ARG REVISION
+
+# Environment variables.
+ENV GOPATH=/go \
+	GOBIN=/go/bin \
+	APP_NAME=relay \
+	APP_DIR=/go/src/github.com/keep-network/tbtc/relay \
+	BIN_PATH=/usr/local/bin \
+	GO111MODULE=on
+
+RUN apk add --update --no-cache \
+	g++ \
+	linux-headers \
+	make \
+	git && \
+	rm -rf /var/cache/apk/ && mkdir /var/cache/apk/ && \
+	rm -rf /usr/share/man
+
+# Get gotestsum tool
+RUN go get gotest.tools/gotestsum
+
+# Configure working directory.
+RUN mkdir -p $APP_DIR
+WORKDIR $APP_DIR
+
+# Copy app files.
+COPY ./ $APP_DIR/
+
+# Build the application.
+RUN GOOS=linux go build \
+	-ldflags "-X main.version=$VERSION -X main.revision=$REVISION" \
+	-a -o $APP_NAME ./ && \
+	mv $APP_NAME $BIN_PATH
+
+# Configure runtime container.
+FROM alpine:3.13
+
+ENV APP_NAME=relay \
+	BIN_PATH=/usr/local/bin
+
+COPY --from=gobuild $BIN_PATH/$APP_NAME $BIN_PATH
+
+# docker caches more when using CMD [] resulting in a faster build.
+CMD []

--- a/relay/pkg/btc/btc_test.go
+++ b/relay/pkg/btc/btc_test.go
@@ -1,0 +1,14 @@
+package btc
+
+import "testing"
+
+func TestConnect(t *testing.T) {
+	btcChain, err := Connect()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if btcChain == nil {
+		t.Errorf("btc chain handle is null")
+	}
+}

--- a/relay/pkg/btc/remote/remote_test.go
+++ b/relay/pkg/btc/remote/remote_test.go
@@ -1,4 +1,4 @@
-package btc
+package remote
 
 import "testing"
 


### PR DESCRIPTION
Depends on:  #762

This pull request introduces the `Dockerfile` for the Go relay maintainer along with a basic `build-test-publish` CI job.