### PR TITLE
Update dependency to `keep-ecdsa` package

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -3933,9 +3933,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.8.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-pre.6.tgz",
-      "integrity": "sha512-XcVCKx8LU+LWgFT6AVZ9Wz2RLt/m5mJ9ongSUeBZDZ9dy3dhaGMKdJnk12fztUcEIiHfyAINZ91UiS3HPyGQsA==",
+      "version": "1.8.0-ropsten.11",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-ropsten.11.tgz",
+      "integrity": "sha512-mHuHb8SgPfXC6gKglYcbeUWWA0+Ijq0tn+f2sN9ZkFpPnAb6Uq4kMTLZle2qqcRkvfqc7JkWvJmDq0kAGdUIrQ==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"
@@ -3949,20 +3949,20 @@
       }
     },
     "@keep-network/keep-ecdsa": {
-      "version": "1.7.0-pre.8",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.7.0-pre.8.tgz",
-      "integrity": "sha512-SqCGfW0ElBsx3iTTR/8YtHT8H6C0uPIb+P5HqD1ei5Typy+H1WUBVLjUQ6YPNraMtTGmBFmG6LUvrY7WCCTC2A==",
+      "version": "1.8.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-ecdsa/-/keep-ecdsa-1.8.0-dev.0.tgz",
+      "integrity": "sha512-DRSPmXklqcZMxW169umN+XjXb1cySHA0lHp3BT7Q4kEKiHatdt50jMzvmrTd9jlwcIj3s9smMq/VF2GYVkWIZQ==",
       "requires": {
-        "@keep-network/keep-core": "^1.8.0-pre.6",
-        "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
+        "@keep-network/keep-core": "^1.8.0-dev.1",
+        "@keep-network/sortition-pools": ">1.2.0-dev <1.2.0-pre",
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.3.0"
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "1.2.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.6.tgz",
-      "integrity": "sha512-6Tusle8KGZldO8jbFDfxChdgI6hMpTAW4LG+cAkf7jgRR48o6NkUiA7mDoWk/+dlitpHrQpWT1JM4N7aR/4/EQ==",
+      "version": "1.2.0-dev.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.0.tgz",
+      "integrity": "sha512-HWmHrVHsVOJQc7dLm6+LFPUXrSqffoB/zAGs6lvnln/zqI0bvCv6hdxlGIVErKn6GOAx3MuwERzZkDBXlzVhaw==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
@@ -5168,9 +5168,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.6.tgz",
-          "integrity": "sha512-sRVq8d+ApGslmkE9e3i+D3gFGk7aZHAT+G4cIpIEdLJYPsWiSPwcAnJEjddLQQDqV3Ra2jOclX/Sv6YrvGYiWA=="
+          "version": "12.20.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.26.tgz",
+          "integrity": "sha512-gIt+h4u2uTho2bsH1K250fUv5fHU71ET1yWT7bM4523zV/XrFb9jlWBOV4DO8FpscY+Sz/WEr1EEjIP2H4yumQ=="
         },
         "bignumber.js": {
           "version": "7.2.1",
@@ -36015,7 +36015,7 @@
       "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
     "scrypt-shim": {
-      "version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+      "version": "github:web3-js/scrypt-shim#aafdadda13e660e25e1c525d1f5b2443f5eb1ebb",
       "from": "github:web3-js/scrypt-shim",
       "requires": {
         "scryptsy": "^2.1.0",
@@ -39504,9 +39504,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         }
       }
     },
@@ -39524,9 +39524,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.30",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-          "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
+          "version": "12.20.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.26.tgz",
+          "integrity": "sha512-gIt+h4u2uTho2bsH1K250fUv5fHU71ET1yWT7bM4523zV/XrFb9jlWBOV4DO8FpscY+Sz/WEr1EEjIP2H4yumQ=="
         }
       }
     },
@@ -39614,9 +39614,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
-          "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q=="
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         },
         "aes-js": {
           "version": "3.0.0",
@@ -39771,9 +39771,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.30",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-          "integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
+          "version": "12.20.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.26.tgz",
+          "integrity": "sha512-gIt+h4u2uTho2bsH1K250fUv5fHU71ET1yWT7bM4523zV/XrFb9jlWBOV4DO8FpscY+Sz/WEr1EEjIP2H4yumQ=="
         }
       }
     },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://tbtc.network/",
   "dependencies": {
     "@celo/contractkit": "^1.0.2",
-    "@keep-network/keep-ecdsa": ">1.7.0-pre <1.7.0-rc",
+    "@keep-network/keep-ecdsa": ">1.8.0-dev <1.8.0-ropsten",
     "@summa-tx/bitcoin-spv-sol": "^3.1.0",
     "@summa-tx/relay-sol": "^2.0.2",
     "openzeppelin-solidity": "2.3.0"


### PR DESCRIPTION
Version `1.8.0` of `keep-ecdsa` has already been released. Also, we no
longer publish packages with `-pre` suffix for `keep-ecdsa`, instead we
use `-dev`. The semver range in `package.json` has been udated to
reflect those changes.