### PR TITLE
Added python3 installation step to relay Dockerfile

### DIFF
--- a/relay/Dockerfile
+++ b/relay/Dockerfile
@@ -10,6 +10,7 @@ ENV GOPATH=/go \
 	APP_NAME=relay \
 	APP_DIR=/go/src/github.com/keep-network/tbtc/relay \
 	BIN_PATH=/usr/local/bin \
+	LD_LIBRARY_PATH=/usr/local/lib/ \
 	GO111MODULE=on
 
 RUN apk add --update --no-cache \
@@ -18,6 +19,7 @@ RUN apk add --update --no-cache \
 	make \
 	nodejs \
 	npm \
+	python3 \
 	git && \
 	rm -rf /var/cache/apk/ && mkdir /var/cache/apk/ && \
 	rm -rf /usr/share/man


### PR DESCRIPTION
Without python3 installation the build fails on step 11/16:
`RUN cd /go/src/github.com/keep-network/tbtc/relay/solidity && npm install`

with node-gyp complaining about not python installation not existing.

```
=> ERROR [gobuild 11/16] RUN cd /go/src/github.com/keep-network/tbtc/relay/solidity && npm install                                                                                                      58.0s
------
 > [gobuild 11/16] RUN cd /go/src/github.com/keep-network/tbtc/relay/solidity && npm install:
#18 56.68
#18 56.68 > bufferutil@4.0.3 install /go/src/github.com/keep-network/tbtc/relay/solidity/node_modules/bufferutil
#18 56.68 > node-gyp-build
#18 56.68
#18 56.84 gyp ERR! find Python
#18 56.84 gyp ERR! find Python Python is not set from command line or npm configuration
#18 56.84 gyp ERR! find Python Python is not set from environment variable PYTHON
#18 56.84 gyp ERR! find Python checking if "python" can be used
#18 56.84 gyp ERR! find Python - "python" is not in PATH or produced an error
#18 56.84 gyp ERR! find Python checking if "python2" can be used
#18 56.84 gyp ERR! find Python - "python2" is not in PATH or produced an error
#18 56.84 gyp ERR! find Python checking if "python3" can be used
#18 56.84 gyp ERR! find Python - "python3" is not in PATH or produced an error
#18 56.84 gyp ERR! find Python
#18 56.84 gyp ERR! find Python **********************************************************
#18 56.84 gyp ERR! find Python You need to install the latest version of Python.
#18 56.84 gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
#18 56.84 gyp ERR! find Python you can try one of the following options:
#18 56.84 gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
#18 56.84 gyp ERR! find Python   (accepted by both node-gyp and npm)
#18 56.84 gyp ERR! find Python - Set the environment variable PYTHON
#18 56.84 gyp ERR! find Python - Set the npm configuration variable python:
#18 56.84 gyp ERR! find Python   npm config set python "/path/to/pythonexecutable"
#18 56.84 gyp ERR! find Python For more information consult the documentation at:
#18 56.84 gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
#18 56.84 gyp ERR! find Python **********************************************************
#18 56.84 gyp ERR! find Python
#18 56.84 gyp ERR! configure error
#18 56.84 gyp ERR! stack Error: Could not find any Python installation to use
#18 56.84 gyp ERR! stack     at PythonFinder.fail (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:307:47)
#18 56.84 gyp ERR! stack     at PythonFinder.runChecks (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:136:21)
#18 56.84 gyp ERR! stack     at PythonFinder.<anonymous> (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:179:16)
#18 56.84 gyp ERR! stack     at PythonFinder.execFileCallback (/usr/lib/node_modules/npm/node_modules/node-gyp/lib/find-python.js:271:16)
#18 56.84 gyp ERR! stack     at exithandler (child_process.js:390:5)
#18 56.84 gyp ERR! stack     at ChildProcess.errorhandler (child_process.js:402:5)
#18 56.84 gyp ERR! stack     at ChildProcess.emit (events.js:400:28)
#18 56.84 gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:280:12)
#18 56.84 gyp ERR! stack     at onErrorNT (internal/child_process.js:469:16)
#18 56.84 gyp ERR! stack     at processTicksAndRejections (internal/process/task_queues.js:82:21)
#18 56.84 gyp ERR! System Linux 5.10.104-linuxkit
#18 56.84 gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
#18 56.84 gyp ERR! cwd /go/src/github.com/keep-network/tbtc/relay/solidity/node_modules/bufferutil
#18 56.84 gyp ERR! node -v v14.19.0
#18 56.84 gyp ERR! node-gyp -v v5.1.0
#18 56.84 gyp ERR! not ok
```