### PR TITLE
Load non-sensitive data from file instead of from secrets

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -101,7 +101,6 @@ jobs:
     if: |
       github.ref == 'refs/heads/master'
         && github.event_name != 'pull_request'
-        || github.ref == 'refs/heads/rfc-18/load-env-var'
     environment: keep-test # keep-test requires a manual aproval
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -114,12 +114,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
+        uses: keep-network/load-env-variables@v1
         env: 
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
+          # TODO: Consider passing of `environment` input instead of using 
+          # hardcoded value. Would require some rework in action's code or
+          # in config files.
           environment: 'ropsten'
-          ref: 'master'
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -208,12 +210,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
+        uses: keep-network/load-env-variables@v1
         env: 
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
+          # TODO: Consider passing of `environment` input instead of using 
+          # hardcoded value. Would require some rework in action's code or
+          # in config files.
           environment: 'alfajores'
-          ref: 'master'
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -98,9 +98,10 @@ jobs:
 
   contracts-migrate-and-publish-ethereum:
     needs: [contracts-build-and-test, contracts-lint]
-    if: |
-      github.ref == 'refs/heads/master'
-        && github.event_name != 'pull_request'
+    if: | # TODO: remove 'rfc-18' condition one tested
+      (github.ref == 'refs/heads/master'
+        && github.event_name != 'pull_request')
+        || github.ref == 'refs/heads/rfc-18/load-env-var'
     environment: keep-test # keep-test requires a manual aproval
     runs-on: ubuntu-latest
     strategy:
@@ -111,6 +112,14 @@ jobs:
         working-directory: ./solidity
     steps:
       - uses: actions/checkout@v2
+
+      - name: Load environment variables
+        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
+        env: 
+          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          environment: 'ropsten'
+          ref: 'master'
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
@@ -134,14 +143,13 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v0.2.0
         with:
