### PR TITLE
Replaced links to artifacts with copies

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -25,8 +25,8 @@ printf "${LOG_START}Migrating contracts...${LOG_END}"
 npm run clean
 npx truffle migrate --reset --network development
 
-printf "${LOG_START}Creating links...${LOG_END}"
-ln -sf build/contracts artifacts
+printf "${LOG_START}Copying contract artifacts...${LOG_END}"
+cp -r build/contracts artifacts
 npm link
 npm link @keep-network/keep-ecdsa
 


### PR DESCRIPTION
This PR replaces links to contract artifacts with copies.
Tested with `local setup` deployment - all components were deployed successfully.