### PR TITLE
Update custom actions paths after moving actions to `ci`

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
         with:
           environment: ${{ github.event.inputs.environment }}
 
@@ -144,7 +144,7 @@ jobs:
         run: npm ci
 
       - name: Get upstream packages' versions
-        uses: keep-network/upstream-builds-query@v1
+        uses: keep-network/ci/actions/upstream-builds-query@move-actions-to-ci # TODO: change to @v1 before merging to main
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -207,7 +207,7 @@ jobs:
       - name: Notify CI about completion of the workflow
         # For Alfajores we want to break the chain of deployments on tBTC contracts.
         if: github.event.inputs.environment != 'alfajores'
-        uses: keep-network/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -188,8 +188,7 @@ jobs:
 
       - name: Push contracts to Tenderly
         if: github.event.inputs.environment == 'ropsten'
-        # TODO: once below action gets tagged replace `@main` with `@v1`
-        uses: keep-network/tenderly-push-action@main
+        uses: keep-network/tenderly-push-action@v1
         continue-on-error: true
         with:
           working-directory: ./solidity

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -120,7 +120,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/load-env-variables@v1
         with:
           environment: ${{ github.event.inputs.environment }}
 
@@ -144,7 +144,7 @@ jobs:
         run: npm ci
 
       - name: Get upstream packages' versions
-        uses: keep-network/ci/actions/upstream-builds-query@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/upstream-builds-query@v1
         id: upstream-builds-query
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
@@ -207,7 +207,7 @@ jobs:
       - name: Notify CI about completion of the workflow
         # For Alfajores we want to break the chain of deployments on tBTC contracts.
         if: github.event.inputs.environment != 'alfajores'
-        uses: keep-network/ci/actions/notify-workflow-completed@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/notify-workflow-completed@v1
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -89,7 +89,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
 
       - name: Cache node modules
         uses: actions/cache@v2

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
+        uses: keep-network/ci/actions/load-env-variables@v1
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Load environment variables
-        uses: keep-network/load-env-variables@v1
+        uses: keep-network/ci/actions/load-env-variables@move-actions-to-ci # TODO: change to @v1 before merging to main
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or


### PR DESCRIPTION
We've moved custom actions used in the Keep/tBTC Continuous Integration
from separate repositories to `ci` repository (under `actions` folder).
We now need to update all the actions' invokations.

Note that temporarily we call the actions on the feature branch - this
is only for testing purposes and will be changed to `@v1` once tested.

Refs:
https://github.com/keep-network/ci/pull/11
https://github.com/keep-network/keep-core/pull/2545
https://github.com/keep-network/keep-ecdsa/pull/868
https://github.com/keep-network/tbtc-dapp/pull/400
https://github.com/keep-network/tbtc.js/pull/128
https://github.com/keep-network/coverage-pools/pull/167

TODO:
- [x] test deployment flow on the feature branch
- [x] point to `@v1` in lines invoking actions (same change required in other repos)