### PR TITLE
Use path-filter action in Relay workflow

### DIFF
--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -6,16 +6,30 @@ on:
       - master
     paths:
       - "relay/**"
-      - ".github/workflows/relay.yml"
   pull_request:
-    branches:
-    paths:
-      - "relay/**"
-      - ".github/workflows/relay.yml"
   workflow_dispatch:
 
 jobs:
-  build-test-publish:
+  relay-detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      path-filter: ${{ steps.filter.outputs.path-filter }}
+    steps:
+    - uses: actions/checkout@v2
+      if: github.event_name == 'pull_request' 
+    - uses: dorny/paths-filter@v2
+      if: github.event_name == 'pull_request' 
+      id: filter
+      with:
+        filters: |
+          path-filter:
+            - './relay/**'
+
+  relay-build-test-publish:
+    needs: relay-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.relay-detect-changes.outputs.path-filter == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -54,8 +68,7 @@ jobs:
       - name: Login to Google Container Registry
         if: |
           github.ref == 'refs/heads/master'
-            && (github.event_name == 'push'
-            || github.event_name == 'workflow_dispatch')
+            && github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ${{ secrets.GCR_REGISTRY_URL }}
@@ -78,5 +91,4 @@ jobs:
             REVISION=${{ github.sha }}
           push: |
             ${{ github.ref == 'refs/heads/master'
-              && (github.event_name == 'push'
-              || github.event_name == 'workflow_dispatch') }}
+              && github.event_name != 'pull_request' }}


### PR DESCRIPTION
As part of work on RFC-18, we want to introduce branch protection rules
on master, requiring the passing of particular jobs (such as
`relay-build-test-publish`) before merging PR to master. What's more,
we want to execute workflows containing those jobs only if there were
changes in files in particular paths. GitHub Actions allows for
specifying those paths by using `on.<event_name>.paths` syntax.
Unfortunately, such configuration for the `pull-request` event clashes
with the functionality of protected branches.
Example: If we set branch protection rule requiring the passing of
`job_a` and `job_a` will be part of `workflow_a` using
`on.pull_request.paths = folder_a` setting, the `workflow_a` won't be
started if we create PR that changes some files outside of `folder_a`.
Hence `job_a` won't be executed. But the PR will still require `job_a`
to be passing (or skipped) and will not allow for the merge of the PR
to the protected branch.
As skipping of the required jobs doesn't block the PRs from merging, we
decided to move the checking of paths for `pull_request` events from
workflow level to job level. It's not something natively supported by
GH Actions, but there is a `dorny/paths-filter` action that allows for
doing exactly that. We've set up the action to execute only if a
workflow was started by the `pull_request` event. Action checks the
list of files changed by the PR and when any of the files matches
provided filter, it sets the output to `true`. We then use that output
as a condition for execution of rest of the jobs in the workflow. This
way, if a particular job is required for the PR, but the path
conditions are not met, the job will be skipped (allowing for PR
merge).