-          project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+          project_id: ${{ env.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Fetch external contracts artifacts
         env:
-          CONTRACT_DATA_BUCKET: ${{ secrets.KEEP_TEST_CONTRACT_DATA_BUCKET }}
           CONTRACT_DATA_BUCKET_DIR: keep-ecdsa
-          ETH_NETWORK_ID: ${{ secrets.KEEP_TEST_ETH_NETWORK_ID }} # currently ='3' (ropsten)
+          ETH_NETWORK_ID: ${{ env.NETWORK_ID }}
         run: ./scripts/ci-provision-external-contracts.sh
 
       - name: Resolve latest contracts
@@ -149,7 +157,6 @@ jobs:
 
       - name: Migrate contracts
         env:
-          TRUFFLE_NETWORK: ${{ secrets.KEEP_TEST_ETH_TRUFFLE_NETWORK }}
           ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
           CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
@@ -163,16 +170,14 @@ jobs:
           working-directory: ./solidity
           tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
           tenderly-project: thesis/keep-test
-          eth-network-id: ${{ secrets.KEEP_TEST_ETH_NETWORK_ID }} # currently ='3' (ropsten)
+          eth-network-id: ${{ env.NETWORK_ID }}
           github-project-name: tbtc
           # version-tag: # TODO: resolve npm package version
 
       - name: Upload contract data
-        env:
-          CONTRACT_DATA_BUCKET: ${{ secrets.KEEP_TEST_CONTRACT_DATA_BUCKET }}
         run: |
           cd build/contracts
-          gsutil -m cp * gs://"$CONTRACT_DATA_BUCKET"/tbtc
+          gsutil -m cp * gs://${{ env.CONTRACT_DATA_BUCKET }}/tbtc
 
       - name: Copy artifacts
         run: |
@@ -191,9 +196,10 @@ jobs:
 
   contracts-migrate-and-publish-celo:
     needs: [contracts-build-and-test, contracts-lint]
-    if: |
-      github.ref == 'refs/heads/master'
-        && github.event_name != 'pull_request'
+    if: | # TODO: remove 'rfc-18' condition one tested
+      (github.ref == 'refs/heads/master'
+        && github.event_name != 'pull_request')
+        || github.ref == 'refs/heads/rfc-18/load-env-var'
     environment: keep-test
     runs-on: ubuntu-latest
     defaults:
@@ -201,6 +207,14 @@ jobs:
         working-directory: ./solidity
     steps:
       - uses: actions/checkout@v2
+
+      - name: Load environment variables
+        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
+        env: 
+          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          environment: 'alfajores'
+          ref: 'master'
 
       - uses: actions/setup-node@v2
         with:
@@ -223,14 +237,13 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v0.2.0
         with:
-          project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+          project_id: ${{ env.GOOGLE_PROJECT_ID }}
           service_account_key: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Fetch external contracts artifacts
         env:
-          CONTRACT_DATA_BUCKET: ${{ secrets.KEEP_TEST_CONTRACT_DATA_BUCKET }}
           CONTRACT_DATA_BUCKET_DIR: keep-ecdsa-celo
-          ETH_NETWORK_ID: ${{ secrets.KEEP_TEST_CELO_NETWORK_ID }}
+          ETH_NETWORK_ID: ${{ env.NETWORK_ID }}
         run: ./scripts/ci-provision-external-contracts.sh
 
       - name: Resolve latest contracts
@@ -238,16 +251,13 @@ jobs:
 
       - name: Migrate contracts
         env:
-          TRUFFLE_NETWORK: ${{ secrets.KEEP_TEST_CELO_TRUFFLE_NETWORK }}
           CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_CELO_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
 
       - name: Upload contract data
-        env:
-          CONTRACT_DATA_BUCKET: ${{ secrets.KEEP_TEST_CONTRACT_DATA_BUCKET }}
         run: |
           cd build/contracts
-          gsutil -m cp * gs://"$CONTRACT_DATA_BUCKET"/tbtc-celo
+          gsutil -m cp * gs://${{ env.CONTRACT_DATA_BUCKET }}/tbtc-celo
 
       # TODO: add NPM publish step once it's clear how artifacts should be tagged

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -98,9 +98,9 @@ jobs:
 
   contracts-migrate-and-publish-ethereum:
     needs: [contracts-build-and-test, contracts-lint]
-    if: | # TODO: remove 'rfc-18' condition one tested
-      (github.ref == 'refs/heads/master'
-        && github.event_name != 'pull_request')
+    if: |
+      github.ref == 'refs/heads/master'
+        && github.event_name != 'pull_request'
         || github.ref == 'refs/heads/rfc-18/load-env-var'
     environment: keep-test # keep-test requires a manual aproval
     runs-on: ubuntu-latest
@@ -196,10 +196,9 @@ jobs:
 
   contracts-migrate-and-publish-celo:
     needs: [contracts-build-and-test, contracts-lint]
-    if: | # TODO: remove 'rfc-18' condition one tested
-      (github.ref == 'refs/heads/master'
-        && github.event_name != 'pull_request')
-        || github.ref == 'refs/heads/rfc-18/load-env-var'
+    if: |
+      github.ref == 'refs/heads/master'
+        && github.event_name != 'pull_request'
     environment: keep-test
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -38,12 +38,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
+        uses: keep-network/load-env-variables@v1
         env: 
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
+          # TODO: Consider passing of `environment` input instead of using 
+          # hardcoded value. Would require some rework in action's code or
+          # in config files.
           environment: 'ropsten'
-          ref: 'master'
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -74,10 +74,9 @@ jobs:
             gotestsum
 
       - name: Login to Google Container Registry
-        if: | # TODO: remove 'rfc-18' condition one tested
-          (github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request')
-            || github.ref == 'refs/heads/rfc-18/load-env-var'
+        if: |
+          github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.GCR_REGISTRY_URL }}
@@ -97,7 +96,6 @@ jobs:
           labels: revision=${{ github.sha }}
           build-args: |
             REVISION=${{ github.sha }}
-          push: | # TODO: remove 'rfc-18' condition one tested
-            ${{ (github.ref == 'refs/heads/master'
-              && github.event_name != 'pull_request')
-              || github.ref == 'refs/heads/rfc-18/load-env-var' }}
+          push: |
+            ${{ github.ref == 'refs/heads/master'
+              && github.event_name != 'pull_request' }}

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -37,6 +37,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Load environment variables
+        uses: keep-network/load-env-variables@main # TODO: use @v1 once availible
+        env: 
+          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          environment: 'ropsten'
+          ref: 'master'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -66,12 +74,13 @@ jobs:
             gotestsum
 
       - name: Login to Google Container Registry
-        if: |
-          github.ref == 'refs/heads/master'
-            && github.event_name != 'pull_request'
+        if: | # TODO: remove 'rfc-18' condition one tested
+          (github.ref == 'refs/heads/master'
+            && github.event_name != 'pull_request')
+            || github.ref == 'refs/heads/rfc-18/load-env-var'
         uses: docker/login-action@v1
         with:
-          registry: ${{ secrets.GCR_REGISTRY_URL }}
+          registry: ${{ env.GCR_REGISTRY_URL }}
           username: _json_key
           password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
@@ -79,16 +88,16 @@ jobs:
         uses: docker/build-push-action@v2
         env:
           IMAGE_NAME: 'relay'
-          GOOGLE_PROJECT_ID: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
         with:
           context: ./relay
           # GCR image should be named according to following convention:
           # HOSTNAME/PROJECT-ID/IMAGE:TAG
           # We don't use TAG yet.
-          tags: ${{ secrets.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
+          tags: ${{ env.GCR_REGISTRY_URL }}/${{ env.GOOGLE_PROJECT_ID }}/${{ env.IMAGE_NAME }}
           labels: revision=${{ github.sha }}
           build-args: |
             REVISION=${{ github.sha }}
-          push: |
-            ${{ github.ref == 'refs/heads/master'
-              && github.event_name != 'pull_request' }}
+          push: | # TODO: remove 'rfc-18' condition one tested
+            ${{ (github.ref == 'refs/heads/master'
+              && github.event_name != 'pull_request')
+              || github.ref == 'refs/heads/rfc-18/load-env-var' }}


### PR DESCRIPTION
Non-sensitive data previously accessed by using `secrets` context is
now accessed by invoking `keep-network/load-env-variables` action and
using `env` context.
BACKGROUND:
We've been storing id of the test environment as
`KEEP_TEST_ETH_NETWORK_ID` organization secret in GitHub's settings to
allow for easy access to that value from multiple projects.
But it turned out to be problematic, as GHA in some situations redacts
workflow logs and actions outputs/inputs based on the values stored in
secrets. So if the secret holds small numeric value, it is quite
probable that at some point in time this value will be recognized as a
substring of `github.sha` or another variable and the `github.sha` will
be redacted with `***` in place of the recognized pattern. If such
redacted value is configured as input of some action, the action gets
invoked by the GHA without that input, which can cause run failure or
can mess up the workflow results.
As a solution for this problem we decided to no longer store
frequently-used, non-sensitive data such as `KEEP_TEST_ETH_NETWORK_ID`
in GitHub's secrets, but instead store them in a file kept in
`keep-network/ci` repository and read that data to `env` context in
order to be able to use it when running workflows. A
`keep-network/load-env-variables` action has been implemented to allow
for loading of the variables to `env` context in one step. The scope of
the loaded variables is limited to the job in which they were loaded.
To use the variables in other job, action `load-env-variables` needs to
be executed there as well.