### PR TITLE
Compact history job for ElectrumX, statefulset services host for rpc set to 0.0.0.0

### DIFF
--- a/infrastructure/kube/keep-prd/electrumx-compact-history-job.yaml
+++ b/infrastructure/kube/keep-prd/electrumx-compact-history-job.yaml
@@ -1,0 +1,62 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tbtc-electrumx-compact-history
+  namespace: default
+  labels:
+    app: bitcoin
+    type: electrumx-compact-history
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: bitcoin
+        job-name: tbtc-electrumx-compact-history
+        type: electrumx
+    spec:
+      containers:
+      - command:
+        - /electrumx/electrumx_compact_history
+        env:
+        - name: DB_DIRECTORY
+          value: /mnt/electrum/data
+        - name: SSL_CERTFILE
+          value: /mnt/electrum/cert/tls.crt
+        - name: SSL_KEYFILE
+          value: /mnt/electrum/cert/tls.key
+        - name: DAEMON_URL
+          valueFrom:
+            secretKeyRef:
+              key: bcoin-url
+              name: bcoin
+        - name: COIN
+          value: BitcoinSegwit
+        - name: NET
+          value: mainnet
+        - name: COST_SOFT_LIMIT
+          value: "0"
+        - name: COST_HARD_LIMIT
+          value: "0"
+        - name: LOG_LEVEL
+          value: debug
+        image: lukechilds/electrumx
+        imagePullPolicy: Always
+        name: electrumx-server
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /mnt/electrum/data
+          name: electrumx-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: electrumx-data
+        persistentVolumeClaim:
+          claimName: electrumx-data-electrumx-0

--- a/infrastructure/kube/keep-prd/electrumx-compact-history-job.yaml
+++ b/infrastructure/kube/keep-prd/electrumx-compact-history-job.yaml
@@ -42,7 +42,7 @@ spec:
           value: "0"
         - name: LOG_LEVEL
           value: debug
-        image: lukechilds/electrumx
+        image: lukechilds/electrumx:v1.16.0
         imagePullPolicy: Always
         name: electrumx-server
         resources: {}

--- a/infrastructure/kube/keep-prd/electrumx-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/electrumx-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: electrumx-server
-        image: lukechilds/electrumx:v1.14.0
+        image: lukechilds/electrumx:v1.16.0
         ports:
           - containerPort: 443
           - containerPort: 8080

--- a/infrastructure/kube/keep-prd/electrumx-statefulset.yaml
+++ b/infrastructure/kube/keep-prd/electrumx-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
                 name: bcoin
                 key: bcoin-url
           - name: SERVICES
-            value: ssl://:443,ws://:8080,wss://:8443,rpc://localhost:8000
+            value: ssl://:443,ws://:8080,wss://:8443,rpc://0.0.0.0:8000
           - name: COIN
             value: BitcoinSegwit
           - name: NET

--- a/infrastructure/kube/keep-test/electrumx-compact-history-job.yaml
+++ b/infrastructure/kube/keep-test/electrumx-compact-history-job.yaml
@@ -1,0 +1,62 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tbtc-electrumx-compact-history
+  labels:
+    app: tbtc
+    type: electrumx-compact-history
+  namespace: tbtc
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: tbtc
+        job-name: tbtc-electrumx-compact-history
+        type: electrumx-server
+    spec:
+      containers:
+      - command:
+        - /electrumx/electrumx_compact_history
+        env:
+        - name: DB_DIRECTORY
+          value: /mnt/electrum/data
+        - name: SSL_CERTFILE
+          value: /mnt/electrum/cert/tls.crt
+        - name: SSL_KEYFILE
+          value: /mnt/electrum/cert/tls.key
+        - name: DAEMON_URL
+          valueFrom:
+            secretKeyRef:
+              key: bcoin-url
+              name: bcoin
+        - name: COIN
+          value: BitcoinSegwit
+        - name: NET
+          value: testnet
+        - name: COST_SOFT_LIMIT
+          value: "0"
+        - name: COST_HARD_LIMIT
+          value: "0"
+        - name: LOG_LEVEL
+          value: debug
+        image: lukechilds/electrumx
+        imagePullPolicy: Always
+        name: electrumx-server
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /mnt/electrum/data
+          name: tbtc-electrumx-server-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: tbtc-electrumx-server-data
+        persistentVolumeClaim:
+          claimName: tbtc-electrumx-server-data-tbtc-electrumx-server-1


### PR DESCRIPTION
ElectrumX instances can enter a state where their index is too large and
requires out-of-band compacting, at which point the ElectrumX server
will crash and fail to restart. The job added here can be run once and
will compact the history.

It needs to be pointed to the correct volume via the
`persistentVolumeClaim`, and is designed to run only once to
completion---successful or not. To run again later, the job can be
deleted from the GCP UI or using kubectl, and then re-applied.

Additionally, changed RPC host in statefulset services to `0.0.0.0`.
Electrum could not bind to port 8000 when we were using
`rpc://localhost:8000` but it binds just well if we use
`rpc://0.0.0.0:8000`.
See https://github.com/lukechilds/docker-electrumx/issues/25#issuecomment-492957782
