### PR TITLE
Unify docs.yml with corresponding file in keep-core

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,27 +1,46 @@
-name: Build docs
+name: Docs
   
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
     paths:
-    - '**.adoc'
+      - '**.adoc'
   pull_request:
-    branches: [ master ]
-    paths:
-    - '**.adoc'
+  workflow_dispatch:
 
 jobs:
-  HTML:
+  docs-detect-changes:
     runs-on: ubuntu-latest
+    outputs:
+      path-filter: ${{ steps.filter.outputs.path-filter }}
+    steps:
+      - uses: actions/checkout@v2
+        if: github.event_name == 'pull_request' 
+      - uses: dorny/paths-filter@v2
+        if: github.event_name == 'pull_request' 
+        id: filter
+        with:
+          filters: |
+            path-filter:
+              - '**.adoc'
 
+  docs-html:
+    runs-on: ubuntu-latest
+    needs: docs-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.docs-detect-changes.outputs.path-filter == 'true'
     steps:
     - uses: actions/checkout@v2
+
     - name: Build HTML docs
       id: html
       uses: thesis/asciidoctor-action@v1.0.1
       with:
         files: 'docs/*.adoc docs/**/*.adoc'
         args: '-a revdate=`date +%Y-%m-%d` --failure-level=ERROR'
+
     # A push event is a master merge; deploy to primary bucket.
     - if: github.event_name == 'push'
       name: Upload asciidocs
@@ -32,6 +51,7 @@ jobs:
         bucket-name: docs.keep.network
         bucket-path: tbtc
         build-folder: ${{ steps.html.outputs.asciidoctor-artifacts }}/docs
+
     # A pull_request event is a PR; deploy to preview bucket.
     - if: github.event_name == 'pull_request'
       name: Upload asciidocs preview
@@ -43,18 +63,23 @@ jobs:
         bucket-path: tbtc/${{ github.head_ref }}
         build-folder: ${{ steps.html.outputs.asciidoctor-artifacts }}/docs
 
-  PDF:
+  docs-pdf:
     runs-on: ubuntu-latest
-
+    needs: docs-detect-changes
+    if: |
+      github.event_name != 'pull_request'
+        || needs.docs-detect-changes.outputs.path-filter == 'true'
     steps:
     - uses: actions/checkout@v2
-    - name: Build HTML docs
-      id: html
+
+    - name: Build PDF docs
+      id: pdf
       uses: thesis/asciidoctor-action@v1.0.1
       with:
         files: 'docs/*.adoc docs/**/*.adoc'
         format: pdf
         args: '-a revdate=`date +%Y-%m-%d` --failure-level=ERROR'
+
     # A push event is a master merge; deploy to primary bucket.
     - if: github.event_name == 'push'
       name: Upload asciidocs
@@ -64,7 +89,8 @@ jobs:
         project: cfc-production
         bucket-name: docs.keep.network
         bucket-path: tbtc
-        build-folder: ${{ steps.html.outputs.asciidoctor-artifacts }}/docs
+        build-folder: ${{ steps.pdf.outputs.asciidoctor-artifacts }}/docs
+
     # A pull_request event is a PR; deploy to preview bucket.
     - if: github.event_name == 'pull_request'
       name: Upload asciidocs preview
@@ -74,4 +100,4 @@ jobs:
         project: cfc-production
         bucket-name: docs.keep.network
         bucket-path: tbtc/${{ github.head_ref }}
-        build-folder: ${{ steps.html.outputs.asciidoctor-artifacts }}/docs
+        build-folder: ${{ steps.pdf.outputs.asciidoctor-artifacts }}/docs


### PR DESCRIPTION
The `docs.yml` workflow config file has been modified in order to make it
similar to the corresponding workflow in the `keep-core`.
Most important changes include:
* Executing the workflow for PRs with all base branches, not only for
those with `master` base branch
* Utilising `dorny/paths-filter` action (this will allow us to set the
`docs-html` and `docs-pdf` jobs as required for a PR merge)
* Changing names of the workflow and jobs to make them unified with
implementation of other workflows
* Fixing the name and `id` value for the step building PDF docs