### PR TITLE
Refactor workflows to add deployment of contracts migrated on Celo

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -109,14 +109,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
-  contracts-migrate-and-publish-ethereum:
+  contracts-migrate-and-publish:
     needs: [contracts-build-and-test]
     if: github.event_name == 'workflow_dispatch'
-    environment: keep-test # line can be deleted once we'll no longer use environment protection
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     defaults:
       run:
         working-directory: ./solidity
@@ -128,15 +124,11 @@ jobs:
         env: 
           CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
-          # TODO: Consider passing of `environment` input instead of using 
-          # hardcoded value. Would require some rework in action's code or
-          # in config files.
-          environment: 'ropsten'
+          environment: ${{ github.event.inputs.environment }}
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "12.x"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -166,11 +158,20 @@ jobs:
             npm install --save-exact \
               @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-solidity-version }}
 
-      - name: Migrate contracts
+      - name: Migrate contracts on Ethereum
+        if: github.event.inputs.environment != 'alfajores'
         env:
           ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
           CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+        run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
+
+      - name: Migrate contracts on Celo
+        if: github.event.inputs.environment == 'alfajores'
+        env:
+          CELO_HOSTNAME: ${{ secrets.KEEP_TEST_CELO_HOSTNAME }}
+          CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY: |
+            ${{ secrets.KEEP_TEST_CELO_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
 
       - name: Copy artifacts
@@ -188,6 +189,7 @@ jobs:
           commit: ${{ github.sha }}
 
       - name: Push contracts to Tenderly
+        if: github.event.inputs.environment == 'ropsten'
         # TODO: once below action gets tagged replace `@main` with `@v1`
         uses: keep-network/tenderly-push-action@main
         continue-on-error: true
@@ -205,6 +207,8 @@ jobs:
           npm publish --access=public
       
       - name: Notify CI about completion of the workflow
+        # For Alfajores we want to break the chain of deployments on tBTC contracts.
+        if: github.event.inputs.environment != 'alfajores'
         uses: keep-network/notify-workflow-completed@v1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
@@ -215,74 +219,3 @@ jobs:
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
           version: ${{ steps.npm-version-bump.outputs.version }}
-
-  contracts-migrate-and-publish-celo:
-    needs: [contracts-build-and-test]
-    if: github.event_name == 'workflow_dispatch'
-    environment: keep-test # line can be deleted once we'll no longer use environment protection
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./solidity
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-        with:
-          # TODO: Consider passing of `environment` input instead of using 
-          # hardcoded value. Would require some rework in action's code or
-          # in config files.
-          environment: 'alfajores'
-
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "12.x"
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-solidity-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Install dependencies
-        run: npm ci
-
-      # TODO: Add copy to `artifacts` dir and NPM publish steps once it's clear
-      # how artifacts should be tagged. Once that's done, no longer fetch/publish
-      # contracts from/to GC Bucket.
-
-      - uses: google-github-actions/setup-gcloud@v0.2.0
-        with:
-          project_id: ${{ env.GOOGLE_PROJECT_ID }}
-          service_account_key: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
-
-      - name: Get upstream packages' versions
-        uses: keep-network/upstream-builds-query@main
-        id: upstream-builds-query
-        with:
-          upstream-builds: ${{ github.event.inputs.upstream_builds }}
-          query: |
-            keep-ecdsa-solidity-version = github.com/keep-network/keep-ecdsa/solidity#version
-
-      - name: Resolve latest contracts
-        run: npm update @keep-network/keep-ecdsa 
-
-      - name: Migrate contracts
-        env:
-          CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY: |
-            ${{ secrets.KEEP_TEST_CELO_CONTRACT_OWNER_PRIVATE_KEY }}
-        run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
-
-      - name: Upload contract data
-        run: |
-          cd build/contracts
-          gsutil -m cp * gs://${{ env.CONTRACT_DATA_BUCKET }}/tbtc-celo

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -161,16 +161,16 @@ jobs:
       - name: Migrate contracts on Ethereum
         if: github.event.inputs.environment != 'alfajores'
         env:
-          ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
-          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: |
+          CHAIN_API_URL: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
 
       - name: Migrate contracts on Celo
         if: github.event.inputs.environment == 'alfajores'
         env:
-          CELO_HOSTNAME: ${{ secrets.KEEP_TEST_CELO_HOSTNAME }}
-          CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY: |
+          CHAIN_API_URL: ${{ secrets.KEEP_TEST_CELO_HOSTNAME }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: |
             ${{ secrets.KEEP_TEST_CELO_CONTRACT_OWNER_PRIVATE_KEY }}
         run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
 

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -86,7 +86,7 @@ module.exports = {
 
     alfajores: {
       provider: function () {
-        const kit = Kit.newKit("https://alfajores-forno.celo-testnet.org")
+        const kit = Kit.newKit(process.env.CELO_HOSTNAME)
         kit.addAccount(process.env.CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY)
         return kit.web3.currentProvider
       },

--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -62,7 +62,7 @@ module.exports = {
     keep_dev: {
       provider: function () {
         return new HDWalletProvider({
-          privateKeys: [process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY],
+          privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
           providerOrUrl: "http://localhost:8545",
         })
       },
@@ -73,8 +73,8 @@ module.exports = {
     ropsten: {
       provider: function () {
         return new HDWalletProvider({
-          privateKeys: [process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY],
-          providerOrUrl: process.env.ETH_HOSTNAME,
+          privateKeys: [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY],
+          providerOrUrl: process.env.CHAIN_API_URL,
         })
       },
       gas: 8000000,
@@ -86,8 +86,8 @@ module.exports = {
 
     alfajores: {
       provider: function () {
-        const kit = Kit.newKit(process.env.CELO_HOSTNAME)
-        kit.addAccount(process.env.CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY)
+        const kit = Kit.newKit(process.env.CHAIN_API_URL)
+        kit.addAccount(process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY)
         return kit.web3.currentProvider
       },
       network_id: 44787,


### PR DESCRIPTION
Workflows have been refactored so that Celo-related artifacts could be
deployed in the chain of automatic execusions triggered by the manual
dispatch of the `Main` workflow in the `ci` project (with `environment`
set to `alfajores`).

Similar changes have been introduced to `keep-core` and `keep-ecdsa`
workflows. See:
https://github.com/keep-network/keep-core/pull/2492
https://github.com/keep-network/keep-ecdsa/pull/823