### PR TITLE
Migrate from `master` to `main` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,12 +94,12 @@ workflows:
       - build_relay_maintainer_initcontainer:
           filters:
             branches:
-              only: master
+              only: main
           context: keep-dev
       - publish_relay_maintainer_initcontainer:
           filters:
             branches:
-              only: master
+              only: main
           context: keep-dev
           requires:
             - build_relay_maintainer_initcontainer

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -3,7 +3,7 @@ name: Solidity
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "solidity/**"
   pull_request:
@@ -19,7 +19,7 @@ on:
       upstream_ref:
         description: 'Git reference to checkout (e.g. branch name)'
         required: false
-        default: 'master'
+        default: 'main'
 
 jobs:
   contracts-detect-changes:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,11 +2,11 @@ name: Build docs
   
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths:
     - '**.adoc'
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths:
     - '**.adoc'
 
@@ -22,7 +22,7 @@ jobs:
       with:
         files: 'docs/*.adoc docs/**/*.adoc'
         args: '-a revdate=`date +%Y-%m-%d` --failure-level=ERROR'
-    # A push event is a master merge; deploy to primary bucket.
+    # A push event is a main merge; deploy to primary bucket.
     - if: github.event_name == 'push'
       name: Upload asciidocs
       uses: thesis/gcp-storage-bucket-action@v3.1.0
@@ -55,7 +55,7 @@ jobs:
         files: 'docs/*.adoc docs/**/*.adoc'
         format: pdf
         args: '-a revdate=`date +%Y-%m-%d` --failure-level=ERROR'
-    # A push event is a master merge; deploy to primary bucket.
+    # A push event is a main merge; deploy to primary bucket.
     - if: github.event_name == 'push'
       name: Upload asciidocs
       uses: thesis/gcp-storage-bucket-action@v3.1.0

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -3,7 +3,7 @@ name: Relay
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - "relay/**"
   pull_request:
@@ -75,7 +75,7 @@ jobs:
 
       - name: Login to Google Container Registry
         if: |
-          github.ref == 'refs/heads/master'
+          github.ref == 'refs/heads/main'
             && github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
@@ -97,5 +97,5 @@ jobs:
           build-args: |
             REVISION=${{ github.sha }}
           push: |
-            ${{ github.ref == 'refs/heads/master'
+            ${{ github.ref == 'refs/heads/main'
               && github.event_name != 'pull_request' }}

--- a/README.adoc
+++ b/README.adoc
@@ -98,7 +98,7 @@ repository. To start a discussion, prefer https://discord.gg/4R6RGFf[Discord]
 over GitHub issues.
 
 *Read the
-https://github.com/keep-network/tbtc/blob/master/CONTRIBUTING.md[Contributing
+https://github.com/keep-network/tbtc/blob/main/CONTRIBUTING.md[Contributing
 guidelines].*
 
 === Setup environment

--- a/README.adoc
+++ b/README.adoc
@@ -97,9 +97,7 @@ All contributions are welcome. To report bugs, please create an issue on this
 repository. To start a discussion, prefer https://discord.gg/4R6RGFf[Discord]
 over GitHub issues.
 
-*Read the
-https://github.com/keep-network/tbtc/blob/main/CONTRIBUTING.md[Contributing
-guidelines].*
+*Read the xref:CONTRIBUTING.adoc[Contributing guidelines].*
 
 === Setup environment
 

--- a/docs/introduction-to-tbtc.md
+++ b/docs/introduction-to-tbtc.md
@@ -87,7 +87,7 @@ The redemption flow is as follows:
 
 The "happy paths" have been covered, but there hasn't been discussion of when *things fall apart*. 
 
-To disincentivise signers from stealing bitcoin, deposits are overcollateralised with ETH. The collateral is priced using an on-chain [ETH:BTC price feed](https://github.com/keep-network/tbtc/blob/master/solidity/contracts/price-feed/SatWeiPriceFeed.sol), which works using a price-feed operated by MakerDAO. This collateral also ensures  guarantees of signer availability within the protocol.
+To disincentivise signers from stealing bitcoin, deposits are overcollateralised with ETH. The collateral is priced using an on-chain [ETH:BTC price feed](https://github.com/keep-network/tbtc/blob/main/solidity/contracts/price-feed/SatWeiPriceFeed.sol), which works using a price-feed operated by MakerDAO. This collateral also ensures  guarantees of signer availability within the protocol.
 
 ---
 

--- a/docs/introduction-to-tbtc.md
+++ b/docs/introduction-to-tbtc.md
@@ -87,7 +87,7 @@ The redemption flow is as follows:
 
 The "happy paths" have been covered, but there hasn't been discussion of when *things fall apart*. 
 
-To disincentivise signers from stealing bitcoin, deposits are overcollateralised with ETH. The collateral is priced using an on-chain [ETH:BTC price feed](https://github.com/keep-network/tbtc/blob/main/solidity/contracts/price-feed/SatWeiPriceFeed.sol), which works using a price-feed operated by MakerDAO. This collateral also ensures  guarantees of signer availability within the protocol.
+To disincentivise signers from stealing bitcoin, deposits are overcollateralised with ETH. The collateral is priced using an on-chain [ETH:BTC price feed](../solidity/contracts/price-feed/SatWeiPriceFeed.sol), which works using a price-feed operated by MakerDAO. This collateral also ensures  guarantees of signer availability within the protocol.
 
 ---
 


### PR DESCRIPTION
Use of the `master` and `slave` terms in the computer industry is
widespread, but has been recently discouraged, as it was brought to
attention that the terms may be considered offensive.
GitHub has already moved their default repositories from the `master`
to `main` in many places. We're planning to do the same for our
repositories, this however requires some changes in the code.
After the proposed changes get merged to the `master` branch, the
repository should be ready for the migration from `master` to `main`.

To migrate from `master` to `main`:
1. Do a local branch rename with `git branch -m master main`
2. Push the renamed branch `git push -u origin main`
3. In the Github repo settings, rename the default branch: Settings ->
    Branches -> Default branch -> (pencil icon) -> (change `master` to
    `main`) -> (approve)

After migration other contributors should update their local repositories:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

Refs:
https://github.com/keep-network/keep-core/pull/2521
https://github.com/keep-network/keep-ecdsa/pull/845
https://github.com/keep-network/tbtc-dapp/pull/399
https://github.com/keep-network/tbtc.js/pull/126
https://github.com/keep-network/keep-common/pull/79
https://github.com/keep-network/sortition-pools/pull/113
https://github.com/keep-network/local-setup/pull/97
https://github.com/keep-network/ci/pull/8
https://github.com/keep-network/run-workflow/pull/3
https://github.com/keep-network/notify-workflow-completed/pull/3
https://github.com/keep-network/load-env-variables/pull/2