### PR TITLE
Pass BondedECDSAKeepFactoryAddress to createSortitionPoolCelo

### DIFF
--- a/solidity/migrations/3_initialize.js
+++ b/solidity/migrations/3_initialize.js
@@ -89,7 +89,7 @@ module.exports = async function (deployer, network, accounts) {
   )
 
   if (network === "alfajores") {
-    await createSortitionPoolCelo(accounts[0])
+    await createSortitionPoolCelo(accounts[0], BondedECDSAKeepFactoryAddress)
   } else {
     await BondedECDSAKeepFactory.createSortitionPool(TBTCSystem.address, {
       from: accounts[0],
@@ -106,7 +106,7 @@ module.exports = async function (deployer, network, accounts) {
   await tbtcSystem.refreshMinimumBondableValue()
 }
 
-async function createSortitionPoolCelo(account) {
+async function createSortitionPoolCelo(account, BondedECDSAKeepFactoryAddress) {
   const celoKit = Kit.newKitFromWeb3(web3)
 
   const BondedECDSAKeepFactory = new web3.eth.Contract(


### PR DESCRIPTION
Script execution was failing for Celo as BondedECDSAKeepFactoryAddress was missing to be passed to the function.