### PR TITLE
Relay maintainer updated to 1.1.0 version

### DIFF
--- a/infrastructure/kube/keep-prd/relay-deployment.yaml
+++ b/infrastructure/kube/keep-prd/relay-deployment.yaml
@@ -67,7 +67,7 @@ spec:
           command: ['node', '/tmp/provision-relay.js']
       containers:
         - name: relay
-          image: gcr.io/keep-prd-210b/relay:1.0.0
+          image: gcr.io/keep-prd-210b/relay:1.1.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Relay maintainer production deployment has been updated to the new
version, v1.1.0, with optimized retry loops 2021-05-20 at 11:22:25 CEST.

All transactions submitted after block 12470446, are from the new version.

See https://github.com/keep-network/tbtc/pull/792