### PR TITLE
Cleanup after moving to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,22 +1,13 @@
 version: 2.1
 
 orbs:
-  gcp-cli: circleci/gcp-cli@1.8.2
   gcp-gcr: circleci/gcp-gcr@0.0.4
 
 executors:
   docker-node:
     docker:
       - image: circleci/node:12
-  docker-node-gcloud:
-    docker:
-      - image: appfarm/node-gcloud-base
-  docker-git:
-    docker:
-      - image: docker:18.06.0-ce-git
-  docker-thesis-buildpack:
-    docker:
-      - image: thesisco/docker-buildpack:bionic
+
 jobs:
   resolve_latest:
     executor: docker-node
@@ -53,126 +44,6 @@ jobs:
           paths:
            - solidity/node_modules
            - solidity/build/contracts
-  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml)
-  # has been created as part of work on RFC-18
-  lint:
-    executor: docker-node
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Lint Implementation
-          working_directory: ~/project/solidity
-          command: |
-            set -ex
-            npm run lint
-  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml)
-  # has been created as part of work on RFC-18
-  unit_test_contracts:
-    executor: docker-node
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Run NPM tests
-          working_directory: ~/project/solidity
-          command: npm run test:quick
-  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml)
-  # has been created as part of work on RFC-18
-  migrate_contracts:
-    executor: docker-node-gcloud
-    steps:
-      - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-      - attach_workspace:
-          at: .
-      - run:
-          name: Set Gcloud Auth for bucket access
-          command: |
-            echo $GCLOUD_SERVICE_KEY > ~/gcloud-service-key.json
-            gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
-      - run:
-          name: Provision External Contract Addresses
-          command: |
-            # This needs to be part of a base docker image, not installed here.
-            apt-get update
-            apt-get install jq -y
-
-            solidity/scripts/ci-provision-external-contracts.sh
-      - run:
-          name: Migrate Contracts
-          command: |
-            export BUILD_TAG=$CIRCLE_SHA1
-            export TRUFFLE_NETWORK=$TRUFFLE_NETWORK
-            solidity/scripts/circleci-migrate-contracts.sh
-      - persist_to_workspace:
-          root: /tmp/tbtc
-          paths:
-            - contracts
-  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml)
-  # has been created as part of work on RFC-18
-  publish_npm_package:
-    executor: docker-node
-    steps:
-      - attach_workspace:
-          at: /tmp/tbtc
-      - checkout
-      - run:
-          name: Bump and publish npm package
-          working_directory: ~/project/solidity
-          command: |
-            set -x
-            mkdir -p artifacts
-            cp -r /tmp/tbtc/contracts/* artifacts/
-            name=$(jq --raw-output .name package.json)
-            version=$(jq --raw-output .version package.json)
-            preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
-
-            # Find the latest published package version matching this preid.
-            # Note that in jq, we wrap the result in an array and then flatten;
-            # this is because npm show json contains a single string if there
-            # is only one matching version, or an array if there are multiple,
-            # and we want to look at an array always.
-            latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | .[-1]")
-            latest_version=${latest_version:-$version}
-            if [ -z $latest_version ]; then
-              echo "Latest version calculation failed. Resolved info:"
-              echo "$name@$version ; preid $preid"
-              exit 1
-            fi
-
-            # Update package.json with the latest published package version matching this
-            # preid to prepare for bumping.
-            echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
-
-            # Bump without doing any git work. Versioning is a build-time action for us.
-            # Consider including commit id? Would be +<commit id>.
-            npm version prerelease --preid=$preid --no-git-tag-version
-
-            # Publish to npm.
-            echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-            npm publish --access=public
-  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml)
-  # has been created as part of work on RFC-18
-  publish_contract_data:
-    executor: gcp-cli/default
-    steps:
-      - attach_workspace:
-          at: /tmp/tbtc
-      - gcp-cli/install
-      - gcp-cli/initialize:
-          google-project-id: GOOGLE_PROJECT_ID
-          google-compute-zone: GOOGLE_COMPUTE_ZONE_A
-          # This param doesn't actually set anything, leaving here as a reminder to check when they fix it.
-          gcloud-service-key: GCLOUD_SERVICE_KEY
-      - run:
-          name: Upload contract data
-          command: |
-            cd /tmp/tbtc/contracts
-            gsutil -m cp * gs://${CONTRACT_DATA_BUCKET}/tbtc
   build_relay_maintainer_initcontainer:
     executor: docker-node
     steps:
@@ -217,18 +88,6 @@ jobs:
 
 workflows:
   version: 2
-  lint:
-    jobs:
-      - compile_contracts
-      - lint:
-          requires:
-            - compile_contracts
-  test:
-    jobs:
-      - compile_contracts
-      - unit_test_contracts:
-          requires:
-            - compile_contracts
   build_publish_keep_dev:
     jobs:
       - compile_contracts
@@ -269,33 +128,6 @@ workflows:
               only: /releases\/.*/
           requires:
             - resolve_latest
