### PR TITLE
Remove artifact folder before copying

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,7 @@ npm run clean
 npx truffle migrate --reset --network development
 
 printf "${LOG_START}Copying contract artifacts...${LOG_END}"
+rm -rf artifacts
 cp -r build/contracts artifacts
 npm link
 npm link @keep-network/keep-ecdsa


### PR DESCRIPTION
This PR adds a small change - remove the folder with contract artifact before copying.
Note: No need to add `artifacts/` to `.gitignore` - it's already there.