### PR TITLE
Remove gasPrice configuration for development network

### DIFF
--- a/solidity/truffle-config.js
+++ b/solidity/truffle-config.js
@@ -55,8 +55,6 @@ module.exports = {
       host: "localhost", // Localhost (default: none)
       port: 8545, // Standard Ethereum port (default: none)
       network_id: "*", // Any network (default: none)
-      //  gas: 100000000000000,
-      gasPrice: 1,
     },
 
     keep_dev: {


### PR DESCRIPTION
There is no need to provide gasPrice for development network. It even
breaks the migration with geth 1.10.8 as truffle reports a timeout
mining the transaction.