-      - migrate_contracts:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: /releases\/.*/
-          context: keep-test
-          requires:
-            - compile_contracts
-      - publish_npm_package:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: /releases\/.*/
-          context: keep-test
-          requires:
-            - migrate_contracts
-      - publish_contract_data:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: /releases\/.*/
-          context: keep-test
-          requires:
-            - migrate_contracts
       - build_relay_maintainer_initcontainer:
           filters:
             tags:
@@ -303,8 +135,6 @@ workflows:
             branches:
               only: /releases\/.*/
           context: keep-test
-          requires:
-            - publish_npm_package
       - publish_relay_maintainer_initcontainer:
           filters:
             tags:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -6,15 +6,31 @@ on:
       - master
     paths:
       - "solidity/**"
-      - ".github/workflows/contracts.yml"
   pull_request:
-    paths:
-      - "solidity/**"
-      - ".github/workflows/contracts.yml"
   workflow_dispatch:
 
 jobs:
-  build-and-test:
+  contracts-detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      path-filter: ${{ steps.filter.outputs.path-filter }}
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event_name == 'pull_request' 
+    - uses: dorny/paths-filter@v2
+      if: github.event_name == 'pull_request' 
+      id: filter
+      with:
+        filters: |
+          path-filter:
+            - './solidity/**'
+
+  contracts-build-and-test:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || (github.event_name == 'pull_request'
+        && needs.contracts-detect-changes.outputs.path-filter == 'true') 
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -47,7 +63,12 @@ jobs:
       - name: Run tests
         run: npm run test:quick
 
-  lint:
+  contracts-lint:
+    needs: contracts-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || (github.event_name == 'pull_request'
+        && needs.contracts-detect-changes.outputs.path-filter == 'true') 
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -77,12 +98,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  migrate-and-publish-ethereum:
-    needs: [build-and-test, lint]
+  contracts-migrate-and-publish-ethereum:
+    needs: [contracts-build-and-test, contracts-lint]
     if: |
       github.ref == 'refs/heads/master'
-        && (github.event_name == 'push'
-        || github.event_name == 'workflow_dispatch')
+        && github.event_name != 'pull_request'
     environment: keep-test # keep-test requires a manual aproval
     runs-on: ubuntu-latest
     strategy:
@@ -171,12 +191,11 @@ jobs:
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
           npm publish --access=public
 
-  migrate-and-publish-celo:
-    needs: [build-and-test, lint]
+  contracts-migrate-and-publish-celo:
+    needs: [contracts-build-and-test, contracts-lint]
     if: |
       github.ref == 'refs/heads/master'
-        && (github.event_name == 'push'
-        || github.event_name == 'workflow_dispatch')
+        && github.event_name != 'pull_request'
     environment: keep-test
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -29,8 +29,7 @@ jobs:
     needs: contracts-detect-changes
     if: |
       github.event_name != 'pull_request'
-        || (github.event_name == 'pull_request'
-        && needs.contracts-detect-changes.outputs.path-filter == 'true') 
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -67,8 +66,7 @@ jobs:
     needs: contracts-detect-changes
     if: |
       github.event_name != 'pull_request'
