### PR TITLE
Added python3 and make installation step to the relay initcontainer

### DIFF
--- a/infrastructure/kube/templates/relay/initcontainer/provision-relay/Dockerfile
+++ b/infrastructure/kube/templates/relay/initcontainer/provision-relay/Dockerfile
@@ -1,6 +1,13 @@
 FROM node:13-alpine AS install
 
-RUN apk --no-cache add git
+ENV LD_LIBRARY_PATH=/usr/local/lib/
+
+RUN apk add --update --no-cache \
+	g++ \
+	linux-headers \
+    make \
+	python3 \
+    git
 
 WORKDIR /tmp
 


### PR DESCRIPTION
Without python3 and make the build fails on `npm ci` step with `node-gyp`
complaining about python and make being not available.