### PR TITLE
Unify CI workflows

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -111,6 +111,7 @@ jobs:
           node-version: "14.x"
           cache: "npm"
           cache-dependency-path: solidity/package-lock.json
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
@@ -171,9 +172,9 @@ jobs:
           version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Publish to npm
-        run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public
 
       - name: Notify CI about completion of the workflow
         # For Alfajores we want to break the chain of deployments on tBTC contracts.

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public
+        run: npm publish --access=public --tag ${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
         # For Alfajores we want to break the chain of deployments on tBTC contracts.


### PR DESCRIPTION
We have CI workflows scattered across various repositories. We try to keep their implementation as similar as possible. In this PR and the ones listed below we introduce a couple of changes which unify used solutions and fix small mistakes, such as:
* making tagging of published packages consistent
* passing `NPM_TOKEN` secret as variable instead of passing it by writing to file
* handling caching of npm/yarn dependencies via `setup-node` action
* adding `workflow_dispatch` job trigger where it's missing
* using Node.js in version 14.x instead of 12.x where possible

Related PRs in other repositories:
* https://github.com/keep-network/keep-core/pull/2776
* https://github.com/keep-network/keep-ecdsa/pull/941
* https://github.com/keep-network/tbtc.js/pull/145
* https://github.com/keep-network/sortition-pools/pull/145
* https://github.com/keep-network/local-setup/pull/124
* https://github.com/keep-network/coverage-pools/pull/204
* https://github.com/keep-network/tbtc-v2/pull/88
* https://github.com/threshold-network/solidity-contracts/pull/59