### PR TITLE
Don't use unathenticated git protocol

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -5476,7 +5476,7 @@
           "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
           "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
           "requires": {
-            "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
+            "@umpirsky/country-list": "git+https://github.com/umpirsky/country-list.git#05fda51",
             "bigi": "^1.1.0",
             "bignumber.js": "^9.0.0",
             "bip32": "2.0.5",
@@ -5509,8 +5509,8 @@
           "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
         },
         "@umpirsky/country-list": {
-          "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-          "from": "git://github.com/umpirsky/country-list.git#05fda51"
+          "version": "git+https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+          "from": "git+https://github.com/umpirsky/country-list.git#05fda51"
         },
         "aes-js": {
           "version": "3.0.0",


### PR DESCRIPTION
GitHub is no longer allowing for referencing the dependencies using
`git://` protocol. Instead we can use `git+https://`.
WIthout the change, `npm ci` executed in GitHub Actions workflows
results with ` The unauthenticated git protocol on port 9418 is no
longer supported.` error.
More info:
https://github.blog/2021-09-01-improving-git-protocol-security-github/.

Ref:
https://github.com/keep-network/keep-ecdsa/pull/927
https://github.com/keep-network/tbtc.js/pull/144