### PR TITLE
Fix typos in the tBTC docs

### DIFF
--- a/docs/bonding/index.adoc
+++ b/docs/bonding/index.adoc
@@ -190,11 +190,11 @@ supply is in line with BTC custodied by TBTC-backing deposits.]
 Forced liquidation should be rare, as rational signers will redeem deposits
 before liquidation becomes necessary. However, the possibility of extreme
 punishment via liquidation is necessary to prevent dishonest behavior from
-signers. Liquidation may occur because because signers
-<<failure/index.adoc#abort,didn't produce a valid signature in response to a
-redemption request>>, because the value of the signing bond dropped below the
-liquidation threshold, because they did not respond to the courtesy call, or
-because the signers <<failure/index.adoc#fraud, produced a fraudulent
+signers. Liquidation may occur because signers <<failure/index.adoc#abort,didn't
+produce a valid signature in response to a redemption request>>, because the
+value of the signing bond dropped below the liquidation threshold, because they
+did not respond to the courtesy call, or because the signers
+<<failure/index.adoc#fraud, produced a fraudulent
 signature>>{fraudulent-signature}.
 
 The primary goal of the liquidation process is to make the deposit owner

--- a/docs/deposits/index.adoc
+++ b/docs/deposits/index.adoc
@@ -122,8 +122,8 @@ generation, they MUST put up a bond (the _signer bond_) in the native token
 of the host chain. This bond is used in a few cases:
 
 - To liquidate deposits in case they are in danger of undercollateralization.
-- To punish a signing group if it signs an unauthorized piece of data is
-  once distributed key generation is complete.
+- To punish a signing group if it signs an unauthorized piece of data once
+  distributed key generation is complete.
 - To punish a signing group that fails to produce a signature for the system
   when requested.
 - To ensure a depositor is refunded if the signing group fails to form.
@@ -156,7 +156,7 @@ The distributed key generation protocol should result in three properties:
 2. Each member of the signing group should have a _threshold ECDSA secret key
    share_{threshold-signature}, which can be used to create a
    _threshold ECDSA signature share_ for any transactions involving the
-   signing group's wallet.
+   signing of the group's wallet.
 3. Each member of the signing group should be able to combine a threshold number
    of signature shares from itself and other members of the group to produce a
    signed version of a given transaction to be performed on behalf of the

--- a/docs/deposits/index.adoc
+++ b/docs/deposits/index.adoc
@@ -156,7 +156,7 @@ The distributed key generation protocol should result in three properties:
 2. Each member of the signing group should have a _threshold ECDSA secret key
    share_{threshold-signature}, which can be used to create a
    _threshold ECDSA signature share_ for any transactions involving the
-   signing of the group's wallet.
+   signing group's wallet.
 3. Each member of the signing group should be able to combine a threshold number
    of signature shares from itself and other members of the group to produce a
    signed version of a given transaction to be performed on behalf of the

--- a/docs/deposits/mistakes.adoc
+++ b/docs/deposits/mistakes.adoc
@@ -4,11 +4,10 @@ The system is designed to function with a few predefined lot sizes for all
 deposits, which are given as system parameter. **Depositors should send the
 exact lot amount of BTC in the funding transaction, or expect loss of funds.**
 Since it is not possible for the system to force users into sending any specific
-amount, ideally the the system would gracefully handle overpayment and
-underpayment. The primary impact of overpayment and underpayment is on the
-specific deposit's collateralization ratio. The system treats overpayment and
-underpayment as faulty depositor behavior, and passes on the associated costs
-to the depositor.
+amount, ideally the system would gracefully handle overpayment and underpayment.
+The primary impact of overpayment and underpayment is on the specific deposit's
+collateralization ratio. The system treats overpayment and underpayment as
+faulty depositor behavior, and passes on the associated costs to the depositor.
 
 == Overpayment
 

--- a/docs/redemption/index.adoc
+++ b/docs/redemption/index.adoc
@@ -60,7 +60,7 @@ A redemption request can be submitted in a few cases:
   <<bonding/index.adoc#liquidation,signer liquidation>>), pre-term, and the
   requester holds the corresponding tBTC Deposit Token.
 * If the deposit is in good standing and is at or past <<at-term,term>>,
-  irrespective of whether the requester holds the corresponding tBTC Deopsit
+  irrespective of whether the requester holds the corresponding tBTC Deposit
   Token.
 * If the deposit has entered <<bonding/index.adoc#pre-liquidation,courtesy
   call>>, an undercollateralization state designed to allow closing deposits


### PR DESCRIPTION
Fixing a couple of typos spotted during reading of the tBTC documentation.