### PR TITLE
Added back-off time in Relay Maintainer's restart loop

### DIFF
--- a/relay/pkg/node/node.go
+++ b/relay/pkg/node/node.go
@@ -2,6 +2,7 @@ package node
 
 import (
 	"context"
+	"time"
 
 	"github.com/keep-network/tbtc/relay/pkg/header"
 
@@ -9,6 +10,11 @@ import (
 	"github.com/keep-network/tbtc/relay/pkg/btc"
 	"github.com/keep-network/tbtc/relay/pkg/chain"
 )
+
+// Back-off time which should be applied when the relay is restarted.
+// It helps to avoid being flooded with error logs in case of a permanent error
+// in the relay.
+const restartBackoffTime = 10 * time.Second
 
 var logger = log.Logger("tbtc-relay-node")
 
@@ -68,6 +74,8 @@ func (n *Node) startRelayControlLoop(
 		case <-ctx.Done():
 			return
 		}
+
+		time.Sleep(restartBackoffTime)
 	}
 }
 


### PR DESCRIPTION
This pull request adds a 10 second back-off time to the `Relay Maintainer`'s restart loop, so that we can avoid being flooded with a large number of error logs when a permanent error occurs in the Relay Maintainer (e.g. we cannot connect to one of the blockchains).