### PR TITLE
Decrease amount of the gas sent for Ropsten env

### DIFF
--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -77,7 +77,7 @@ module.exports = {
           providerOrUrl: process.env.CHAIN_API_URL,
         })
       },
-      gas: 8000000,
+      gas: 6000000,
       network_id: 3,
       skipDryRun: true,
       networkCheckTimeout: 120000,


### PR DESCRIPTION
Amount of the gas sent for Ropsten env has been decreased to fix failing
migrations of contracts (`"Migrations" exceeded the block limit (with a
gas value you set)`).