### PR TITLE
Use `-dev` suffix in the versioning of the npm package

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "1.1.2-pre",
+  "version": "1.1.2-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/tbtc",
-  "version": "1.1.2-pre",
+  "version": "1.1.2-dev",
   "description": "The tBTC smart contracts implementing the TBTC trustlessly Bitcoin-backed ERC-20 token.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
We've recently added an NPM workflow which publishes npm packages meant
for development environment and versioned using `-dev.X` suffix. For
consistency we should also use `-dev` suffix in the `package.json` and
`package-lock.json`.