### PR TITLE
Adding cron for daily tests and builds for meercode

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,6 +1,8 @@
 name: Solidity
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -1,6 +1,8 @@
 name: Relay
 
 on:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches:
       - main
@@ -77,6 +79,7 @@ jobs:
         if: |
           github.ref == 'refs/heads/main'
             && github.event_name != 'pull_request'
+            && github.event_name != 'schedule'
         uses: docker/login-action@v1
         with:
           registry: ${{ env.GCR_REGISTRY_URL }}
@@ -84,6 +87,7 @@ jobs:
           password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Build and publish Docker Runtime Image
+        if: github.event_name != 'schedule'
         uses: docker/build-push-action@v2
         env:
           IMAGE_NAME: 'relay'
@@ -106,6 +110,7 @@ jobs:
         # https://github.com/moby/buildkit/issues/1896
         # Without the change some jobs were failing with `no space left on device`
         name: Move cache
+        if: github.event_name != 'schedule'
         run: |
           rm -rf /tmp/.buildx-relay-cache
           mv /tmp/.buildx-relay-cache-new /tmp/.buildx-relay-cache

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -87,7 +87,6 @@ jobs:
           password: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
 
       - name: Build and publish Docker Runtime Image
-        if: github.event_name != 'schedule'
         uses: docker/build-push-action@v2
         env:
           IMAGE_NAME: 'relay'
@@ -102,7 +101,8 @@ jobs:
             REVISION=${{ github.sha }}
           push: |
             ${{ github.ref == 'refs/heads/main'
-              && github.event_name != 'pull_request' }}
+              && github.event_name != 'pull_request'
+              && github.event_name != 'schedule' }}
 
       - # Temp fix - move cache instead of copying (added below step and
         # modified value of `cache-to`).
@@ -110,7 +110,6 @@ jobs:
         # https://github.com/moby/buildkit/issues/1896
         # Without the change some jobs were failing with `no space left on device`
         name: Move cache
-        if: github.event_name != 'schedule'
         run: |
           rm -rf /tmp/.buildx-relay-cache
           mv /tmp/.buildx-relay-cache-new /tmp/.buildx-relay-cache


### PR DESCRIPTION
The purpose of this PR is to set a cron job that would run tests and builds on a daily basis (at midnight) so the results can be displayed on Meercode dashboard.