### PR TITLE
Rename `-solidity-version` parameter suffix with `-contracts-version`

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -149,12 +149,12 @@ jobs:
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
-            keep-ecdsa-solidity-version = github.com/keep-network/keep-ecdsa/solidity#version
+            keep-ecdsa-contracts-version = github.com/keep-network/keep-ecdsa/solidity#version
 
       - name: Resolve latest contracts
         run: |
             npm install --save-exact \
-              @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-solidity-version }}
+              @keep-network/keep-ecdsa@${{ steps.upstream-builds-query.outputs.keep-ecdsa-contracts-version }}
 
       - name: Migrate contracts on Ethereum
         if: github.event.inputs.environment != 'alfajores'


### PR DESCRIPTION
Change introduced for better understandability of parameter's meaning.

Refs:
https://github.com/keep-network/keep-core/pull/2532
https://github.com/keep-network/keep-ecdsa/pull/864
https://github.com/keep-network/tbtc.js/pull/127
https://github.com/keep-network/upstream-builds-query/pull/3
https://github.com/keep-network/coverage-pools/pull/157