### PR TITLE
Replace the CircleCI build status badge with GHA badges

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,8 +2,7 @@
 
 = tBTC
 
-https://circleci.com/gh/keep-network/tbtc[image:https://circleci.com/gh/keep-network/tbtc.svg?style=svg&circle-token=ec728f5ca814b6cb2db5ffeb7258151b752a207e[CircleCI
-Build Status]]
+https://github.com/keep-network/tbtc/actions/workflows/contracts.yml[image:https://img.shields.io/github/workflow/status/keep-network/tbtc/Solidity/master?event=push&label=Solidity build[Solidity contracts build status]]
 http://docs.keep.network/tbtc/solidity/[image:https://img.shields.io/badge/docs-website-green.svg[Docs]]
 https://discord.gg/4R6RGFf[image:https://img.shields.io/badge/chat-Discord-blueViolet.svg[Chat
 with us on Discord]]


### PR DESCRIPTION
We no longer use CircleCI to test/build the `tbtc` code. We need to
replace the CircleCI build status badge in the projec'ts README with
the similiar badge for GitHub Actions build.
The badge has been replaced with the Solidity build badge (showing
status of the last `Solidity` workflow executed on `master` branch and
triggered by the push event).
The badges is displayed using `shields.io` tool, which was already
used for the Discord and docs badges.

Refs:
https://github.com/keep-network/keep-core/pull/2502
https://github.com/keep-network/keep-ecdsa/pull/835