### PR TITLE
Cleanup of v1-related GH Actions workflows

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,8 +1,6 @@
 name: Solidity
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches:
       - main

--- a/.github/workflows/relay.yml
+++ b/.github/workflows/relay.yml
@@ -1,8 +1,6 @@
 name: Relay
 
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
We're no loger adding new functionalities to the `tbtc` code, as this repository is related to the `v1` of the system and is no longer used in `v2`. There is no need to run the code-checking workflows every night.