### PR TITLE
Document `unauthenticated git protocol issue` in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,8 +34,8 @@ tBTC contracts are currently published in the NPM Registry as the package
 https://www.npmjs.com/package/@keep-network/tbtc[`@keep-network/tbtc`].
 Packages have versions corresponding to their network:
 
-- `-pre` packages contain prerelease packages for the internal Keep testnet.
-- `-rc` packages contain prerelease packages for the Ropsten Ethereum testnet.
+- `-dev` packages contain prerelease packages for the internal Keep testnet.
+- `-ropsten` packages contain prerelease packages for the Ropsten Ethereum testnet.
 
 Note that only the latest package in a series is expected to reference
 contracts that have a backing set of signers.
@@ -44,6 +44,18 @@ To install the package:
 
 ```sh
 $ npm install @keep-network/tbtc
+```
+
+*NOTE:* The `tbtc` package contains an indirect dependency to
+`@summa-tx/relay-sol@2.0.2` package, which downloads one of its sub-dependencies
+via unathenticated `git://` protocol. That protocol is no longer supported by
+GitHub. This means that in certain situations installation of the package may
+result in `The unauthenticated git protocol on port 9418 is no longer supported`
+error. +
+As a workaround, we advise changing Git configuration to use `https://` protocol
+instead of `git://` by executing:
+```
+git config --global url."https://".insteadOf git://
 ```
 
 == Usage

--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -41,6 +41,9 @@ RUN go mod download
 COPY ./solidity $APP_DIR/solidity
 RUN cd $APP_DIR/solidity && npm install
 
+# Configure git to don't use unauthenticated protocol.
+RUN git config --global url."https://".insteadOf git://
+
 # Generate code.
 COPY ./pkg/chain/ethereum/gen $APP_DIR/pkg/chain/ethereum/gen
 RUN go generate ./...

--- a/relay/solidity/package-lock.json
+++ b/relay/solidity/package-lock.json
@@ -845,7 +845,7 @@
       "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
       "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
       "requires": {
-        "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
+        "@umpirsky/country-list": "git+https://github.com/umpirsky/country-list.git#05fda51",
         "bigi": "^1.1.0",
         "bignumber.js": "^9.0.0",
         "bip32": "2.0.5",
@@ -5115,8 +5115,8 @@
       "optional": true
     },
     "@umpirsky/country-list": {
-      "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-      "from": "git://github.com/umpirsky/country-list.git#05fda51"
+      "version": "git+https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+      "from": "git+https://github.com/umpirsky/country-list.git#05fda51"
     },
     "@web3-js/scrypt-shim": {
       "version": "0.1.0",


### PR DESCRIPTION
The `tbtc` package contains an indirect dependency to
`@summa-tx/relay-sol@2.0.2` package, which downloads one of its
sub-dependencies via unathenticated `git://` protocol. That protocol is
no longer supported by GitHub. This means that in certain situations
installation of the package may result in `The unauthenticated git
protocol on port 9418 is no longer supported` error.

As a workaround, we advise changing Git configuration to use `https://`
protocol instead of `git://` by executing:
```
git config --global url."https://".insteadOf git://
```