### PR TITLE
Updated relay deployment to v1.2.0

### DIFF
--- a/infrastructure/kube/keep-prd/relay-deployment.yaml
+++ b/infrastructure/kube/keep-prd/relay-deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       initContainers:
         - name: initcontainer-provision-relay
-          image: gcr.io/keep-prd-210b/initcontainer-provision-relay:1.0.0
+          image: gcr.io/keep-prd-210b/initcontainer-provision-relay:v1.2.0
           imagePullPolicy: Always
           env:
             - name: HOST_CHAIN_WS_URL
@@ -71,7 +71,7 @@ spec:
           command: ['node', '/tmp/provision-relay.js']
       containers:
         - name: relay
-          image: gcr.io/keep-prd-210b/relay:1.1.0
+          image: gcr.io/keep-prd-210b/relay:v1.2.0
           imagePullPolicy: Always
           ports:
             - containerPort: 8080


### PR DESCRIPTION
Depends on #867

Relay init container and the main container deployments updated to use v1.2.0 images.