### PR TITLE
CI workflows - Move cache instead of copying

### DIFF
--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -64,7 +64,7 @@ jobs:
           tags: go-build-env
           load: true # load image to local registry to use it in next steps
           cache-from: type=local,src=/tmp/.buildx-relay-cache
-          cache-to: type=local,dest=/tmp/.buildx-relay-cache
+          cache-to: type=local,dest=/tmp/.buildx-relay-cache-new
 
       - name: Run Go tests
         run: |
@@ -99,3 +99,13 @@ jobs:
           push: |
             ${{ github.ref == 'refs/heads/master'
               && github.event_name != 'pull_request' }}
+
+      - # Temp fix - move cache instead of copying (added below step and
+        # modified value of `cache-to`).
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        # Without the change some jobs were failing with `no space left on device`
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-relay-cache
+          mv /tmp/.buildx-relay-cache-new /tmp/.buildx-relay-cache


### PR DESCRIPTION
In `keep-ecdsa` we've seen a number of workflows failing with `No space
lefton device` error.
The problem was a combination of a big cache size and significant memory
allocation after building Docker image.
According to moby/buildkit#1850:
"At the moment caches are copied over the existing cache so it keeps
growing".
As a temporary fix (until issue gets fixed by GH), we introduced a step
that moves the cache (similarily to how it's described in
moby/buildkit#1896) instead of copying.
Although we havent seen the problems with cache size yet in other
projects than `keep-ecdsa`, we're applying the solution across the
repositories to decrease the likelyhood of encountering problem in the
future.

See also:
https://github.com/keep-network/keep-ecdsa/pull/822
https://github.com/keep-network/keep-core/pull/2501
https://github.com/keep-network/tbtc-dapp/pull/398