-        || (github.event_name == 'pull_request'
-        && needs.contracts-detect-changes.outputs.path-filter == 'true') 
+        || needs.contracts-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,20 +1,13 @@
 name: Solidity
 
-#TODO: extend the conditions once workflow gets tested together with other workflows
 on:
   push:
     branches:
-      # TODO: Run only on master after we're fully migrated from Circle CI
-      - "rfc-18/**"
       - master
     paths:
       - "solidity/**"
       - ".github/workflows/contracts.yml"
   pull_request:
-    branches:
-      # TODO: Run on all branches after we're fully migrated from Circle CI
-      - "rfc-18/**"
-      - master
     paths:
       - "solidity/**"
       - ".github/workflows/contracts.yml"
@@ -86,10 +79,8 @@ jobs:
 
   migrate-and-publish-ethereum:
     needs: [build-and-test, lint]
-    # TODO: Remove 'rfc-18/' condition once migration to GH Actions is done
     if: |
-      (startsWith(github.ref, 'refs/heads/rfc-18/')
-        || github.ref == 'refs/heads/master')
+      github.ref == 'refs/heads/master'
         && (github.event_name == 'push'
         || github.event_name == 'workflow_dispatch')
     environment: keep-test # keep-test requires a manual aproval
@@ -176,10 +167,9 @@ jobs:
           workDir: ./solidity
 
       - name: Publish to npm
-        # TODO: --dry-run to be removed once testing of workflow is done
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public --dry-run
+          npm publish --access=public
 
   migrate-and-publish-celo:
     needs: [build-and-test, lint]


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvement and
make the processes faster and less error prone. A part of this task is
migration from CircleCI jobs to GitHub Actions.

Now that we have most CircleCI jobs from `tbtc` moved to GH Actions
(and verified), we can implement some changes removing obsolete
CircleCI configs and cleaning up pieces of code used for workflows
testing. Here is a list of changes applied:
- removed unnecessary comments
- removed references to `rfc-18...` branches, which were used for 
  workflow testing
- removed `--dry-run` flag from command publishing npm image
- deleted couple of CircleCI jobs from `./circleci/config.yml` (those
  who are migrated to GH Actions and are not necessary for building of
  relay maintainer initcontainer)
- added restrictions on workflow triggering conditions (see more info 
  below)

As we've migrated most of the CircleCI jobs to GitHub Actions, we want
to introduce branch protection rules on master, requiring the passing
of particular jobs before merging PR to master. Those jobs in `tbtc`
are:
* `contracts-build-and-test`
* `contracts-lint`

What's more, we want to execute workflows containing those jobs only if
there were changes in particular paths. GitHub Actions allows for
specifying those paths by using `on.<event_name>.paths` syntax.
Unfortunately, such configuration for the `pull-request` event clashes
with the functionality of protected branches.
Example: If we set branch protection rule requiring the passing of
`job_a` and `job_a` will be part of `workflow_a` using
`on.pull_request.paths = folder_a` setting, the `workflow_a` won't be
started if we create PR that changes some files outside of `folder_a`.
Hence `job_a` won't be executed. But the PR will still require `job_a`
to be passing (or skipped) and will not allow for the merge of the PR
to the protected branch.
As skipping of the required jobs doesn't block the PRs from merging, we
decided to move the checking of paths for `pull_request` events from
workflow level to job level. It's not something natively supported by
GH Actions, but there is a `dorny/paths-filter` action that allows for
doing exactly that. We've set up the action to execute only if a
workflow was started by the `pull_request` event. Action checks the
list of files changed by the PR and when any of the files matches
provided filter, it sets the output to `true`. We then use that output
as a condition for execution of rest of the jobs in the workflow. This
way, if a particular job is required for the PR, but the path
conditions are not met, the job will be skipped (allowing for PR
merge).

Here is a summary of triggering conditions for `Solidity` workflow:

* workflow dispatch:
    Everything executed
* push on `master`:
    Everything executed if there are any changes IN this path:
    - `solidity/**`
* pull_request:
    Everything (except migrating/publishing contracts) executed
    if there are any changes IN this path:
    - `solidity/**`