### PR TITLE
Replace `npm install` with `npm ci` in `install.sh`

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -23,7 +23,7 @@ KEEP_ECDSA_SOL_ARTIFACTS_PATH=$(realpath $KEEP_ECDSA_SOL_PATH/build/contracts)
 cd $TBTC_SOL_PATH
 
 printf "${LOG_START}Installing NPM dependencies...${LOG_END}"
-npm install
+npm ci
 
 printf "${LOG_START}Unlocking ethereum accounts...${LOG_END}"
 KEEP_ETHEREUM_PASSWORD=$KEEP_ETHEREUM_PASSWORD \


### PR DESCRIPTION
Replacing `npm install` command wirh `npm ci`. The `install.sh` script
is used by `run-install.sh` script in `local-setup` project during
preparation for e2e tests. We don't need to use most recent
`package-lock.json` (result of `npm install`) there. It's safer to use
there a fixed and verified version of `package-lock.json`. Running `npm
ci` will not update the dependencies, which can prevent from running the
tests on faulty, not verified configuration.